### PR TITLE
[IR][Script] Allow specify cluster dimensions through `cluster_blocks`

### DIFF
--- a/python/tilus/backends/codegen.py
+++ b/python/tilus/backends/codegen.py
@@ -447,8 +447,10 @@ class Codegen(IRFunctor):
             name=func.name + "_kernel",
             kind="cuda_kernel" if is_nvgpu() else "hip_kernel",
             label="",
-            grid_dim=self._function.metadata.num_blocks,
-            cluster_dim=self._function.metadata.num_blocks_per_cluster,
+            grid_dim=self._function.metadata.grid_blocks,
+            cluster_dim=self._function.metadata.cluster_blocks
+            if self._function.metadata.cluster_blocks != (1, 1, 1)
+            else None,
             block_dim=func.metadata.num_warps * 32,
             dynamic_smem_bytes=None,
             min_blocks=None,

--- a/python/tilus/backends/codegen.py
+++ b/python/tilus/backends/codegen.py
@@ -448,6 +448,7 @@ class Codegen(IRFunctor):
             kind="cuda_kernel" if is_nvgpu() else "hip_kernel",
             label="",
             grid_dim=self._function.metadata.num_blocks,
+            cluster_dim=self._function.metadata.num_blocks_per_cluster,
             block_dim=func.metadata.num_warps * 32,
             dynamic_smem_bytes=None,
             min_blocks=None,

--- a/python/tilus/extensions/hidet/transforms/hoist_loop_invariants.py
+++ b/python/tilus/extensions/hidet/transforms/hoist_loop_invariants.py
@@ -211,8 +211,10 @@ class HoistLoopInvariantsRewriter(IRRewriter):
             return stmt
         else:
             sb = StmtBuilder()
-            bind_vars = [hash2var[h] for h in hashes]
-            bind_values = [hash2value[h] for h in hashes]
+            bind_vars, bind_values = [], []
+            for var, value in hash2var.items():
+                bind_vars.append(value)
+                bind_values.append(hash2value[var])
             with sb.lets(bind_vars, bind_values):
                 with sb.for_loop(stmt.loop_var, stmt.extent, str(stmt.attr)):
                     sb += body

--- a/python/tilus/ir/analyzers/scalar_analyzer.py
+++ b/python/tilus/ir/analyzers/scalar_analyzer.py
@@ -436,8 +436,8 @@ def analyze_scalar(func: Function) -> Function:
 
     # update the scalar set of built-in variables
     for i, var in enumerate(metadata.block_indices):  # type: ignore
-        if isinstance(metadata.num_blocks[i], Constant):
-            var2set[var] = ScalarSet(lower_bound=0, upper_bound=int(metadata.num_blocks[i]) - 1)
+        if isinstance(metadata.grid_blocks[i], Constant):
+            var2set[var] = ScalarSet(lower_bound=0, upper_bound=int(metadata.grid_blocks[i]) - 1)
         else:
             var2set[var] = ScalarSet(lower_bound=0)
 

--- a/python/tilus/ir/func.py
+++ b/python/tilus/ir/func.py
@@ -45,6 +45,7 @@ class Analysis:
 @dataclass(frozen=True)
 class Metadata:
     num_blocks: tuple[Expr, Expr, Expr]
+    num_blocks_per_cluster: tuple[int, int, int]
     block_indices: tuple[Var, Var, Var]
     num_warps: int
     param2divisibility: frozendict[Var, int]
@@ -53,15 +54,17 @@ class Metadata:
     @staticmethod
     def create(
         num_blocks: Sequence[Expr],
+        num_blocks_per_cluster: Sequence[int],
         block_indices: Sequence[Var],
         num_warps: int,
         divisibility: Optional[Mapping[Var, int]] = None,
         analysis: Optional[Analysis] = None,
     ) -> Metadata:
-        assert len(num_blocks) == 3 and len(block_indices) == 3
+        assert len(num_blocks) == 3 and len(block_indices) == 3 and len(num_blocks_per_cluster) == 3
 
         return Metadata(
             num_blocks=(num_blocks[0], num_blocks[1], num_blocks[2]),
+            num_blocks_per_cluster=(num_blocks_per_cluster[0], num_blocks_per_cluster[1], num_blocks_per_cluster[2]),
             block_indices=(block_indices[0], block_indices[1], block_indices[2]),
             num_warps=num_warps,
             param2divisibility=frozendict(divisibility) if divisibility else frozendict(),

--- a/python/tilus/ir/func.py
+++ b/python/tilus/ir/func.py
@@ -44,8 +44,8 @@ class Analysis:
 
 @dataclass(frozen=True)
 class Metadata:
-    num_blocks: tuple[Expr, Expr, Expr]
-    num_blocks_per_cluster: tuple[int, int, int]
+    grid_blocks: tuple[Expr, Expr, Expr]
+    cluster_blocks: tuple[int, int, int]
     block_indices: tuple[Var, Var, Var]
     num_warps: int
     param2divisibility: frozendict[Var, int]
@@ -53,18 +53,18 @@ class Metadata:
 
     @staticmethod
     def create(
-        num_blocks: Sequence[Expr],
-        num_blocks_per_cluster: Sequence[int],
+        grid_blocks: Sequence[Expr],
+        cluster_blocks: Sequence[int],
         block_indices: Sequence[Var],
         num_warps: int,
         divisibility: Optional[Mapping[Var, int]] = None,
         analysis: Optional[Analysis] = None,
     ) -> Metadata:
-        assert len(num_blocks) == 3 and len(block_indices) == 3 and len(num_blocks_per_cluster) == 3
+        assert len(grid_blocks) == 3 and len(block_indices) == 3 and len(cluster_blocks) == 3
 
         return Metadata(
-            num_blocks=(num_blocks[0], num_blocks[1], num_blocks[2]),
-            num_blocks_per_cluster=(num_blocks_per_cluster[0], num_blocks_per_cluster[1], num_blocks_per_cluster[2]),
+            grid_blocks=(grid_blocks[0], grid_blocks[1], grid_blocks[2]),
+            cluster_blocks=(cluster_blocks[0], cluster_blocks[1], cluster_blocks[2]),
             block_indices=(block_indices[0], block_indices[1], block_indices[2]),
             num_warps=num_warps,
             param2divisibility=frozendict(divisibility) if divisibility else frozendict(),
@@ -74,8 +74,8 @@ class Metadata:
     def with_analysis(self, analysis: Optional[Analysis]) -> Metadata:
         return dataclasses.replace(self, analysis=analysis)
 
-    def with_num_blocks(self, num_blocks: tuple[Expr, Expr, Expr]) -> Metadata:
-        return dataclasses.replace(self, num_blocks=num_blocks)
+    def with_num_blocks(self, grid_blocks: tuple[Expr, Expr, Expr]) -> Metadata:
+        return dataclasses.replace(self, grid_blocks=grid_blocks)
 
 
 @dataclass(frozen=True, eq=False)

--- a/python/tilus/ir/tools/printer.py
+++ b/python/tilus/ir/tools/printer.py
@@ -176,8 +176,8 @@ class IRPrinter(IRFunctor):
 
     def visit_FuncMetadata(self, metadata: Metadata) -> Doc:
         doc = Doc()
-        doc += NewLine() + "num_blocks = [" + self.visit(metadata.grid_blocks) + "]"
-        doc += NewLine() + "num_blocks_per_cluster = [" + self.visit(metadata.cluster_blocks) + "]"
+        doc += NewLine() + "grid_blocks = [" + self.visit(metadata.grid_blocks) + "]"
+        doc += NewLine() + "cluster_blocks= [" + self.visit(metadata.cluster_blocks) + "]"
         doc += NewLine() + "num_warps = " + self.visit(metadata.num_warps)
         if metadata.param2divisibility:
             doc += NewLine() + "param_divisibility = {" + self.visit(metadata.param2divisibility) + "}"

--- a/python/tilus/ir/tools/printer.py
+++ b/python/tilus/ir/tools/printer.py
@@ -176,8 +176,8 @@ class IRPrinter(IRFunctor):
 
     def visit_FuncMetadata(self, metadata: Metadata) -> Doc:
         doc = Doc()
-        doc += NewLine() + "num_blocks = [" + self.visit(metadata.num_blocks) + "]"
-        doc += NewLine() + "num_blocks_per_cluster = [" + self.visit(metadata.num_blocks_per_cluster) + "]"
+        doc += NewLine() + "num_blocks = [" + self.visit(metadata.grid_blocks) + "]"
+        doc += NewLine() + "num_blocks_per_cluster = [" + self.visit(metadata.cluster_blocks) + "]"
         doc += NewLine() + "num_warps = " + self.visit(metadata.num_warps)
         if metadata.param2divisibility:
             doc += NewLine() + "param_divisibility = {" + self.visit(metadata.param2divisibility) + "}"

--- a/python/tilus/ir/tools/printer.py
+++ b/python/tilus/ir/tools/printer.py
@@ -177,6 +177,7 @@ class IRPrinter(IRFunctor):
     def visit_FuncMetadata(self, metadata: Metadata) -> Doc:
         doc = Doc()
         doc += NewLine() + "num_blocks = [" + self.visit(metadata.num_blocks) + "]"
+        doc += NewLine() + "num_blocks_per_cluster = [" + self.visit(metadata.num_blocks_per_cluster) + "]"
         doc += NewLine() + "num_warps = " + self.visit(metadata.num_warps)
         if metadata.param2divisibility:
             doc += NewLine() + "param_divisibility = {" + self.visit(metadata.param2divisibility) + "}"

--- a/python/tilus/ir/utils/normalize.py
+++ b/python/tilus/ir/utils/normalize.py
@@ -1,0 +1,64 @@
+from typing import Sequence
+
+from hidet.ir.dtypes import int32
+from hidet.ir.expr import Expr
+from hidet.ir.tools.simplifier import simplify, simplify_to_int
+
+
+def normalize_grid_blocks(blocks: Expr | int | Sequence[Expr | int]) -> tuple[Expr, Expr, Expr]:
+    """Normalize grid blocks to a tuple of three expressions.
+
+    Parameters
+    ----------
+    blocks: Expr | int | Sequence[Expr | int]
+        The number of blocks in the grid. It can be an integer, an expression, or a list/tuple of integers or
+        expressions. If it is an integer or expression, it represents the number of blocks in the x dimension, and the
+        y and z dimensions are set to 1. If it is a list or tuple, it should have a length of 1, 2, or 3. If the length
+        is less than 3, the missing dimensions are set to 1.
+
+    Returns
+    -------
+    ret: tuple[Expr, Expr, Expr]
+        The normalized number of blocks in the x, y, and z dimensions.
+    """
+    if isinstance(blocks, (Expr, int)):
+        blocks_x: Expr = simplify(blocks)
+        return blocks_x, int32.one, int32.one
+    elif isinstance(blocks, (list, tuple)):
+        blocks_expr = [simplify(b) for b in blocks]
+        while len(blocks_expr) < 3:
+            blocks_expr.append(int32.one)
+        if len(blocks_expr) > 3:
+            raise ValueError("The length of blocks_per_cluster should not be greater than 3.")
+        return blocks_expr[0], blocks_expr[1], blocks_expr[2]
+    else:
+        raise ValueError("The type of blocks_per_cluster should be int, Expr, list or tuple.")
+
+
+def normalize_cluster_blocks(blocks: Expr | int | Sequence[Expr | int]) -> tuple[int, int, int]:
+    """Normalize cluster blocks to a tuple of three integers.
+
+    Parameters
+    ----------
+    blocks: int or Expr or list or tuple
+        The number of blocks per cluster. It can be an integer, an expression, or a list/tuple of integers or
+        expressions. If it is an integer or expression, it represents the number of blocks in the x dimension, and the
+        y and z dimensions are set to 1. If it is a list or tuple, it should have a length of 1, 2, or 3. If the length
+        is less than 3, the missing dimensions are set to 1.
+
+    Returns
+    -------
+    ret: tuple[int, int, int]
+        The normalized number of blocks per cluster in the x, y, and z dimensions.
+    """
+    if isinstance(blocks, (Expr, int)):
+        return simplify_to_int(blocks), 1, 1
+    elif isinstance(blocks, (list, tuple)):
+        blocks_int = [simplify_to_int(b) for b in blocks]
+        while len(blocks_int) < 3:
+            blocks_int.append(1)
+        if len(blocks_int) > 3:
+            raise ValueError("The length of blocks_per_cluster should not be greater than 3.")
+        return blocks_int[0], blocks_int[1], blocks_int[2]
+    else:
+        raise ValueError("The type of blocks_per_cluster should be int, Expr, list or tuple.")

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -36,7 +36,7 @@ class Attributes:
     """Attributes of the script program."""
 
     _blocks: Optional[Sequence[Expr | int] | Expr | int] = None
-    _blocks_per_cluster: Optional[Sequence[Expr | int] | int] = (1, 1, 1)
+    _cluster_blocks: Optional[Sequence[Expr | int] | int] = (1, 1, 1)
     _warps: Optional[int] = None
 
     @property
@@ -51,16 +51,18 @@ class Attributes:
         self._blocks = value
 
     @property
-    def blocks_per_cluster(self) -> Sequence[Expr | int] | int | None:
+    def cluster_blocks(self) -> Sequence[Expr | int] | int | None:
         """The number of blocks per cluster."""
-        return self._blocks_per_cluster
+        return self._cluster_blocks
 
-    @blocks_per_cluster.setter
-    def blocks_per_cluster(self, value: Sequence[Expr | int] | int) -> Optional[Sequence[Expr | int] | int]:
+    @cluster_blocks.setter
+    def cluster_blocks(self, value: Sequence[Expr | int] | int) -> None:
         """The number of blocks per cluster."""
-        if not isinstance(value, (int, Constant)) and not (isinstance(value, Sequence) and all(isinstance(v, (int, Constant)) for v in value)):
+        if not isinstance(value, (int, Constant)) and not (
+            isinstance(value, Sequence) and all(isinstance(v, (int, Constant)) for v in value)
+        ):
             raise ValueError("The number of blocks per cluster must be an integer or a sequence of integers")
-        self._blocks_per_cluster = value
+        self._cluster_blocks = value
 
     @property
     def warps(self) -> Optional[int]:

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -36,6 +36,7 @@ class Attributes:
     """Attributes of the script program."""
 
     _blocks: Optional[Sequence[Expr | int] | Expr | int] = None
+    _blocks_per_cluster: Optional[Sequence[Expr | int] | int] = (1, 1, 1)
     _warps: Optional[int] = None
 
     @property
@@ -45,7 +46,21 @@ class Attributes:
 
     @blocks.setter
     def blocks(self, value: Sequence[Expr | int] | Expr | int) -> None:
+        if not (isinstance(value, Sequence) and len(value) in [1, 2, 3]) and not isinstance(value, (int, Expr)):
+            raise ValueError("Expect 1d/2d/3d number of blocks, got {}".format(value))
         self._blocks = value
+
+    @property
+    def blocks_per_cluster(self) -> Sequence[Expr | int] | int | None:
+        """The number of blocks per cluster."""
+        return self._blocks_per_cluster
+
+    @blocks_per_cluster.setter
+    def blocks_per_cluster(self, value: Sequence[Expr | int] | int) -> Optional[Sequence[Expr | int] | int]:
+        """The number of blocks per cluster."""
+        if not isinstance(value, (int, Constant)) and not (isinstance(value, Sequence) and all(isinstance(v, (int, Constant)) for v in value)):
+            raise ValueError("The number of blocks per cluster must be an integer or a sequence of integers")
+        self._blocks_per_cluster = value
 
     @property
     def warps(self) -> Optional[int]:

--- a/python/tilus/lang/transpiler.py
+++ b/python/tilus/lang/transpiler.py
@@ -54,6 +54,7 @@ from tilus.ir.stmt import (
 from tilus.ir.tensor import GlobalTensor, Tensor
 from tilus.lang.constructs.loops import TilusLoopIterable
 from tilus.lang.script import InstructionError, Script
+from tilus.lang.utils import normalize_blocks_per_cluster
 from tilus.utils import lcm
 
 
@@ -439,14 +440,12 @@ class Transpiler(PythonAstFunctor):
                 )
                 raise TilusProgramError(self, func_def, msg)
             blocks = [as_expr(dim) for dim in normalize_launch_dims(attrs.blocks)]
-            attrs.blocks = None
-
+            blocks_per_cluster = normalize_blocks_per_cluster(attrs.blocks_per_cluster)
             if attrs.warps is None:
                 raise TilusProgramError(
                     self, func_def, "Tilus script should set the number of warps via self.warps = ..."
                 )
             warps = attrs.warps
-            attrs.warps = None
 
             return Function.create(
                 name=func_def.name,
@@ -454,6 +453,7 @@ class Transpiler(PythonAstFunctor):
                 body=scope.flush_stmts(),
                 metadata=Metadata.create(
                     num_blocks=blocks,
+                    num_blocks_per_cluster=blocks_per_cluster,
                     block_indices=[blockIdx.x, blockIdx.y, blockIdx.z],  # type: ignore
                     num_warps=warps,
                     divisibility=divisibility,

--- a/python/tilus/lang/utils.py
+++ b/python/tilus/lang/utils.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Callable, Sequence, TypeVar
-from hidet.ir.expr import Expr
-from hidet.ir.tools import simplify_to_int
 
 ArgType = TypeVar("ArgType")
 ReturnType = TypeVar("ReturnType")
@@ -25,18 +23,3 @@ def group_function_argument(f: Callable[..., ReturnType]) -> Callable[[Sequence[
         return f(*args)
 
     return wrapped
-
-def normalize_blocks_per_cluster(blocks_per_cluster) -> tuple[int, int, int]:
-    if isinstance(blocks_per_cluster, (Expr, int)):
-        blocks_per_cluster = simplify_to_int(blocks_per_cluster)
-        return blocks_per_cluster, 1, 1
-    elif isinstance(blocks_per_cluster, (list, tuple)):
-        blocks_per_cluster = [simplify_to_int(b) for b in blocks_per_cluster]
-        while len(blocks_per_cluster) < 3:
-            blocks_per_cluster.append(1)
-        if len(blocks_per_cluster) > 3:
-            raise ValueError("The length of blocks_per_cluster should not be greater than 3.")
-        return tuple(blocks_per_cluster)  # type: ignore
-    else:
-        raise ValueError("The type of blocks_per_cluster should be int, Expr, list or tuple.")
-

--- a/python/tilus/lang/utils.py
+++ b/python/tilus/lang/utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Callable, Sequence, TypeVar
+from hidet.ir.expr import Expr
+from hidet.ir.tools import simplify_to_int
 
 ArgType = TypeVar("ArgType")
 ReturnType = TypeVar("ReturnType")
@@ -23,3 +25,18 @@ def group_function_argument(f: Callable[..., ReturnType]) -> Callable[[Sequence[
         return f(*args)
 
     return wrapped
+
+def normalize_blocks_per_cluster(blocks_per_cluster) -> tuple[int, int, int]:
+    if isinstance(blocks_per_cluster, (Expr, int)):
+        blocks_per_cluster = simplify_to_int(blocks_per_cluster)
+        return blocks_per_cluster, 1, 1
+    elif isinstance(blocks_per_cluster, (list, tuple)):
+        blocks_per_cluster = [simplify_to_int(b) for b in blocks_per_cluster]
+        while len(blocks_per_cluster) < 3:
+            blocks_per_cluster.append(1)
+        if len(blocks_per_cluster) > 3:
+            raise ValueError("The length of blocks_per_cluster should not be greater than 3.")
+        return tuple(blocks_per_cluster)  # type: ignore
+    else:
+        raise ValueError("The type of blocks_per_cluster should be int, Expr, list or tuple.")
+

--- a/python/tilus/transforms/lower_param_only_expr.py
+++ b/python/tilus/transforms/lower_param_only_expr.py
@@ -80,13 +80,13 @@ class LowerParamOnlyExprRewriter(IRRewriter):
     def visit_Function(self, func: Function) -> Function:
         self.params = func.params
         body = self.visit(func.body)
-        num_blocks = func.metadata.num_blocks
+        num_blocks = func.metadata.grid_blocks
         num_blocks = (
             self.lower_param_only_param(num_blocks[0]),
             self.lower_param_only_param(num_blocks[1]),
             self.lower_param_only_param(num_blocks[2]),
         )
-        if body is func.body and all(e is t for e, t in zip(func.metadata.num_blocks, num_blocks)):
+        if body is func.body and all(e is t for e, t in zip(func.metadata.grid_blocks, num_blocks)):
             return func
         else:
             return func.with_metadata(func.metadata.with_num_blocks(num_blocks)).with_body(body)

--- a/tests/lang/test_blocks_per_cluster.py
+++ b/tests/lang/test_blocks_per_cluster.py
@@ -1,0 +1,16 @@
+import tilus
+from tilus.target import nvgpu_sm90
+from tilus.testing.requires import requires
+
+class DemoBlockCluster(tilus.Script):
+    def __call__(self):
+        self.attrs.blocks = [4, 8, 2]
+        self.attrs.blocks_per_cluster = [2, 2, 1]
+        self.attrs.warps = 4
+
+        self.printf("blockIdx: [%d, %d, %d]\n", self.blockIdx.x, self.blockIdx.y, self.blockIdx.z)
+
+@requires(nvgpu_sm90)
+def test_script_blocks_per_cluster():
+    kernel = DemoBlockCluster()
+    kernel()

--- a/tests/lang/test_blocks_per_cluster.py
+++ b/tests/lang/test_blocks_per_cluster.py
@@ -1,16 +1,28 @@
 import tilus
-from tilus.target import nvgpu_sm90
+from tilus.target import nvgpu_sm80, nvgpu_sm90
 from tilus.testing.requires import requires
 
+
 class DemoBlockCluster(tilus.Script):
+    def __init__(self, cluster_blocks):
+        super().__init__()
+        self.cluster_blocks = cluster_blocks
+
     def __call__(self):
-        self.attrs.blocks = [4, 8, 2]
-        self.attrs.blocks_per_cluster = [2, 2, 1]
+        self.attrs.blocks = [2, 2, 2]
+        self.attrs.cluster_blocks = self.cluster_blocks
         self.attrs.warps = 4
 
         self.printf("blockIdx: [%d, %d, %d]\n", self.blockIdx.x, self.blockIdx.y, self.blockIdx.z)
 
+
 @requires(nvgpu_sm90)
-def test_script_blocks_per_cluster():
-    kernel = DemoBlockCluster()
+def test_script_blocks_per_cluster_post_sm90():
+    kernel = DemoBlockCluster((2, 2, 1))
+    kernel()
+
+
+@requires(nvgpu_sm80)
+def test_script_blocks_per_cluster_pre_sm90():
+    kernel = DemoBlockCluster((1, 1, 1))
     kernel()


### PR DESCRIPTION
This PR allows Tilus Script to specify the cluster dimensions, a feature occured in Hopper and later GPUs.

```python
class Kernel(tilus.Script):
    def __call__(self):
        self.attrs.blocks = ...
        self.attrs.cluster_blocks = [2, 2, 1]  # must be compilation-time constants
        self.attrs.warps = 4
```