### PR TITLE
[Example] Add the fused kernel for decoding of flash linear attention

### DIFF
--- a/examples/flash_attention_decode/main.py
+++ b/examples/flash_attention_decode/main.py
@@ -4,14 +4,17 @@ from tilus.utils import benchmark_func
 from tilus_kernel import (
     fused_gdn_gating_tilus,
     fused_recurrent_gated_delta_rule_update_fwd_tilus,
+    sigmoid_gating_delta_rule_update_tilus,
 )
 from torch_kernel import (
     fused_gdn_gating_torch,
     fused_recurrent_gated_delta_rule_update_fwd_torch,
+    sigmoid_gating_delta_rule_update_torch,
 )
 from triton_kernel import (
     fused_gdn_gating,
     fused_recurrent_gated_delta_rule_update_fwd_triton,
+    sigmoid_gating_delta_rule_update_triton,
 )
 
 
@@ -161,6 +164,98 @@ def main_fused_recurrent_gated_delta_rule_update_fwd():
         print()
 
 
+def main_sigmoid_gating_delta_rule_update():
+    """Test and benchmark sigmoid gating delta rule update implementations."""
+    headers = ["name", "(B, T, H, K)", "(HV, V)", "latency (ms)"]
+    rows = []
+
+    for B, T, H, K, HV, V in [
+        [1, 1, 4, 128, 8, 128],
+        [1, 2, 4, 128, 8, 128],
+        [1, 4, 4, 128, 8, 128],
+        [1, 8, 4, 128, 8, 128],
+        [1, 16, 4, 128, 8, 128],
+        [1, 32, 4, 128, 8, 128],
+    ]:
+        # Create test inputs for sigmoid gating delta rule update
+        A_log = torch.randn(HV, device="cuda", dtype=torch.float32) * 0.1
+        a = torch.randn(T, HV, device="cuda", dtype=torch.bfloat16)
+        dt_bias = torch.randn(HV, device="cuda", dtype=torch.float32) * 0.1
+        softplus_beta = 1.0
+        softplus_threshold = 20.0
+
+        q = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(B, T, H, K, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(B, T, HV, V, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(
+            T, HV, device="cuda", dtype=torch.bfloat16
+        )  # Will be sigmoid'd to get beta
+        scale = K**-0.5
+        initial_state_source = (
+            torch.randn(129, HV, K, V, device="cuda", dtype=torch.float32) * 0.1
+        )
+        initial_state_indices = 126 - torch.arange(T, device="cuda", dtype=torch.int32)
+        cu_seqlens = torch.arange(T + 1, device="cuda", dtype=torch.int32)
+
+        arguments = {
+            "A_log": A_log,
+            "a": a,
+            "dt_bias": dt_bias,
+            "softplus_beta": softplus_beta,
+            "softplus_threshold": softplus_threshold,
+            "q": q,
+            "k": k,
+            "v": v,
+            "b": b,
+            "scale": scale,
+            "initial_state_source": initial_state_source,
+            "initial_state_indices": initial_state_indices,
+            "use_qk_l2norm_in_kernel": True,
+        }
+
+        # Clone arguments for each implementation
+        torch_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        triton_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        tilus_arguments = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in arguments.items()
+        }
+        triton_arguments["cu_seqlens"] = cu_seqlens
+
+        # Test correctness
+        torch_output = sigmoid_gating_delta_rule_update_torch(**torch_arguments)
+        triton_output = sigmoid_gating_delta_rule_update_triton(**triton_arguments)
+        tilus_output = sigmoid_gating_delta_rule_update_tilus(**tilus_arguments)
+
+        # Verify outputs match
+        torch.testing.assert_close(triton_output, torch_output, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(tilus_output, torch_output, atol=1e-3, rtol=1e-3)
+        print(
+            f"✓ Correctness test passed for batch={B}, T={T}, H={H}, K={K}, HV={HV}, V={V}"
+        )
+
+        # Benchmark implementations
+        for name, func, args in [
+            ["torch", sigmoid_gating_delta_rule_update_torch, torch_arguments],
+            ["triton", sigmoid_gating_delta_rule_update_triton, triton_arguments],
+            ["tilus", sigmoid_gating_delta_rule_update_tilus, tilus_arguments],
+        ]:
+            latency = benchmark_func(lambda: func(**args), warmup=10, repeat=50)
+            rows.append([name, f"({B}, {T}, {H}, {K})", f"({HV}, {V})", f"{latency:.3f}"])
+
+    # Print benchmark results
+    df = pd.DataFrame(rows, columns=headers)
+    print("\nSigmoid Gating Delta Rule Update Benchmark Results:")
+    print(df)
+    print()
+
+
 def main():
     """Run all tests and benchmarks."""
     print("Running Fused GDN Gating tests and benchmarks...")
@@ -168,6 +263,9 @@ def main():
 
     print("Running Fused Recurrent Gated Delta Rule Update tests and benchmarks...")
     main_fused_recurrent_gated_delta_rule_update_fwd()
+
+    print("Running Sigmoid Gating Delta Rule Update tests and benchmarks...")
+    main_sigmoid_gating_delta_rule_update()
 
 
 if __name__ == "__main__":

--- a/examples/flash_attention_decode/tilus_kernel.py
+++ b/examples/flash_attention_decode/tilus_kernel.py
@@ -275,3 +275,237 @@ def fused_gdn_gating_tilus(
     )
 
     return g
+
+
+@tilus.autotune("num_warps", [1, 2, 4])
+@tilus.autotune("BV", [2, 4, 8, 16, 32, 64, 128])
+class FusedSigmoidGatingDeltaRuleUpdateKernel(tilus.Script):
+    def __init__(self, num_warps: int, BV: int):
+        super().__init__()
+        self.num_warps = num_warps
+        self.BV = BV
+
+    def __call__(
+        self,
+        A_log_ptr: ~float32,
+        a_ptr: ~bfloat16,
+        dt_bias_ptr: ~float32,
+        softplus_beta: float,
+        softplus_threshold: float,
+        q_ptr: ~bfloat16,
+        k_ptr: ~bfloat16,
+        v_ptr: ~bfloat16,
+        b_ptr: ~bfloat16,
+        o_ptr: ~bfloat16,
+        scale: float,
+        initial_state_source_ptr: ~float32,
+        initial_state_indices_ptr: ~int32,
+        T: int32,
+        B: int,
+        H: int,
+        HV: int,
+        K: int,
+        V: int,
+        MAX_T: int,
+        USE_INITIAL_STATE: bool,
+        USE_QK_L2NORM_IN_KERNEL: bool,
+    ):
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (T, cdiv(V, self.BV), HV)
+
+        # Create global views
+        g_A_log = self.global_view(A_log_ptr, dtype=float32, shape=[HV])
+        g_a = self.global_view(a_ptr, dtype=bfloat16, shape=[T, HV])
+        g_dt_bias = self.global_view(dt_bias_ptr, dtype=float32, shape=[HV])
+        g_q = self.global_view(q_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_k = self.global_view(k_ptr, dtype=bfloat16, shape=[B, T, H, K])
+        g_v = self.global_view(v_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        g_b = self.global_view(b_ptr, dtype=bfloat16, shape=[T, HV])
+        g_o = self.global_view(o_ptr, dtype=bfloat16, shape=[B, T, HV, V])
+        initial_state_source = self.global_view(
+            initial_state_source_ptr, dtype=float32, shape=[MAX_T, HV, K, V]
+        )
+        initial_state_indices = self.global_view(
+            initial_state_indices_ptr, dtype=int32, shape=[T]
+        )
+
+        i_t, i_bv, i_hv = self.blockIdx
+        i_h = i_hv // (HV // H)
+
+        # Load query and key for this timestep and head
+        r_q = self.load_global(g_q, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+        r_k = self.load_global(g_k, offsets=[0, i_t, i_h, 0], shape=[K], dims=[3]).to(
+            float32
+        )
+
+        # Apply L2 normalization if enabled
+        if USE_QK_L2NORM_IN_KERNEL:
+            r_q = r_q / self.sqrt(self.sum(r_q * r_q, dim=0))
+            r_k = r_k / self.sqrt(self.sum(r_k * r_k, dim=0))
+
+        # Scale query
+        r_q = r_q * scale
+
+        # Load gating computation inputs
+        r_A_log = self.load_global(g_A_log, offsets=[i_hv], shape=[1], dims=[0]).to(
+            float32
+        )
+        r_a = self.load_global(g_a, offsets=[i_t, i_hv], shape=[1], dims=[0]).to(float32)
+        r_dt_bias = self.load_global(g_dt_bias, offsets=[i_hv], shape=[1], dims=[0]).to(
+            float32
+        )
+
+        # Compute gating: g = -exp(A_log) * softplus(a + dt_bias)
+        r_x = r_a + r_dt_bias
+        r_beta_x = r_x * softplus_beta
+
+        # Apply softplus with numerical stability
+        r_exp_beta_x = self.exp(r_beta_x)
+        r_log_term = self.log(r_exp_beta_x + 1.0)
+        r_softplus = self.where(
+            r_x >= softplus_threshold, r_x, r_log_term * (1.0 / softplus_beta)
+        )
+
+        # Compute gating value
+        r_g = -self.exp(r_A_log) * r_softplus
+
+        # Load b and compute beta = sigmoid(b)
+        r_b = self.load_global(g_b, offsets=[i_t, i_hv], shape=[1], dims=[0]).to(float32)
+        r_beta = 1.0 / (1.0 + self.exp(-r_b))  # sigmoid
+
+        # Load initial state
+        if USE_INITIAL_STATE:
+            state_idx: int32 = initial_state_indices[i_t]
+            r_h = self.load_global(
+                initial_state_source,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                shape=[K, self.BV],
+                dims=[2, 3],
+            )
+        else:
+            state_idx: int32 = -1
+            r_h = self.register_tensor(dtype=float32, shape=[K, self.BV], init=0.0)
+
+        # Apply gating to hidden state: H' = alpha * H
+        alpha: float32 = self.exp(r_g)
+        r_h = r_h * alpha
+
+        # Compute prediction: p = k * H
+        r_p = self.sum(self.unsqueeze(r_k, dim=1) * r_h, dim=0)
+
+        # Load value and apply delta rule: r = beta * (v - p)
+        r_v = self.load_global(
+            g_v, offsets=[0, i_t, i_hv, i_bv * self.BV], shape=[self.BV], dims=[3]
+        ).to(float32)
+        r_r = r_beta * (r_v - r_p)
+
+        # Update hidden state: H'' = H' + k * r
+        r_h += self.unsqueeze(r_k, dim=1) * self.unsqueeze(r_r, dim=0)
+
+        # Compute output: o = q * h
+        r_o = self.sum(self.unsqueeze(r_q, dim=1) * r_h, dim=0).to(bfloat16)
+
+        # Store output
+        self.store_global(g_o, r_o, offsets=[0, i_t, i_hv, i_bv * self.BV], dims=[3])
+
+        # Store updated state back
+        if state_idx >= 0:
+            self.store_global(
+                initial_state_source,
+                r_h,
+                offsets=[state_idx, i_hv, 0, i_bv * self.BV],
+                dims=[2, 3],
+            )
+
+        # Annotate layout for optimization
+        self.annotate_layout(
+            r_h,
+            self.cuda.default_register_layout(
+                num_warps=self.num_warps, dtype=float32, shape=[K, self.BV]
+            ),
+        )
+
+
+def sigmoid_gating_delta_rule_update_tilus(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float,
+    softplus_threshold: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    b: torch.Tensor,
+    scale: float,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor = None,
+):
+    """
+    Tilus implementation of sigmoid gating delta rule update using a single fused kernel.
+
+    This function uses a single kernel that combines both sigmoid gating computation
+    and the fused recurrent gated delta rule update for better performance.
+
+    Args:
+        A_log: Log of A parameter for gating computation
+        a: Input tensor for gating computation
+        dt_bias: Bias parameter for gating computation
+        softplus_beta: Beta parameter for softplus in gating
+        softplus_threshold: Threshold for numerical stability in softplus
+        q: Query tensor
+        k: Key tensor
+        v: Value tensor
+        b: Tensor to apply sigmoid to get beta
+        scale: Scaling factor for queries
+        initial_state_source: Initial hidden states
+        initial_state_indices: Indices for initial states
+        use_qk_l2norm_in_kernel: Whether to apply L2 normalization to q and k
+        cu_seqlens: Cumulative sequence lengths (optional, for variable length)
+
+    Returns:
+        o: Output tensor from the delta rule update
+    """
+    _ = cu_seqlens  # Not used in current implementation
+
+    # Get dimensions
+    B, T, H, K = q.shape
+    HV, V = v.shape[-2:]
+    MAX_T = initial_state_source.shape[0]
+
+    # Create output tensor
+    o = torch.empty_like(v)
+
+    USE_INITIAL_STATE = True
+    USE_QK_L2NORM_IN_KERNEL = use_qk_l2norm_in_kernel
+
+    # Run the fused kernel
+    FusedSigmoidGatingDeltaRuleUpdateKernel()(
+        A_log,
+        a,
+        dt_bias,
+        softplus_beta,
+        softplus_threshold,
+        q,
+        k,
+        v,
+        b,
+        o,
+        scale,
+        initial_state_source,
+        initial_state_indices,
+        T,
+        B,
+        H,
+        HV,
+        K,
+        V,
+        MAX_T,
+        USE_INITIAL_STATE,
+        USE_QK_L2NORM_IN_KERNEL,
+    )
+
+    return o


### PR DESCRIPTION
This PR adds the example of fused kernel for flash linear attention:

```
Sigmoid Gating Delta Rule Update Benchmark Results:
      name     (B, T, H, K)   (HV, V) latency (ms)
0    torch   (1, 1, 4, 128)  (8, 128)        1.164
1   triton   (1, 1, 4, 128)  (8, 128)        0.010
2    tilus   (1, 1, 4, 128)  (8, 128)        0.006
3    torch   (1, 2, 4, 128)  (8, 128)        2.270
4   triton   (1, 2, 4, 128)  (8, 128)        0.011
5    tilus   (1, 2, 4, 128)  (8, 128)        0.007
6    torch   (1, 4, 4, 128)  (8, 128)        4.475
7   triton   (1, 4, 4, 128)  (8, 128)        0.013
8    tilus   (1, 4, 4, 128)  (8, 128)        0.009
9    torch   (1, 8, 4, 128)  (8, 128)        8.848
10  triton   (1, 8, 4, 128)  (8, 128)        0.018
11   tilus   (1, 8, 4, 128)  (8, 128)        0.013
12   torch  (1, 16, 4, 128)  (8, 128)       17.589
13  triton  (1, 16, 4, 128)  (8, 128)        0.029
14   tilus  (1, 16, 4, 128)  (8, 128)        0.022
15   torch  (1, 32, 4, 128)  (8, 128)       35.413
16  triton  (1, 32, 4, 128)  (8, 128)        0.051
17   tilus  (1, 32, 4, 128)  (8, 128)        0.044
```