### PR TITLE
[Example] Add a kernel in the flash linear attention

### DIFF
--- a/examples/flash_attention_decode/main.py
+++ b/examples/flash_attention_decode/main.py
@@ -1,181 +1,92 @@
-import math
-from typing import Optional
-
 import pandas as pd
-import tilus
 import torch
-from tilus import bfloat16, float32, int32
-from tilus.utils import benchmark_func, cdiv
-from torch_kernel import fused_recurrent_gated_delta_rule_update_fwd_torch
-from triton_kernel import fused_recurrent_gated_delta_rule_update_fwd_triton
+from tilus.utils import benchmark_func
+from tilus_kernel import (
+    fused_gdn_gating_tilus,
+    fused_recurrent_gated_delta_rule_update_fwd_tilus,
+)
+from torch_kernel import (
+    fused_gdn_gating_torch,
+    fused_recurrent_gated_delta_rule_update_fwd_torch,
+)
+from triton_kernel import (
+    fused_gdn_gating,
+    fused_recurrent_gated_delta_rule_update_fwd_triton,
+)
 
 
-@tilus.autotune("num_warps", [1, 2, 4])
-@tilus.autotune("BV", [2, 4, 8, 16, 32, 64, 128])
-class FusedRecurrentGatedDeltaRuleUpdateFwdKernel(tilus.Script):
-    def __init__(self, num_warps: int, BV: int):
-        super().__init__()
-        self.num_warps = num_warps
-        self.BV = BV
+def main_fused_gdn_gating():
+    """Test and benchmark fused GDN gating implementations."""
+    headers = ["name", "(batch, num_heads)", "latency (ms)"]
+    rows = []
 
-    def __call__(
-        self,
-        q_ptr: ~bfloat16,
-        k_ptr: ~bfloat16,
-        v_ptr: ~bfloat16,
-        g_ptr: ~float32,
-        o_ptr: ~bfloat16,
-        beta_ptr: ~bfloat16,
-        scale: float,
-        initial_state_source_ptr: ~float32,
-        initial_state_indices_ptr: ~int32,
-        T: int32,
-        B: int,
-        H: int,
-        HV: int,
-        K: int,
-        V: int,
-        MAX_T: int,
-        USE_INITIAL_STATE: bool,
-        USE_QK_L2NORM_IN_KERNEL: bool,
-    ):
-        self.attrs.warps = self.num_warps
-        self.attrs.blocks = (T, cdiv(V, self.BV), HV)
+    for batch, num_heads in [
+        [1, 8],
+        [1, 16],
+        [1, 32],
+        [1, 64],
+        [1, 128],
+        [1, 256],
+        [2, 128],
+        [4, 128],
+        [8, 128],
+    ]:
+        # Create test inputs
+        A_log = torch.randn(num_heads, device="cuda", dtype=torch.float32) * 0.1
+        a = torch.randn(batch, num_heads, device="cuda", dtype=torch.bfloat16)
+        dt_bias = torch.randn(num_heads, device="cuda", dtype=torch.float32) * 0.1
+        beta = 1.0
+        threshold = 20.0
 
-        g_q = self.global_view(q_ptr, dtype=bfloat16, shape=[B, T, H, K])
-        g_k = self.global_view(k_ptr, dtype=bfloat16, shape=[B, T, H, K])
-        g_v = self.global_view(v_ptr, dtype=bfloat16, shape=[B, T, HV, V])
-        g_g = self.global_view(g_ptr, dtype=float32, shape=[B, T, HV])
-        g_o = self.global_view(o_ptr, dtype=bfloat16, shape=[B, T, HV, V])
-        g_beta = self.global_view(beta_ptr, dtype=bfloat16, shape=[B, T, HV])
-        initial_state_source = self.global_view(
-            initial_state_source_ptr, dtype=float32, shape=[MAX_T, HV, K, V]
-        )
-        initial_state_indices = self.global_view(
-            initial_state_indices_ptr, dtype=int32, shape=[T]
-        )
+        arguments = {
+            "A_log": A_log,
+            "a": a,
+            "dt_bias": dt_bias,
+            "beta": beta,
+            "threshold": threshold,
+        }
 
-        i_t, i_bv, i_hv = self.blockIdx
-        i_h = i_hv // (HV // H)
+        # Clone arguments for each implementation
+        torch_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        triton_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        tilus_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
 
-        r_q = self.load_global(g_q, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
-            float32
-        )
-        r_k = self.load_global(g_k, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
-            float32
-        )
+        # Test correctness
+        torch_output = fused_gdn_gating_torch(**torch_arguments)
+        triton_output = fused_gdn_gating(**triton_arguments)
+        tilus_output = fused_gdn_gating_tilus(**tilus_arguments)
 
-        # self.print_tensor('r_q ', r_q)
-        # self.print_tensor('r_k ', r_k)
+        # Verify outputs match
+        torch.testing.assert_close(triton_output, torch_output, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(tilus_output, torch_output, atol=1e-3, rtol=1e-3)
+        print(f"✓ Correctness test passed for batch={batch}, num_heads={num_heads}")
 
-        # normalize q and k
-        if USE_QK_L2NORM_IN_KERNEL:
-            r_q = r_q / self.sqrt(self.sum(r_q * r_q, dim=0))
-            r_k = r_k / self.sqrt(self.sum(r_k * r_k, dim=0))
+        # Benchmark all implementations
+        for name, func, args in [
+            ["torch", fused_gdn_gating_torch, torch_arguments],
+            ["triton", fused_gdn_gating, triton_arguments],
+            ["tilus", fused_gdn_gating_tilus, tilus_arguments],
+        ]:
+            latency = benchmark_func(lambda: func(**args), warmup=10, repeat=50)
+            rows.append([name, f"({batch}, {num_heads})", f"{latency:.3f}"])
 
-        r_q = r_q * scale
-
-        # self.print_tensor('normalized r_q ', r_q)
-        # self.print_tensor('normalized r_k ', r_k)
-
-        # load initial state
-        if USE_INITIAL_STATE:
-            state_idx: int32 = initial_state_indices[i_t]
-            r_h = self.load_global(
-                initial_state_source,
-                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
-                shape=[K, self.BV],
-                dims=[2, 3],
-            )
-        else:
-            state_idx: int32 = -1
-            r_h = self.register_tensor(dtype=float32, shape=[K, self.BV], init=0.0)
-
-        # H' = alpha * H : [K, BV] = [] * [K, BV]
-        alpha: float32 = math.exp(g_g[0, i_t, i_hv])
-        r_h = r_h * alpha
-
-        # p = k * H : [BV] = reduce([K, 1] * [K, BV], dim=0)
-        r_p = self.sum(self.unsqueeze(r_k, dim=1) * r_h, dim=0)
-        # self.print_tensor('r_p ', r_p)
-
-        # r = beta * (v - p) : [BV] = [] * ([BV] - [BV])
-        beta: float32 = float32(g_beta[0, i_t, i_hv])
-        r_v = self.load_global(
-            g_v, offsets=[0, i_t, i_hv, i_bv * self.BV], shape=[self.BV], dims=[3]
-        ).to(float32)
-        r_r = beta * (r_v - r_p)
-
-        # H'' = H' + k * r : [K, BV] = [K, BV] + [K] * [BV]
-        r_h += self.unsqueeze(r_k, dim=1) * self.unsqueeze(r_r, dim=0)
-
-        # o = q * h : [BV] = [K] * [K, BV]
-        r_o = self.sum(self.unsqueeze(r_q, dim=1) * r_h, dim=0).to(bfloat16)
-
-        self.store_global(g_o, r_o, offsets=[0, i_t, i_hv, i_bv * self.BV], dims=[3])
-        if state_idx >= 0:
-            self.store_global(
-                initial_state_source,
-                r_h,
-                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
-                dims=[2, 3],
-            )
-
-        self.annotate_layout(
-            r_h,
-            self.cuda.default_register_layout(
-                num_warps=self.num_warps, dtype=float32, shape=[K, self.BV]
-            ),
-        )
+    # Print benchmark results
+    df = pd.DataFrame(rows, columns=headers)
+    print("\nFused GDN Gating Benchmark Results:")
+    print(df)
+    print()
 
 
-def fused_recurrent_gated_delta_rule_update_fwd_tilus(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    scale: float,
-    initial_state_source: torch.Tensor,
-    initial_state_indices: torch.Tensor,
-    use_qk_l2norm_in_kernel: bool = False,
-    cu_seqlens: Optional[torch.LongTensor] = None,
-) -> torch.Tensor:
-    _ = cu_seqlens
-    o = torch.empty_like(v)
-
-    B, T, H, K = q.shape
-    HV, V = v.shape[-2:]
-    MAX_T = initial_state_source.shape[0]
-
-    USE_INITIAL_STATE = True
-    USE_QK_L2NORM_IN_KERNEL = use_qk_l2norm_in_kernel
-
-    FusedRecurrentGatedDeltaRuleUpdateFwdKernel()(
-        q,
-        k,
-        v,
-        g,
-        o,
-        beta,
-        scale,
-        initial_state_source,
-        initial_state_indices,
-        T,
-        B,
-        H,
-        HV,
-        K,
-        V,
-        MAX_T,
-        USE_INITIAL_STATE,
-        USE_QK_L2NORM_IN_KERNEL,
-    )
-
-    return o
-
-
-def main():
+def main_fused_recurrent_gated_delta_rule_update_fwd():
     headers = ["name", "(B, T, H, K)", "(HV, V)", "latency (ms)"]
     rows = []
 
@@ -248,6 +159,15 @@ def main():
         df = pd.DataFrame(rows, columns=headers)
         print(df)
         print()
+
+
+def main():
+    """Run all tests and benchmarks."""
+    print("Running Fused GDN Gating tests and benchmarks...")
+    main_fused_gdn_gating()
+
+    print("Running Fused Recurrent Gated Delta Rule Update tests and benchmarks...")
+    main_fused_recurrent_gated_delta_rule_update_fwd()
 
 
 if __name__ == "__main__":

--- a/examples/flash_attention_decode/tilus_kernel.py
+++ b/examples/flash_attention_decode/tilus_kernel.py
@@ -1,0 +1,277 @@
+import math
+from typing import Optional
+
+import tilus
+import torch
+from tilus import bfloat16, float32, int32
+from tilus.utils import cdiv
+
+
+@tilus.autotune("num_warps", [1])
+@tilus.autotune("block_heads", [4])
+class FusedGdnGatingKernel(tilus.Script):
+    def __init__(self, num_warps: int, block_heads: int):
+        super().__init__()
+        self.num_warps = num_warps
+        self.block_heads = block_heads
+
+    def __call__(
+        self,
+        g_ptr: ~float32,
+        A_log_ptr: ~float32,
+        a_ptr: ~bfloat16,
+        dt_bias_ptr: ~float32,
+        batch: int,
+        num_heads: int,
+        beta: float,
+        threshold: float,
+    ):
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (batch, cdiv(num_heads, self.block_heads))
+
+        # Create global views
+        g_g = self.global_view(g_ptr, dtype=float32, shape=[batch, num_heads])
+        g_A_log = self.global_view(A_log_ptr, dtype=float32, shape=[num_heads])
+        g_a = self.global_view(a_ptr, dtype=bfloat16, shape=[batch, num_heads])
+        g_dt_bias = self.global_view(dt_bias_ptr, dtype=float32, shape=[num_heads])
+
+        # Get block indices
+        i_batch = self.blockIdx.x
+        i_head_block = self.blockIdx.y
+
+        # Load a slice of heads for this block
+        head_offset = i_head_block * self.block_heads
+
+        # Load inputs as tensors
+        r_A_log = self.load_global(
+            g_A_log, offsets=[head_offset], shape=[self.block_heads], dims=[0]
+        ).to(float32)
+        r_a = self.load_global(
+            g_a, offsets=[i_batch, head_offset], shape=[self.block_heads], dims=[1]
+        ).to(float32)
+        r_dt_bias = self.load_global(
+            g_dt_bias, offsets=[head_offset], shape=[self.block_heads], dims=[0]
+        ).to(float32)
+
+        # Compute x = a + dt_bias
+        r_x = r_a + r_dt_bias
+
+        # Apply softplus with beta and threshold for numerical stability
+        r_beta_x = r_x * beta
+
+        # For numerical stability, we'll compute both branches and let the hardware handle it
+        # This is a simplified version that should work with Tilus
+        r_exp_beta_x = self.exp(r_beta_x)
+        r_log_term = self.log(r_exp_beta_x + 1.0)
+        r_softplus = self.where(r_x >= threshold, r_x, r_log_term * (1.0 / beta))
+
+        # Compute final result: g = -exp(A_log) * softplus_x
+        r_result = -self.exp(r_A_log) * r_softplus
+
+        # Store result
+        self.store_global(g_g, r_result, offsets=[i_batch, head_offset], dims=[1])
+
+
+@tilus.autotune("num_warps", [1, 2, 4])
+@tilus.autotune("BV", [2, 4, 8, 16, 32, 64, 128])
+class FusedRecurrentGatedDeltaRuleUpdateFwdKernel(tilus.Script):
+    def __init__(self, num_warps: int, BV: int):
+        super().__init__()
+        self.num_warps = num_warps
+        self.BV = BV
+
+    def __call__(
+        self,
+        q_ptr: ~bfloat16,
+        k_ptr: ~bfloat16,
+        v_ptr: ~bfloat16,
+        g_ptr: ~float32,
+        o_ptr: ~bfloat16,
+        beta_ptr: ~bfloat16,
+        scale: float,
+        initial_state_source_ptr: ~float32,
+        initial_state_indices_ptr: ~int32,
+        T: int32,
+        B: int,
+        H: int,
+        HV: int,
+        K: int,
+        V: int,
+        MAX_T: int,
+        USE_INITIAL_STATE: bool,
+        USE_QK_L2NORM_IN_KERNEL: bool,
+    ):
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (T, cdiv(V, self.BV), HV)
+
+        g_q = self.global_view(q_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_k = self.global_view(k_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_v = self.global_view(v_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        g_g = self.global_view(g_ptr, dtype=float32, shape=[B, T, HV])
+        g_o = self.global_view(o_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        g_beta = self.global_view(beta_ptr, dtype=bfloat16, shape=[B, T, HV])
+        initial_state_source = self.global_view(
+            initial_state_source_ptr, dtype=float32, shape=[MAX_T, HV, K, V]
+        )
+        initial_state_indices = self.global_view(
+            initial_state_indices_ptr, dtype=int32, shape=[T]
+        )
+
+        i_t, i_bv, i_hv = self.blockIdx
+        i_h = i_hv // (HV // H)
+
+        r_q = self.load_global(g_q, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+        r_k = self.load_global(g_k, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+
+        # self.print_tensor('r_q ', r_q)
+        # self.print_tensor('r_k ', r_k)
+
+        # normalize q and k
+        if USE_QK_L2NORM_IN_KERNEL:
+            r_q = r_q / self.sqrt(self.sum(r_q * r_q, dim=0))
+            r_k = r_k / self.sqrt(self.sum(r_k * r_k, dim=0))
+
+        r_q = r_q * scale
+
+        # self.print_tensor('normalized r_q ', r_q)
+        # self.print_tensor('normalized r_k ', r_k)
+
+        # load initial state
+        if USE_INITIAL_STATE:
+            state_idx: int32 = initial_state_indices[i_t]
+            r_h = self.load_global(
+                initial_state_source,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                shape=[K, self.BV],
+                dims=[2, 3],
+            )
+        else:
+            state_idx: int32 = -1
+            r_h = self.register_tensor(dtype=float32, shape=[K, self.BV], init=0.0)
+
+        # H' = alpha * H : [K, BV] = [] * [K, BV]
+        alpha: float32 = math.exp(g_g[0, i_t, i_hv])
+        r_h = r_h * alpha
+
+        # p = k * H : [BV] = reduce([K, 1] * [K, BV], dim=0)
+        r_p = self.sum(self.unsqueeze(r_k, dim=1) * r_h, dim=0)
+        # self.print_tensor('r_p ', r_p)
+
+        # r = beta * (v - p) : [BV] = [] * ([BV] - [BV])
+        beta: float32 = float32(g_beta[0, i_t, i_hv])
+        r_v = self.load_global(
+            g_v, offsets=[0, i_t, i_hv, i_bv * self.BV], shape=[self.BV], dims=[3]
+        ).to(float32)
+        r_r = beta * (r_v - r_p)
+
+        # H'' = H' + k * r : [K, BV] = [K, BV] + [K] * [BV]
+        r_h += self.unsqueeze(r_k, dim=1) * self.unsqueeze(r_r, dim=0)
+
+        # o = q * h : [BV] = [K] * [K, BV]
+        r_o = self.sum(self.unsqueeze(r_q, dim=1) * r_h, dim=0).to(bfloat16)
+
+        self.store_global(g_o, r_o, offsets=[0, i_t, i_hv, i_bv * self.BV], dims=[3])
+        if state_idx >= 0:
+            self.store_global(
+                initial_state_source,
+                r_h,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                dims=[2, 3],
+            )
+
+        self.annotate_layout(
+            r_h,
+            self.cuda.default_register_layout(
+                num_warps=self.num_warps, dtype=float32, shape=[K, self.BV]
+            ),
+        )
+
+
+def fused_recurrent_gated_delta_rule_update_fwd_tilus(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+) -> torch.Tensor:
+    _ = cu_seqlens
+    o = torch.empty_like(v)
+
+    B, T, H, K = q.shape
+    HV, V = v.shape[-2:]
+    MAX_T = initial_state_source.shape[0]
+
+    USE_INITIAL_STATE = True
+    USE_QK_L2NORM_IN_KERNEL = use_qk_l2norm_in_kernel
+
+    FusedRecurrentGatedDeltaRuleUpdateFwdKernel()(
+        q,
+        k,
+        v,
+        g,
+        o,
+        beta,
+        scale,
+        initial_state_source,
+        initial_state_indices,
+        T,
+        B,
+        H,
+        HV,
+        K,
+        V,
+        MAX_T,
+        USE_INITIAL_STATE,
+        USE_QK_L2NORM_IN_KERNEL,
+    )
+
+    return o
+
+
+def fused_gdn_gating_tilus(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+) -> torch.Tensor:
+    """
+    Tilus implementation of the fused GDN gating computation.
+
+    Args:
+        A_log: Log of A parameter, shape [num_heads]
+        a: Input tensor, shape [batch, num_heads]
+        dt_bias: Bias parameter, shape [num_heads]
+        beta: Beta parameter for softplus (default: 1.0)
+        threshold: Threshold for numerical stability (default: 20.0)
+
+    Returns:
+        g: Output tensor, shape [batch, num_heads]
+    """
+    batch, num_heads = a.shape
+
+    # Create output tensor
+    g = torch.empty_like(a, dtype=torch.float32)
+
+    # Run the Tilus kernel
+    FusedGdnGatingKernel()(
+        g,
+        A_log,
+        a,
+        dt_bias,
+        batch,
+        num_heads,
+        beta,
+        threshold,
+    )
+
+    return g

--- a/examples/flash_attention_decode/triton_kernel.py
+++ b/examples/flash_attention_decode/triton_kernel.py
@@ -198,3 +198,48 @@ def fused_recurrent_gated_delta_rule_update_fwd_triton(
     )
     o = o.squeeze(0)
     return o
+
+
+# g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+@triton.jit
+def fused_gdn_gating_kernel(
+    g,
+    A_log,
+    a,
+    dt_bias,
+    seq_len,
+    NUM_HEADS: tl.constexpr,
+    beta: tl.constexpr,
+    threshold: tl.constexpr,
+    BLK_HEADS: tl.constexpr,
+):
+    i_b, i_s, i_d = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    head_off = i_d * BLK_HEADS + tl.arange(0, BLK_HEADS)
+    off = i_b * seq_len * NUM_HEADS + i_s * NUM_HEADS + head_off
+    mask = head_off < NUM_HEADS
+    blk_A_log = tl.load(A_log + head_off, mask=mask)
+    blk_a = tl.load(a + off, mask=mask)
+    blk_bias = tl.load(dt_bias + head_off, mask=mask)
+    x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
+    softplus_x = tl.where(
+        beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x
+    )
+    blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
+    tl.store(g + off, blk_g.to(g.dtype.element_ty), mask=mask)
+
+
+def fused_gdn_gating(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+) -> torch.Tensor:
+    batch, num_heads = a.shape
+    seq_len = 1
+    grid = (batch, seq_len, triton.cdiv(num_heads, 8))
+    g = torch.empty_like(a, dtype=torch.float32)
+    fused_gdn_gating_kernel[grid](
+        g, A_log, a, dt_bias, seq_len, num_heads, beta, threshold, 8, num_warps=1
+    )
+    return g

--- a/python/tilus/ir/builders/stmt_builder.py
+++ b/python/tilus/ir/builders/stmt_builder.py
@@ -18,7 +18,7 @@ from typing import Callable, List, Optional, Sequence, Type, Union
 
 from hidet.ir import primitives
 from hidet.ir.dtypes import boolean, int32
-from hidet.ir.expr import Expr, Var, as_expr
+from hidet.ir.expr import Equal, Expr, LessEqual, LessThan, NotEqual, Var, as_expr
 from hidet.ir.tools import infer_type
 from hidet.ir.type import BaseType, DataType
 from hidet.ir.utils import broadcast_shapes, can_broadcast
@@ -596,6 +596,34 @@ class StmtBuilder(StmtBuilderCore):
     def mod(self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self._binary(x, y, ModInst, out=out)
 
+    def less_than(
+        self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None
+    ) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: LessThan(a, b), out=out)
+
+    def less_equal(
+        self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None
+    ) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: LessEqual(a, b), out=out)
+
+    def greater_than(
+        self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None
+    ) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: LessThan(b, a), out=out)
+
+    def greater_equal(
+        self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None
+    ) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: LessEqual(b, a), out=out)
+
+    def equal(self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: Equal(a, b), out=out)
+
+    def not_equal(
+        self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None
+    ) -> RegisterTensor:
+        return self.elementwise_binary(x, y, f_compute=lambda a, b: NotEqual(a, b), out=out)
+
     def maximum(self, x: RegisterTensor, y: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_binary(x, y, f_compute=lambda a, b: primitives.max(a, b), out=out)
 
@@ -630,6 +658,9 @@ class StmtBuilder(StmtBuilderCore):
     def sqrt(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.sqrt(arg), out=out)
 
+    def neg(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_unary(x, f_compute=lambda arg: -arg, out=out)
+
     def abs(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.abs(arg), out=out)
 
@@ -638,6 +669,9 @@ class StmtBuilder(StmtBuilderCore):
 
     def exp2(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.math.exp2(arg), out=out)
+
+    def log(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_unary(x, f_compute=lambda arg: primitives.log(arg), out=out)
 
     def print_tensor(self, msg: str, tensor: Tensor, fmt: Optional[str] = None, cond: Expr = boolean.true) -> None:
         inst = PrintTensorInst.create(tensor, cond=cond, msg=msg, fmt=fmt)

--- a/python/tilus/ir/tensor.py
+++ b/python/tilus/ir/tensor.py
@@ -169,6 +169,24 @@ class RegisterTensor(Tensor):
     converted in the Tilus Script transpiler defined in tilus.lang.transpiler module.
     """
 
+    __hash__ = object.__hash__  # use default hash function
+
+    def __bool__(self):
+        # We return True for all RegisterTensor so that we can use `if inst.output` to check whether the instruction
+        # has an output tensor. We will handle the case of `if tensor:` in the Tilus Script transpiler differently to
+        # avoid ambiguity.
+        return True
+
+    def __neg__(self):
+        """Negate the tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the negation.
+        """
+        raise RuntimeError(" -tensor could only be used in Tilus Script.")
+
     def __add__(self, other: RegisterTensor | int | float | Expr) -> RegisterTensor:
         """Perform addition with another tensor or a scalar.
 
@@ -229,6 +247,81 @@ class RegisterTensor(Tensor):
             A new tensor that is the result of the division.
         """
         raise RuntimeError("tensor / tensor could only be used in Tilus Script.")
+
+    def __ge__(self, other):
+        """Greater than or equal to comparison.
+
+        Parameters
+        ----------
+        other: RegisterTensor | int | float | Expr
+            The tensor or scalar to compare with this tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the comparison.
+        """
+        raise RuntimeError("tensor >= tensor could only be used in Tilus Script.")
+
+    def __le__(self, other):
+        """Less than or equal to comparison.
+
+        Parameters
+        ----------
+        other: RegisterTensor | int | float | Expr
+            The tensor or scalar to compare with this tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the comparison.
+        """
+        raise RuntimeError("tensor <= tensor could only be used in Tilus Script.")
+
+    def __gt__(self, other):
+        """Greater than comparison.
+
+        Parameters
+        ----------
+        other: RegisterTensor | int | float | Expr
+            The tensor or scalar to compare with this tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the comparison.
+        """
+        raise RuntimeError("tensor > tensor could only be used in Tilus Script.")
+
+    def __lt__(self, other):
+        """Less than comparison.
+
+        Parameters
+        ----------
+        other: RegisterTensor | int | float | Expr
+            The tensor or scalar to compare with this tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the comparison.
+        """
+        raise RuntimeError("tensor < tensor could only be used in Tilus Script.")
+
+    def __eq__(self, other):
+        """Equal to comparison.
+
+        Parameters
+        ----------
+        other: RegisterTensor | int | float | Expr
+            The tensor or scalar to compare with this tensor.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A new tensor that is the result of the comparison.
+        """
+        raise RuntimeError("tensor == tensor could only be used in Tilus Script.")
 
     def squeeze(self, dim: int | Sequence[int]) -> RegisterTensor:
         """Squeeze the tensor by removing dimensions of size 1.

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -1028,6 +1028,32 @@ class Script:
         """
         return self._builder.exp2(x, out=out)
 
+    def log(
+        self,
+        x: RegisterTensor,
+        *,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Compute the natural logarithm of each element.
+
+        This instruction computes the natural logarithm of each element in the register tensor `x`. The result is a
+        new register tensor with the same dtype, shape, and layout as `x`.
+
+        Parameters
+        ----------
+        x: RegisterTensor
+            The register tensor to compute the natural logarithm of.
+        out: RegisterTensor, optional
+            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            The register tensor containing the natural logarithm values of the elements in `x`. The shape and dtype of the
+            output tensor will be the same as that of `x`.
+        """
+        return self._builder.log(x, out=out)
+
     def round(
         self,
         x: RegisterTensor,


### PR DESCRIPTION
This PR adds `fused_gdn_gating` kernel in flash linear attention.

To support this kernel:
1. support to use >, <, >=, <= in Tilus Script.
2. support unary negative operator - in Tilus Script.
3. add `Script.log` operator.
