### PR TITLE
[Example] Add example for decoding kernel of flash linear attention

### DIFF
--- a/examples/flash_attention_decode/main.py
+++ b/examples/flash_attention_decode/main.py
@@ -1,0 +1,254 @@
+import math
+from typing import Optional
+
+import pandas as pd
+import tilus
+import torch
+from tilus import bfloat16, float32, int32
+from tilus.utils import benchmark_func, cdiv
+from torch_kernel import fused_recurrent_gated_delta_rule_update_fwd_torch
+from triton_kernel import fused_recurrent_gated_delta_rule_update_fwd_triton
+
+
+@tilus.autotune("num_warps", [1, 2, 4])
+@tilus.autotune("BV", [2, 4, 8, 16, 32, 64, 128])
+class FusedRecurrentGatedDeltaRuleUpdateFwdKernel(tilus.Script):
+    def __init__(self, num_warps: int, BV: int):
+        super().__init__()
+        self.num_warps = num_warps
+        self.BV = BV
+
+    def __call__(
+        self,
+        q_ptr: ~bfloat16,
+        k_ptr: ~bfloat16,
+        v_ptr: ~bfloat16,
+        g_ptr: ~float32,
+        o_ptr: ~bfloat16,
+        beta_ptr: ~bfloat16,
+        scale: float,
+        initial_state_source_ptr: ~float32,
+        initial_state_indices_ptr: ~int32,
+        T: int32,
+        B: int,
+        H: int,
+        HV: int,
+        K: int,
+        V: int,
+        MAX_T: int,
+        USE_INITIAL_STATE: bool,
+        USE_QK_L2NORM_IN_KERNEL: bool,
+    ):
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (T, cdiv(V, self.BV), HV)
+
+        g_q = self.global_view(q_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_k = self.global_view(k_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_v = self.global_view(v_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        g_g = self.global_view(g_ptr, dtype=float32, shape=[B, T, HV])
+        g_o = self.global_view(o_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        g_beta = self.global_view(beta_ptr, dtype=bfloat16, shape=[B, T, HV])
+        initial_state_source = self.global_view(
+            initial_state_source_ptr, dtype=float32, shape=[MAX_T, HV, K, V]
+        )
+        initial_state_indices = self.global_view(
+            initial_state_indices_ptr, dtype=int32, shape=[T]
+        )
+
+        i_t, i_bv, i_hv = self.blockIdx
+        i_h = i_hv // (HV // H)
+
+        r_q = self.load_global(g_q, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+        r_k = self.load_global(g_k, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+
+        # self.print_tensor('r_q ', r_q)
+        # self.print_tensor('r_k ', r_k)
+
+        # normalize q and k
+        if USE_QK_L2NORM_IN_KERNEL:
+            r_q = r_q / self.sqrt(self.sum(r_q * r_q, dim=0))
+            r_k = r_k / self.sqrt(self.sum(r_k * r_k, dim=0))
+
+        r_q = r_q * scale
+
+        # self.print_tensor('normalized r_q ', r_q)
+        # self.print_tensor('normalized r_k ', r_k)
+
+        # load initial state
+        if USE_INITIAL_STATE:
+            state_idx: int32 = initial_state_indices[i_t]
+            r_h = self.load_global(
+                initial_state_source,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                shape=[K, self.BV],
+                dims=[2, 3],
+            )
+        else:
+            state_idx: int32 = -1
+            r_h = self.register_tensor(dtype=float32, shape=[K, self.BV], init=0.0)
+
+        # H' = alpha * H : [K, BV] = [] * [K, BV]
+        alpha: float32 = math.exp(g_g[0, i_t, i_hv])
+        r_h = r_h * alpha
+
+        # p = k * H : [BV] = reduce([K, 1] * [K, BV], dim=0)
+        r_p = self.sum(self.unsqueeze(r_k, dim=1) * r_h, dim=0)
+        # self.print_tensor('r_p ', r_p)
+
+        # r = beta * (v - p) : [BV] = [] * ([BV] - [BV])
+        beta: float32 = float32(g_beta[0, i_t, i_hv])
+        r_v = self.load_global(
+            g_v, offsets=[0, i_t, i_hv, i_bv * self.BV], shape=[self.BV], dims=[3]
+        ).to(float32)
+        r_r = beta * (r_v - r_p)
+
+        # H'' = H' + k * r : [K, BV] = [K, BV] + [K] * [BV]
+        r_h += self.unsqueeze(r_k, dim=1) * self.unsqueeze(r_r, dim=0)
+
+        # o = q * h : [BV] = [K] * [K, BV]
+        r_o = self.sum(self.unsqueeze(r_q, dim=1) * r_h, dim=0).to(bfloat16)
+
+        self.store_global(g_o, r_o, offsets=[0, i_t, i_hv, i_bv * self.BV], dims=[3])
+        if state_idx >= 0:
+            self.store_global(
+                initial_state_source,
+                r_h,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                dims=[2, 3],
+            )
+
+        self.annotate_layout(
+            r_h,
+            self.cuda.default_register_layout(
+                num_warps=self.num_warps, dtype=float32, shape=[K, self.BV]
+            ),
+        )
+
+
+def fused_recurrent_gated_delta_rule_update_fwd_tilus(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+) -> torch.Tensor:
+    _ = cu_seqlens
+    o = torch.empty_like(v)
+
+    B, T, H, K = q.shape
+    HV, V = v.shape[-2:]
+    MAX_T = initial_state_source.shape[0]
+
+    USE_INITIAL_STATE = True
+    USE_QK_L2NORM_IN_KERNEL = use_qk_l2norm_in_kernel
+
+    FusedRecurrentGatedDeltaRuleUpdateFwdKernel()(
+        q,
+        k,
+        v,
+        g,
+        o,
+        beta,
+        scale,
+        initial_state_source,
+        initial_state_indices,
+        T,
+        B,
+        H,
+        HV,
+        K,
+        V,
+        MAX_T,
+        USE_INITIAL_STATE,
+        USE_QK_L2NORM_IN_KERNEL,
+    )
+
+    return o
+
+
+def main():
+    headers = ["name", "(B, T, H, K)", "(HV, V)", "latency (ms)"]
+    rows = []
+
+    for B, T, H, K, HV, V in [
+        [1, 1, 4, 128, 8, 128],
+        [1, 2, 4, 128, 8, 128],
+        [1, 4, 4, 128, 8, 128],
+        [1, 8, 4, 128, 8, 128],
+        [1, 16, 4, 128, 8, 128],
+        [1, 32, 4, 128, 8, 128],
+        [1, 64, 4, 128, 8, 128],
+        [1, 128, 4, 128, 8, 128],
+    ]:
+        q = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, device="cuda", dtype=torch.bfloat16)
+        g = torch.randn(B, T, HV, device="cuda", dtype=torch.float32) * 0.1
+        beta = torch.rand(B, T, HV, device="cuda", dtype=torch.bfloat16) * 0.5 + 0.5
+        initial_state_source = (
+            torch.randn(129, HV, K, V, device="cuda", dtype=torch.float32) * 0.1
+        )
+        initial_state_indices = 126 - torch.arange(T, device="cuda", dtype=torch.int32)
+        scale = K**-0.5
+        cu_seqlens = torch.arange(T + 1, device="cuda", dtype=torch.int32)
+
+        arguments = {
+            "q": q,
+            "k": k,
+            "v": v,
+            "g": g,
+            "beta": beta,
+            "scale": scale,
+            "initial_state_source": initial_state_source,
+            "initial_state_indices": initial_state_indices,
+            "use_qk_l2norm_in_kernel": True,
+        }
+
+        torch_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        tilus_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        triton_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        triton_arguments["cu_seqlens"] = cu_seqlens
+
+        expect_o = fused_recurrent_gated_delta_rule_update_fwd_torch(**torch_arguments)
+        actual_o = fused_recurrent_gated_delta_rule_update_fwd_tilus(**tilus_arguments)
+        triton_o = fused_recurrent_gated_delta_rule_update_fwd_triton(**triton_arguments)
+
+        torch.testing.assert_close(actual_o, expect_o, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(triton_o, expect_o, atol=1e-3, rtol=1e-3)
+
+        # benchmark
+        for name, func, args in [
+            [
+                "triton",
+                fused_recurrent_gated_delta_rule_update_fwd_triton,
+                triton_arguments,
+            ],
+            ["tilus", fused_recurrent_gated_delta_rule_update_fwd_tilus, tilus_arguments],
+        ]:
+            latency = benchmark_func(lambda: func(**args), warmup=10, repeat=50)
+            rows.append([name, f"({B}, {T}, {H}, {K})", f"({HV}, {V})", f"{latency:.3f}"])
+        df = pd.DataFrame(rows, columns=headers)
+        print(df)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flash_attention_decode/torch_kernel.py
+++ b/examples/flash_attention_decode/torch_kernel.py
@@ -1,0 +1,94 @@
+import torch
+
+
+def fused_recurrent_gated_delta_rule_update_fwd_torch(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale,
+    initial_state_source,
+    initial_state_indices,
+    use_qk_l2norm_in_kernel=False,
+):
+    """
+    Reference implementation of the fused recurrent gated delta rule update.
+
+    This implements the same computation as the Tilus kernel but in pure PyTorch.
+    """
+    # Get dimensions
+    B, T, H, K = q.shape
+    _, _, HV, V = v.shape
+    device = q.device
+    dtype = torch.float32
+
+    # Initialize output
+    o = torch.zeros(B, T, HV, V, device=device, dtype=q.dtype)
+
+    # Process each batch element
+    for b in range(B):
+        # Process each timestep independently (matching kernel approach)
+        for t in range(T):
+            # Process each head group (HV heads)
+            for hv in range(HV):
+                # Determine which H head this HV head corresponds to
+                h_idx = hv // (HV // H) if HV >= H else 0
+
+                # Initialize hidden state [K, V]
+                h_state = torch.zeros(K, V, device=device, dtype=dtype)
+
+                # Load initial state if provided
+                if initial_state_source is not None and initial_state_indices is not None:
+                    idx = initial_state_indices[t].item()  # Use timestep-specific index
+                    if idx >= 0 and idx < initial_state_source.shape[0]:
+                        h_state = initial_state_source[idx, hv].clone().to(dtype)
+                # Get current inputs
+                q_t = q[b, t, h_idx].to(dtype)  # [K]
+                k_t = k[b, t, h_idx].to(dtype)  # [K]
+                v_t = v[b, t, hv].to(dtype)  # [V]
+                g_t = g[b, t, hv].to(dtype)  # scalar
+
+                # Handle beta (can be headwise or scalar)
+                if beta.ndim == v.ndim:  # headwise
+                    beta_t = beta[b, t, hv].to(dtype)  # [V] or scalar
+                else:
+                    beta_t = beta[b, t, hv].to(dtype)  # scalar
+
+                # Apply L2 normalization if enabled
+                if use_qk_l2norm_in_kernel:
+                    q_norm = torch.sqrt(torch.sum(q_t * q_t)) + 1e-6
+                    k_norm = torch.sqrt(torch.sum(k_t * k_t)) + 1e-6
+                    q_t = q_t / q_norm
+                    k_t = k_t / k_norm
+
+                # Scale query
+                q_t = q_t * scale
+
+                # Decay hidden state: h *= exp(g)
+                h_state = h_state * torch.exp(g_t)
+
+                # Delta rule: v -= sum(h * k, dim=0)
+                # h_state is [K, V], k_t is [K], so we want sum over K dimension
+                prediction = torch.sum(h_state * k_t[:, None], dim=0)  # [V]
+                v_t = v_t - prediction
+
+                # Apply beta gating: v *= beta
+                v_t = v_t * beta_t
+
+                # Update hidden state: h += k[:, None] * v[None, :]
+                h_state = h_state + k_t[:, None] * v_t[None, :]  # [K, V]
+
+                # Compute output: o = sum(h * q, dim=0)
+                o_t = torch.sum(h_state * q_t[:, None], dim=0)  # [V]
+                o[b, t, hv] = o_t.to(q.dtype)
+
+                # Store final state back (if needed - the kernel does this)
+                if initial_state_source is not None and initial_state_indices is not None:
+                    idx = initial_state_indices[t].item()  # Use timestep-specific index
+                    if idx >= 0 and idx < initial_state_source.shape[0]:
+                        initial_state_source[idx, hv] = h_state.to(
+                            initial_state_source.dtype
+                        )
+
+    return o

--- a/examples/flash_attention_decode/triton_kernel.py
+++ b/examples/flash_attention_decode/triton_kernel.py
@@ -1,0 +1,200 @@
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0_source"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["T"])
+def fused_recurrent_gated_delta_rule_update_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    o,
+    h0_source,
+    h0_indices,
+    cu_seqlens,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
+    IS_BETA_HEADWISE: tl.constexpr,  # whether beta is headwise vector or scalar,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """
+    {
+        'q': 'torch.Size([1, 1, 4, 128])',
+        'k': 'torch.Size([1, 1, 4, 128])',
+        'v': 'torch.Size([1, 1, 8, 128])',
+        'g': 'torch.Size([1, 1, 8])',
+        'beta': 'torch.Size([1, 1, 8])',
+        'scale': None,
+        'initial_state_source': 'torch.Size([129, 8, 128, 128])',
+        'initial_state_indices': 'torch.Size([1])',
+        'cu_seqlens': 'torch.Size([2])',
+        'use_qk_l2norm_in_kernel': True
+    }
+    """
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        all = B * T
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    if IS_BETA_HEADWISE:
+        p_beta = beta + (bos * HV + i_hv) * V + o_v
+    else:
+        p_beta = beta + bos * HV + i_hv
+    p_g = g + bos * HV + i_hv
+    p_o = o + ((i_k * all + bos) * HV + i_hv) * V + o_v
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        idx = tl.load(h0_indices + i_n)
+        # Add bounds checking for idx
+        if idx >= 0:  # Assuming negative indices are invalid
+            p_h0 = (
+                h0_source
+                + idx * HV * K * V
+                + i_hv * K * V
+                + o_k[:, None] * V
+                + o_v[None, :]
+            )
+            b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+        b_g = tl.load(p_g).to(tl.float32)
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / (tl.sqrt(tl.sum(b_q * b_q)) + 1e-6)
+            b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k)) + 1e-6)
+        b_q = b_q * scale
+        # [BK, BV]
+        b_h *= tl.exp(b_g)
+        # [BV]
+        b_v -= tl.sum(b_h * b_k[:, None], 0)
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(p_beta, mask=mask_v, other=0).to(tl.float32)
+        else:
+            b_beta = tl.load(p_beta).to(tl.float32)
+        b_v *= b_beta
+        # [BK, BV]
+        b_h += b_k[:, None] * b_v[None, :]
+        # [BV]
+        b_o = tl.sum(b_h * b_q[:, None], 0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+        p_q += H * K
+        p_k += H * K
+        p_o += HV * V
+        p_v += HV * V
+        p_g += HV
+        p_beta += HV * (V if IS_BETA_HEADWISE else 1)
+
+    # Store final state back to h0_source with bounds checking
+    idx = tl.load(h0_indices + i_n)
+    if idx >= 0:  # Add bounds checking
+        p_h0 = (
+            h0_source + idx * HV * K * V + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+        )
+        tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=mask_h)
+
+
+def fused_recurrent_gated_delta_rule_update_fwd_triton(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Example Inputs:
+        q: dtype: torch.bfloat16, shape: torch.Size([1, 1, 4, 128])
+        k: dtype: torch.bfloat16, shape: torch.Size([1, 1, 4, 128])
+        v: dtype: torch.bfloat16, shape: torch.Size([1, 1, 8, 128])
+        g: dtype: torch.float32, shape: torch.Size([1, 1, 8])
+        beta: dtype: torch.bfloat16, shape: torch.Size([1, 1, 8])
+        scale: None
+        initial_state_source: dtype: torch.float32, shape: torch.Size([129, 8, 128, 128])
+        initial_state_indices: tensor([126], device='cuda:1', dtype=torch.int32)
+        cu_seqlens: tensor([0, 1], device='cuda:1', dtype=torch.int32)
+        use_qk_l2norm_in_kernel: True
+    """
+    B, T, H, K, V = *k.shape, v.shape[-1]  # B=1, T=1, H=4, K=V=128
+    HV = v.shape[2]  # HV=8
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1  # N=1
+    BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 8)  # BK=128, BV=8
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)  # NK=1, NV=16
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    o = q.new_empty(NK, *v.shape)  # [1, 1, 1, 8, 128]
+    grid = (NK, NV, N * HV)  # (1, 16, 8)
+
+    fused_recurrent_gated_delta_rule_update_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        o=o,
+        h0_source=initial_state_source,
+        h0_indices=initial_state_indices,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        IS_BETA_HEADWISE=beta.ndim == v.ndim,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    o = o.squeeze(0)
+    return o

--- a/python/tilus/drivers.py
+++ b/python/tilus/drivers.py
@@ -131,6 +131,7 @@ def optimize_ir_module(ir_module: IRModule, cache_dir: Path) -> IRModule:
     from hidet.transforms.instruments import PassInstrument, ProfileInstrument, SaveIRInstrument
     from hidet.transforms.lower_integer_subbyte import lower_integer_subbyte_pass
     from hidet.transforms.lower_special_cast import lower_special_cast_pass
+    from hidet.transforms.lower_task_mapping import lower_task_mapping_pass
     from hidet.transforms.propagate_launch_bound import propagate_launch_bound_pass
     from hidet.transforms.resolve_generic_primitive_function import resolve_primitive_func_pass
     from hidet.transforms.simplify_addition_chain import simplify_addition_chain_pass
@@ -159,6 +160,7 @@ def optimize_ir_module(ir_module: IRModule, cache_dir: Path) -> IRModule:
         flatten_tensor_slice_pass(),
         flatten_tensor_index_pass(),
         declare_to_let_pass(),
+        lower_task_mapping_pass(),
         rule_based_simplify_pass(),  # make ir more readable
         lower_special_cast_pass(),
         inline_function_pass(),

--- a/python/tilus/ir/analyzers/grid_analyzer.py
+++ b/python/tilus/ir/analyzers/grid_analyzer.py
@@ -547,17 +547,10 @@ def analyze_grid(
     ret = analyzer.analyze(axes, shape, var2info, expr)
 
     if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("shape: %s", shape)
-        logger.debug("axes: %s", axes)
-        logger.debug("expr: %s", expr)
-        logger.debug("var2info: %s", var2info)
+        logger.debug("shape: %s, axes: %s, expr: %s", shape, axes, expr)
         for var in var2info:
             logger.debug("%s: %s", var, var2info[var])
         logger.debug("ret: %s", ret)
-        for expr in analyzer.memo:
-            logger.debug("expr: %s", expr)
-            logger.debug("      %s", analyzer.memo[expr])
-        logger.debug("=" * 20)
 
     return ret
 

--- a/python/tilus/ir/builders/stmt_builder.py
+++ b/python/tilus/ir/builders/stmt_builder.py
@@ -627,6 +627,9 @@ class StmtBuilder(StmtBuilderCore):
     def round(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.round(arg), out=out)
 
+    def sqrt(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_unary(x, f_compute=lambda arg: primitives.sqrt(arg), out=out)
+
     def abs(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.abs(arg), out=out)
 

--- a/python/tilus/ir/layout/inference/__init__.py
+++ b/python/tilus/ir/layout/inference/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from . import inference_rules, validation_rules
-from .inference import infer_layout
+from .inference import infer_layout, verify_layouts

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -1055,6 +1055,32 @@ class Script:
         """
         return self._builder.round(x, out=out)
 
+    def sqrt(
+        self,
+        x: RegisterTensor,
+        *,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Compute the square root of each element.
+
+        This instruction computes the square root of each element in the register tensor `x`. The result is a new
+        register tensor with the same dtype, shape, and layout as `x`.
+
+        Parameters
+        ----------
+        x: RegisterTensor
+            The register tensor to compute the square root of.
+        out: RegisterTensor, optional
+            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            The register tensor containing the square root values of the elements in `x`. The shape and dtype of the
+            output tensor will be the same as that of `x`.
+        """
+        return self._builder.sqrt(x, out=out)
+
     def clip(
         self,
         x: RegisterTensor,

--- a/python/tilus/transforms/layout_inference.py
+++ b/python/tilus/transforms/layout_inference.py
@@ -15,8 +15,10 @@
 from tilus.ir.func import Function
 from tilus.ir.functors import IRRewriter
 from tilus.ir.instructions import AnnotateLayoutInst
-from tilus.ir.layout.inference import infer_layout
-from tilus.ir.tools import rewrite
+from tilus.ir.layout.inference import infer_layout, verify_layouts
+from tilus.ir.layout.inference.inference import LayoutInferenceError
+from tilus.ir.tensor import RegisterTensor, SharedTensor
+from tilus.ir.tools import IRPrinter, rewrite
 from tilus.transforms.base import Pass
 
 
@@ -60,7 +62,33 @@ class LayoutInferencePass(Pass):
         apply_annotation = ApplyLayoutAnnotationRewriter()
         func = apply_annotation(func)
         func = infer_layout(func)
+        self.verify_layouts(func)
+
         return func
+
+    @staticmethod
+    def verify_layouts(func):
+        invalid_instructions = verify_layouts(func)
+
+        if invalid_instructions:
+            printer = IRPrinter()
+            program_text = str(printer(func).indent())
+            lines = [
+                "Layout verification failed for the following program:",
+                program_text,
+                "",
+                "Instructions with invalid layouts:",
+            ]
+            for inst in invalid_instructions:
+                lines.append(str(printer(inst)))
+                tensors = inst.inputs + ((inst.output,) if inst.output else tuple())
+                for tensor in tensors:
+                    if isinstance(tensor, (SharedTensor, RegisterTensor)):
+                        lines.append("  " + str(printer(tensor)) + ": " + str(tensor.optional_layout))
+                lines.append("")
+            error_message = "\n".join(lines)
+            raise LayoutInferenceError(error_message)
+        pass
 
 
 def layout_inference_pass() -> Pass:


### PR DESCRIPTION
This PR adds the implementation for the decoding kernel of flash linear attention:
https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/gated_delta_rule/fused_recurrent.py

```
      name      (B, T, H, K)   (HV, V) latency (ms)
0   triton    (1, 1, 4, 128)  (8, 128)        0.007
1    tilus    (1, 1, 4, 128)  (8, 128)        0.006
2   triton    (1, 2, 4, 128)  (8, 128)        0.008
3    tilus    (1, 2, 4, 128)  (8, 128)        0.007
4   triton    (1, 4, 4, 128)  (8, 128)        0.011
5    tilus    (1, 4, 4, 128)  (8, 128)        0.009
6   triton    (1, 8, 4, 128)  (8, 128)        0.016
7    tilus    (1, 8, 4, 128)  (8, 128)        0.013
8   triton   (1, 16, 4, 128)  (8, 128)        0.026
9    tilus   (1, 16, 4, 128)  (8, 128)        0.022
10  triton   (1, 32, 4, 128)  (8, 128)        0.047
11   tilus   (1, 32, 4, 128)  (8, 128)        0.044
12  triton   (1, 64, 4, 128)  (8, 128)        0.081
13   tilus   (1, 64, 4, 128)  (8, 128)        0.086
14  triton  (1, 128, 4, 128)  (8, 128)        0.153
15   tilus  (1, 128, 4, 128)  (8, 128)        0.161
```

To support this kernel, have some other enhancements:
1. add sqrt operator
2. move the layout inference verification to have better visualization in debug log
