### PR TITLE
[Instruction][PrintTensor] Support printing tensor memory tensor

### DIFF
--- a/python/tilus/transforms/__init__.py
+++ b/python/tilus/transforms/__init__.py
@@ -21,6 +21,7 @@ from .inject_print_instruction import inject_print_instruction_pass
 from .layout_inference import layout_inference_pass
 from .lower_load_store import lower_load_store_pass
 from .lower_param_only_expr import lower_param_only_expr_pass
+from .lower_print_tmem_tensor import lower_print_tmemory_tensor_pass
 from .lower_to_load_matrix import lower_to_load_matrix_pass
 from .scalar_analyze import analyze_scalar_pass
 
@@ -30,6 +31,7 @@ def get_default_passes() -> list[Pass]:
         declare_to_let_pass(),
         lower_param_only_expr_pass(),
         analyze_scalar_pass(),
+        lower_print_tmemory_tensor_pass(),
         layout_inference_pass(),
         lower_to_load_matrix_pass(),
         lower_load_store_pass(),

--- a/python/tilus/transforms/lower_print_tmem_tensor.py
+++ b/python/tilus/transforms/lower_print_tmem_tensor.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Union
+
+from tilus.ir.builders import StmtBuilder
+from tilus.ir.func import Function
+from tilus.ir.functors import IRRewriter
+from tilus.ir.inst import Instruction
+from tilus.ir.instructions import PrintTensorInst
+from tilus.ir.stmt import Stmt
+from tilus.ir.tensor import TMemoryTensor
+from tilus.transforms.base import Pass
+
+
+class LowerPrintTMemoryTensorRewriter(IRRewriter):
+    def visit_PrintTensorInst(self, inst: PrintTensorInst) -> Union[Instruction, Stmt]:
+        if not isinstance(inst.inputs[0], TMemoryTensor):
+            return super().visit_Instruction(inst)
+
+        sb = StmtBuilder()
+
+        tmem_tensor = inst.inputs[0].as_tmemory_tensor()
+        regs_tensor = sb.tcgen05_load(tmem_tensor, offsets=[0, 0], shape=tmem_tensor.shape)
+        sb.tcgen05_wait_load()
+        sb.print_tensor(inst.msg, regs_tensor)
+        return sb.flush_stmts()
+
+
+class LowerPrintTMemoryTensorPass(Pass):
+    def process_function(self, function: Function) -> Function:
+        rewriter = LowerPrintTMemoryTensorRewriter()
+        return rewriter.visit(function)
+
+
+def lower_print_tmemory_tensor_pass() -> Pass:
+    return LowerPrintTMemoryTensorPass()

--- a/tests/instructions/test_print_tensor.py
+++ b/tests/instructions/test_print_tensor.py
@@ -1,0 +1,18 @@
+import tilus
+from tilus import float32
+from tilus.testing import requires
+
+
+class PrintTmemTensor(tilus.Script):
+    def __call__(self):
+        self.attrs.blocks = 1
+        self.attrs.warps = 4
+
+        t_a = self.tcgen05.alloc(dtype=float32, shape=[128, 32])
+        self.print_tensor("t_a: ", t_a)
+
+
+@requires.nvgpu_sm100
+def test_print_tmem_tensor():
+    kernel = PrintTmemTensor()
+    kernel()


### PR DESCRIPTION
This PR allows the `print_tensor` instruction accepts the tensor memory tensor.