### PR TITLE
[Script] Support thread group in Tilus Script

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Additional features include automatic tuning, caching, and a Pythonic interface 
    programming-guides/type-system/__init__
    programming-guides/instructions
    programming-guides/control-flow
+   programming-guides/thread-group
    programming-guides/cache
    programming-guides/autotuning
    programming-guides/layout-system/__init__

--- a/docs/source/programming-guides/control-flow.rst
+++ b/docs/source/programming-guides/control-flow.rst
@@ -95,3 +95,4 @@ In addition to the control flow statements mentioned above, Tilus Script also su
   When encountered, it will immediately terminate the innermost loop and continue execution after the loop.
 - **continue**: This statement can be used to skip the current iteration of a loop and continue with the next iteration.
   When encountered, it will immediately jump to the next iteration of the innermost loop.
+

--- a/docs/source/programming-guides/thread-group.rst
+++ b/docs/source/programming-guides/thread-group.rst
@@ -1,0 +1,161 @@
+Thread Group
+============
+
+In Tilus Script, you can partition the threads in a thread block into smaller **thread groups** and define instructions that execute only within specific thread groups. This provides fine-grained control over thread execution and enables efficient parallel programming patterns.
+
+Overview
+--------
+
+At the root level of a kernel, there is one thread group that includes all threads in the thread block. Using the ``thread_group`` context manager, you can:
+
+- Partition threads into multiple sub-groups
+- Execute instructions on specific thread groups only
+- Create nested thread group hierarchies
+- Synchronize threads within a group
+
+The ``thread_group`` Context Manager
+------------------------------------
+
+**Syntax:**
+
+.. code-block:: python
+
+    with self.thread_group(group_index, *, num_groups=None, group_size=None):
+        # Instructions executed by threads in the specified thread group
+        ...
+
+**Parameters:**
+
+- ``group_index`` (int): The index of the thread group to create. Must be in range [0, num_groups).
+- ``num_groups`` (int, optional): The number of thread groups to partition the current thread group into.
+- ``group_size`` (int, optional): The number of threads in each thread group.
+
+**Constraints:**
+
+- Either ``num_groups`` or ``group_size`` must be specified (or both).
+- If both are specified, they must satisfy: ``num_groups * group_size == parent_group_size``
+- If only one is specified, the other is automatically inferred.
+
+How Thread Partitioning Works
+------------------------------
+
+Thread groups partition the current thread group based on the relationship:
+
+.. code-block:: text
+
+    num_groups * group_size = parent_group_size
+
+**Examples:**
+
+- If you have 128 threads and specify ``group_size=32``, you get ``num_groups=4``
+- If you have 128 threads and specify ``num_groups=8``, you get ``group_size=16``
+- If you specify both ``num_groups=4`` and ``group_size=32``, they must multiply to 128
+
+Basic Usage Examples
+--------------------
+
+**Example 1: Simple Thread Group Partitioning**
+
+.. code-block:: python
+
+    class MyScript(tilus.Script):
+        def __init__(self):
+            super().__init__()
+            
+        def __call__(self, ...):
+            # Specify 4 warps = 128 threads total
+            self.attrs.warps = 4
+            
+            # All threads execute this
+            data = self.register_tensor(dtype=f32, shape=[16])
+            
+            # Only threads in group 0 execute this block (threads 0-31)
+            with self.thread_group(0, num_groups=4):
+                # Instructions for first quarter of threads
+                result = self.load_global(src, offsets=[0, 0])
+                
+            # Only threads in group 1 execute this block (threads 32-63)
+            with self.thread_group(1, num_groups=4):
+                # Instructions for second quarter of threads
+                result = self.load_global(src, offsets=[16, 0])
+            
+            # All threads execute this again
+            self.sync()
+
+**Example 2: Using Group Size Instead of Number of Groups**
+
+.. code-block:: python
+
+    class MyScript(tilus.Script):
+        def __init__(self):
+            super().__init__()
+            
+        def __call__(self, ...):
+            # Specify 4 warps = 128 threads total
+            self.attrs.warps = 4
+            
+            # Only threads in group 0 execute this (32 threads: 0-31)
+            with self.thread_group(0, group_size=32):
+                # First group of 32 threads processes first chunk
+                data = self.load_global(src, offsets=[0, 0])
+                
+            # Only threads in group 1 execute this (32 threads: 32-63)  
+            with self.thread_group(1, group_size=32):
+                # Second group of 32 threads processes second chunk
+                data = self.load_global(src, offsets=[32, 0])
+
+**Example 3: Nested Thread Groups**
+
+.. code-block:: python
+
+    class MyScript(tilus.Script):
+        def __init__(self):
+            super().__init__()
+            
+        def __call__(self, ...):
+            # Specify 4 warps = 128 threads total
+            self.attrs.warps = 4
+            
+            # First level: split into 4 groups of 32 threads each
+            with self.thread_group(0, num_groups=4):
+                # Only first group (threads 0-31) enters here
+                
+                # Second level: further split into 2 sub-groups of 16 threads each
+                with self.thread_group(0, num_groups=2):
+                    # Only threads 0-15 execute this
+                    fine_grained_work()
+                    
+                with self.thread_group(1, num_groups=2):
+                    # Only threads 16-31 execute this
+                    different_fine_grained_work()
+                
+                # Back to first level - all threads 0-31 execute this
+                self.sync()
+
+Synchronization Within Thread Groups
+------------------------------------
+
+The ``self.sync()`` instruction synchronizes all threads in the **current thread group**, not the entire thread block.
+
+.. code-block:: python
+
+    class MyScript(tilus.Script):
+        def __init__(self):
+            super().__init__()
+            
+        def __call__(self, ...):
+            # Specify 4 warps = 128 threads total
+            self.attrs.warps = 4
+            
+            with self.thread_group(0, num_groups=2):
+                # Some work by first half of threads (threads 0-63)
+                work_part_1()
+                
+                # Synchronize only threads in group 0
+                self.sync()  # Only waits for threads 0-63
+                
+                # Continue with synchronized work
+                work_part_2()
+            
+            # Synchronize all threads in the thread block
+            self.sync()

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -44,6 +44,7 @@ Language Constructs
 
    assume
    range
+   thread_group
 
 
 Instructions

--- a/python/tilus/ir/functors/functor.py
+++ b/python/tilus/ir/functors/functor.py
@@ -27,7 +27,6 @@ from tilus.ir.stmt import (
     BreakStmt,
     DeclareStmt,
     ForStmt,
-    ForThreadGroupStmt,
     IfStmt,
     InstStmt,
     LetStmt,
@@ -36,6 +35,7 @@ from tilus.ir.stmt import (
     Stmt,
     TensorElemPtrStmt,
     TensorElemValueStmt,
+    ThreadGroupStmt,
     WhileStmt,
 )
 from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedLayout, SharedTensor
@@ -90,8 +90,8 @@ class IRFunctor:
             ret = self.visit_SeqStmt(node)
         elif isinstance(node, ForStmt):
             ret = self.visit_ForStmt(node)
-        elif isinstance(node, ForThreadGroupStmt):
-            ret = self.visit_ForThreadGroupStmt(node)
+        elif isinstance(node, ThreadGroupStmt):
+            ret = self.visit_ThreadGroupStmt(node)
         elif isinstance(node, IfStmt):
             ret = self.visit_IfStmt(node)
         elif isinstance(node, WhileStmt):
@@ -184,7 +184,7 @@ class IRFunctor:
     def visit_ForStmt(self, stmt: ForStmt) -> Any:
         raise NotImplementedError()
 
-    def visit_ForThreadGroupStmt(self, stmt: ForThreadGroupStmt) -> Any:
+    def visit_ThreadGroupStmt(self, stmt: ThreadGroupStmt) -> Any:
         raise NotImplementedError()
 
     def visit_IfStmt(self, stmt: IfStmt) -> Any:
@@ -311,12 +311,12 @@ class IRRewriter(IRFunctor):
         else:
             return ForStmt(stmt.iter_var, extent, body, stmt.unroll_factor)
 
-    def visit_ForThreadGroupStmt(self, stmt: ForThreadGroupStmt) -> Stmt:
+    def visit_ThreadGroupStmt(self, stmt: ThreadGroupStmt) -> Stmt:
         body = self.visit(stmt.body)
         if body is stmt.body:
             return stmt
         else:
-            return ForThreadGroupStmt(stmt.iter_var, stmt.num_groups, body)
+            return ThreadGroupStmt(stmt.group_index, stmt.group_size, stmt.num_groups, body)
 
     def visit_IfStmt(self, stmt: IfStmt) -> Stmt:
         cond = self.visit(stmt.cond)
@@ -479,7 +479,7 @@ class IRVisitor(IRFunctor):
         self.visit(stmt.extent)
         self.visit(stmt.body)
 
-    def visit_ForThreadGroupStmt(self, stmt: ForThreadGroupStmt) -> None:
+    def visit_ThreadGroupStmt(self, stmt: ThreadGroupStmt) -> None:
         self.visit(stmt.body)
 
     def visit_IfStmt(self, stmt: IfStmt) -> None:

--- a/python/tilus/ir/stmt.py
+++ b/python/tilus/ir/stmt.py
@@ -52,12 +52,19 @@ class ForStmt(Stmt):
 
 
 @dataclass(frozen=True, eq=False)
-class ForThreadGroupStmt(Stmt):
-    iter_var: Var
-    num_groups: int
+class ThreadGroupStmt(Stmt):
+    group_index: int
+    group_size: Optional[int]
+    num_groups: Optional[int]
     body: Stmt
 
-    # todo: this node is not used in the current implementation
+    @staticmethod
+    def create(
+        group_index: int, body: Stmt, group_size: Optional[int] = None, num_groups: Optional[int] = None
+    ) -> ThreadGroupStmt:
+        if group_size is None and num_groups is None:
+            raise ValueError("At least one of group_size or num_groups must be provided.")
+        return ThreadGroupStmt(group_index, group_size, num_groups, body)
 
 
 @dataclass(frozen=True, eq=False)

--- a/python/tilus/ir/tools/printer.py
+++ b/python/tilus/ir/tools/printer.py
@@ -30,7 +30,6 @@ from tilus.ir.stmt import (
     BreakStmt,
     DeclareStmt,
     ForStmt,
-    ForThreadGroupStmt,
     IfStmt,
     InstStmt,
     LetStmt,
@@ -38,6 +37,7 @@ from tilus.ir.stmt import (
     SeqStmt,
     TensorElemPtrStmt,
     TensorElemValueStmt,
+    ThreadGroupStmt,
     WhileStmt,
 )
 from tilus.ir.tensor import GlobalLayout, GlobalTensor, RegisterTensor, SharedLayout, SharedTensor, Tensor
@@ -242,13 +242,13 @@ class IRPrinter(IRFunctor):
         doc += self.visit(stmt.body).indent(4)
         return doc
 
-    def visit_ForThreadGroupStmt(self, stmt: ForThreadGroupStmt) -> Doc:
+    def visit_ThreadGroupStmt(self, stmt: ThreadGroupStmt) -> Doc:
         head_doc = (
             NewLine()
-            + Text("for ")
-            + self.printer(stmt.iter_var)
-            + " in thread_groups(num_groups="
-            + self.visit(stmt.num_groups)
+            + Text("with thread_group(group_index=")
+            + self.visit(stmt.group_index)
+            + ", group_size="
+            + self.visit(stmt.group_size)
             + "):"
         )
         body_doc = self.visit(stmt.body)

--- a/python/tilus/lang/constructs/contexts.py
+++ b/python/tilus/lang/constructs/contexts.py
@@ -1,0 +1,29 @@
+from typing import Any, Optional
+
+from tilus.ir.builders import StmtBuilder
+from tilus.ir.stmt import Stmt
+
+
+class TilusContext:
+    def bind_value(self) -> Optional[Any]:
+        raise NotImplementedError()
+
+    def post_process(self, body: Stmt) -> Stmt:
+        raise NotImplementedError()
+
+
+class ThreadGroupContext(TilusContext):
+    def __init__(self, group_index: int, group_size: Optional[int], num_groups: Optional[int]):
+        self.group_index: int = group_index
+        self.num_groups: Optional[int] = num_groups
+        self.group_size: Optional[int] = group_size
+
+    def bind_value(self) -> None:
+        return None
+
+    def post_process(self, body: Stmt) -> Stmt:
+        sb = StmtBuilder()
+
+        with sb.thread_group(group_index=self.group_index, group_size=self.group_size, num_groups=self.num_groups):
+            sb.append(body)
+        return sb.flush_stmts()

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -29,6 +29,7 @@ from tilus.ir.inst import InstructionError
 from tilus.ir.layout import GlobalLayout, RegisterLayout, SharedLayout, global_row_major, global_strides
 from tilus.ir.prog import Program
 from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor, Tensor
+from tilus.lang.constructs.contexts import ThreadGroupContext
 from tilus.lang.modules.cuda import cuda
 from tilus.lang.modules.utils import utils
 
@@ -304,6 +305,18 @@ class Script:
                 self._transpiler.var2divisibility[a] = int(term.a.b.value)  # type: ignore[arg-type]
             else:
                 raise InstructionError("Can not recognize the condition in assume: {}".format(term))
+
+    def thread_group(
+        self, group_index: int, *, num_groups: Optional[int] = None, group_size: Optional[int] = None
+    ) -> ThreadGroupContext:
+        if num_groups is None and group_size is None:
+            raise InstructionError("Either num_groups or group_size must be specified")
+        if group_index < 0 or (num_groups is not None and group_index >= num_groups):
+            raise InstructionError("Invalid group_index {}, must be in [0, {})".format(group_index, num_groups))
+
+        return ThreadGroupContext(group_index=group_index, group_size=group_size, num_groups=num_groups)
+
+    # instructions
 
     def register_tensor(
         self,

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -309,6 +309,59 @@ class Script:
     def thread_group(
         self, group_index: int, *, num_groups: Optional[int] = None, group_size: Optional[int] = None
     ) -> ThreadGroupContext:
+        """Create a thread group context.
+
+        This method creates a thread group context that is used to narrow down the threads that execute the instructions
+        within the context.
+
+        Syntax:
+
+        .. code-block:: python
+
+            class MyScript(tilus.Script):
+
+                def __call__(self, ...):
+                    # instructions executed by all threads in the thread block
+                    ...
+                    with self.thread_group(group_index, num_groups=num_groups, group_size=group_size):
+                        # instructions executed by threads in the specified thread group
+                        ...
+                        with self.thread_group(...):
+                            # we can continue to partition the current thread group into sub thread groups
+                            ...
+                        ...
+                        self.sync()  # synchronize all threads in the current thread group
+                        ...
+
+                    # instructions executed by all threads in the thread block
+                    ...
+
+        At the root level of the kernel, there is one thread group that includes all threads in the thread block.
+        We can partition the threads in the current thread group into multiple sub thread groups by specifying the
+        number of threads in each sub thread group using the `group_size` parameter, and/or by specifying the number
+        of sub thread groups using the `num_groups` parameter. The two parameters are related by the equation:
+        ```
+        num_groups * group_size == parent group_size
+        ```
+        If only one of the two parameters is specified, the other parameter will be inferred based on the size of the
+        parent thread group. If both parameters are specified, they must satisfy the above equation.
+
+        All instructions within the context will be executed by all threads in the specified thread group.
+
+        Parameters
+        ----------
+        group_index: int
+            The index of the thread group to be created. It must be in the range [0, num_groups).
+        num_groups: int, optional
+            The number of thread groups to partition the current thread group into.
+        group_size: int, optional
+            The number of threads in each thread group.
+
+        Returns
+        -------
+        ret: ThreadGroupContext
+            The thread group context created.
+        """
         if num_groups is None and group_size is None:
             raise InstructionError("Either num_groups or group_size must be specified")
         if group_index < 0 or (num_groups is not None and group_index >= num_groups):

--- a/python/tilus/transforms/bound_aware_simplify.py
+++ b/python/tilus/transforms/bound_aware_simplify.py
@@ -28,7 +28,7 @@ from tilus.ir.instructions import (
     LoadGlobalGenericInst,
     StoreGlobalGenericInst,
 )
-from tilus.ir.stmt import ForStmt, ForThreadGroupStmt, IfStmt, LetStmt, SeqStmt, Stmt
+from tilus.ir.stmt import ForStmt, IfStmt, LetStmt, SeqStmt, Stmt
 from tilus.transforms.base import Pass
 from tilus.utils import same_list
 
@@ -163,15 +163,6 @@ class BoundAwareSimplifyRewriter(IRRewriter):
             return stmt
         else:
             return SeqStmt.create(seq)
-
-    def visit_ForThreadGroupStmt(self, stmt: ForThreadGroupStmt) -> Stmt:
-        if stmt.num_groups == 1:
-            self.bound[stmt.iter_var] = BoundInfo(value=0)
-            self.memo[stmt.iter_var] = int32.zero
-            assert self.bound_info_simplifier.memo is not None
-            self.bound_info_simplifier.memo[stmt.iter_var] = int32.zero
-            return self.visit(stmt.body)
-        return super().visit_ForThreadGroupStmt(stmt)
 
     # instructions
 

--- a/tests/lang/demo_thread_group.py
+++ b/tests/lang/demo_thread_group.py
@@ -1,0 +1,55 @@
+import tilus
+import torch
+from tilus import float16, int32
+from tilus.utils import cdiv
+
+tilus.option.cache_dir("./cache")
+tilus.option.debug.dump_ir()
+
+
+class ThreadGroupExample(tilus.Script):
+    def __init__(self):
+        super().__init__()
+        self.block: int = 64
+
+    def __call__(self, n: int32, x_ptr: ~float16, y_ptr: ~float16):
+        self.attrs.blocks = cdiv(n, self.block)
+        self.attrs.warps = 4
+
+        g_x = self.global_view(x_ptr, dtype=float16, shape=[n])
+        g_y = self.global_view(y_ptr, dtype=float16, shape=[n])
+
+        s_x = self.shared_tensor(dtype=float16, shape=[self.block])
+        offset = self.blockIdx.x * self.block
+
+        with self.thread_group(0, group_size=64):
+            self.store_shared(s_x, self.load_global(g_x, offsets=[offset], shape=[self.block]))
+            self.sync()
+        self.sync()
+
+        r_x = self.load_shared(s_x)
+        r_x += 1
+        self.store_shared(dst=s_x, src=r_x)
+        self.sync()
+
+        with self.thread_group(1, group_size=64):
+            self.store_global(dst=g_y, src=self.load_shared(s_x), offsets=[offset])
+
+        self.sync()
+
+
+def demo_thread_group():
+    n = 1024
+    x = torch.randn(n, dtype=torch.float16)
+    y = torch.zeros(n, dtype=torch.float16)
+
+    kernel = ThreadGroupExample()
+    kernel(n, x, y)
+
+    expect = x + 1
+    actual = y
+    torch.testing.assert_close(actual=actual, expected=expect)
+
+
+if __name__ == "__main__":
+    demo_thread_group()

--- a/tests/lang/test_thread_group.py
+++ b/tests/lang/test_thread_group.py
@@ -38,7 +38,7 @@ class ThreadGroupExample(tilus.Script):
         self.sync()
 
 
-def demo_thread_group():
+def test_thread_group():
     n = 1024
     x = torch.randn(n, dtype=torch.float16)
     y = torch.zeros(n, dtype=torch.float16)
@@ -52,4 +52,4 @@ def demo_thread_group():
 
 
 if __name__ == "__main__":
-    demo_thread_group()
+    test_thread_group()

--- a/tests/lang/test_thread_group.py
+++ b/tests/lang/test_thread_group.py
@@ -3,9 +3,6 @@ import torch
 from tilus import float16, int32
 from tilus.utils import cdiv
 
-tilus.option.cache_dir("./cache")
-tilus.option.debug.dump_ir()
-
 
 class ThreadGroupExample(tilus.Script):
     def __init__(self):
@@ -40,8 +37,8 @@ class ThreadGroupExample(tilus.Script):
 
 def test_thread_group():
     n = 1024
-    x = torch.randn(n, dtype=torch.float16)
-    y = torch.zeros(n, dtype=torch.float16)
+    x = torch.randn(n, dtype=torch.float16, device="cuda")
+    y = torch.zeros(n, dtype=torch.float16, device="cuda")
 
     kernel = ThreadGroupExample()
     kernel(n, x, y)


### PR DESCRIPTION
In Tilus Script, you can partition the threads in a thread block into smaller thread groups and define instructions that execute only within specific thread groups. This provides fine-grained control over thread execution and enables efficient parallel programming patterns.

Example:
```python
class MyScript(tilus.Script):
    def __init__(self):
        super().__init__()

    def __call__(self, ...):
        # Specify 4 warps = 128 threads total
        self.attrs.warps = 4

        # First level: split into 4 groups of 32 threads each
        with self.thread_group(0, num_groups=4):
            # Only first group (threads 0-31) enters here

            # Second level: further split into 2 sub-groups of 16 threads each
            with self.thread_group(0, num_groups=2):
                # Only threads 0-15 execute this
                fine_grained_work()

            with self.thread_group(1, num_groups=2):
                # Only threads 16-31 execute this
                different_fine_grained_work()

            # Back to first level - all threads 0-31 execute this
            self.sync()
```