### PR TITLE
[Codegen] Reduce warp-divergence with predicated instruction emitting

### DIFF
--- a/examples/blackwell_matmul/matmul_v0.py
+++ b/examples/blackwell_matmul/matmul_v0.py
@@ -54,16 +54,11 @@ class BlackwellMatmulV0(tilus.Script):
             self.copy_async_wait_all()
             self.sync()
 
-            with self.single_thread():
-                # perform tcgen05 mma on two shared tensors
+            with self.single_warp():
                 self.tcgen05.mma(
                     s_a, s_b.transpose(), t_acc, enable_input_d=offset_k != 0
                 )
-
-                # commit the mma operation the finish of the committed operations will trigger a arrive event on the barrier
                 self.tcgen05.commit(mbarrier=mbarriers[0])
-
-                # wait for all pending arrivals to finish (in this case, the expected count = 1, which is the operation of mma)
                 self.mbarrier.wait(mbarriers[0], phase=phase)
             self.sync()
 

--- a/examples/blackwell_matmul/matmul_v1.py
+++ b/examples/blackwell_matmul/matmul_v1.py
@@ -49,10 +49,11 @@ class BlackwellMatmulV1(tilus.Script):
         self.sync()
 
         for offset_k in range(0, k_size, self.block_k):
-            with self.single_thread():  # we use a single thread to issue the TMA copy
-                self.mbarrier.arrive_and_expect_tx(
-                    tma_barrier, transaction_bytes=s_a.nbytes + s_b.nbytes
-                )
+            with self.single_warp():
+                with self.single_thread():
+                    self.mbarrier.arrive_and_expect_tx(
+                        tma_barrier, transaction_bytes=s_a.nbytes + s_b.nbytes
+                    )
                 self.tma.global_to_shared(
                     src=g_a,
                     dst=s_a,
@@ -66,16 +67,10 @@ class BlackwellMatmulV1(tilus.Script):
                     mbarrier=tma_barrier,
                 )
                 self.mbarrier.wait(tma_barrier, phase=phase)
-
-                # perform tcgen05 mma on two shared tensors
                 self.tcgen05.mma(
                     s_a, s_b.transpose(), t_acc, enable_input_d=offset_k != 0
                 )
-
-                # commit the mma operation the finish of the committed operations will trigger a arrive event on the barrier
                 self.tcgen05.commit(mbarrier=mma_barrier)
-
-                # wait for all pending arrivals to finish (in this case, the expected count = 1, which is the operation of mma)
                 self.mbarrier.wait(mma_barrier, phase=phase)
             self.sync()
 

--- a/examples/blackwell_matmul/matmul_v2.py
+++ b/examples/blackwell_matmul/matmul_v2.py
@@ -54,10 +54,11 @@ class BlackwellMatmulV2(tilus.Script):
 
         for i in range(self.stages - 1):
             offset_k = i * self.block_k
-            with self.single_thread():
-                self.mbarrier.arrive_and_expect_tx(
-                    tma_barriers[i], transaction_bytes=s_a[i].nbytes + s_b[i].nbytes
-                )
+            with self.single_warp():
+                with self.single_thread():
+                    self.mbarrier.arrive_and_expect_tx(
+                        tma_barriers[i], transaction_bytes=s_a[i].nbytes + s_b[i].nbytes
+                    )
                 self.tma.global_to_shared(
                     src=g_a,
                     dst=s_a[i],
@@ -77,14 +78,14 @@ class BlackwellMatmulV2(tilus.Script):
         preload_stage: int32 = self.stages - 1
 
         for offset_k in self.range(0, k_size, self.block_k, unroll=self.stages):
-            with self.single_thread():  # we use a single thread to issue the TMA copy
-                # preload
+            with self.single_warp():
                 preload_offset_k = offset_k + (self.stages - 1) * self.block_k
-                self.mbarrier.arrive_and_expect_tx(
-                    tma_barriers[preload_stage],
-                    transaction_bytes=s_a[preload_stage].nbytes
-                    + s_b[preload_stage].nbytes,
-                )
+                with self.single_thread():
+                    self.mbarrier.arrive_and_expect_tx(
+                        tma_barriers[preload_stage],
+                        transaction_bytes=s_a[preload_stage].nbytes
+                        + s_b[preload_stage].nbytes,
+                    )
                 self.tma.global_to_shared(
                     src=g_a,
                     dst=s_a[preload_stage],
@@ -100,7 +101,6 @@ class BlackwellMatmulV2(tilus.Script):
                 self.mbarrier.wait(
                     tma_barriers[current_stage], phase=tma_phases[current_stage].item()
                 )
-
                 self.tcgen05.mma(
                     s_a[current_stage],
                     s_b[current_stage].transpose(),

--- a/examples/blackwell_matmul/matmul_v3.py
+++ b/examples/blackwell_matmul/matmul_v3.py
@@ -70,18 +70,18 @@ class BlackwellMatmulV3(tilus.Script):
                         consumer_barriers[stage],
                         transaction_bytes=s_a[stage].nbytes + s_b[stage].nbytes,
                     )
-                    self.tma.global_to_shared(
-                        src=g_a,
-                        dst=s_a[stage],
-                        offsets=[offset_m, offset_k],
-                        mbarrier=consumer_barriers[stage],
-                    )
-                    self.tma.global_to_shared(
-                        src=g_b,
-                        dst=s_b[stage],
-                        offsets=[offset_n, offset_k],
-                        mbarrier=consumer_barriers[stage],
-                    )
+                self.tma.global_to_shared(
+                    src=g_a,
+                    dst=s_a[stage],
+                    offsets=[offset_m, offset_k],
+                    mbarrier=consumer_barriers[stage],
+                )
+                self.tma.global_to_shared(
+                    src=g_b,
+                    dst=s_b[stage],
+                    offsets=[offset_n, offset_k],
+                    mbarrier=consumer_barriers[stage],
+                )
                 stage = (stage + 1) % self.stages
 
             # remaining mma stages to wait for completion
@@ -103,14 +103,13 @@ class BlackwellMatmulV3(tilus.Script):
                     consumer_barriers[stage], phase=consumer_phases[stage]
                 )  # wait until the stage is ready for consumption
                 consumer_phases[stage] ^= 1
-                with self.single_thread():
-                    self.tcgen05.mma(
-                        s_a[stage],
-                        s_b[stage].transpose(),
-                        t_acc,
-                        enable_input_d=offset_k != 0,
-                    )
-                    self.tcgen05.commit(mbarrier=producer_barriers[stage])
+                self.tcgen05.mma(
+                    s_a[stage],
+                    s_b[stage].transpose(),
+                    t_acc,
+                    enable_input_d=offset_k != 0,
+                )
+                self.tcgen05.commit(mbarrier=producer_barriers[stage])
                 stage = (stage + 1) % self.stages
 
         self.sync()

--- a/examples/blackwell_matmul/matmul_v4.py
+++ b/examples/blackwell_matmul/matmul_v4.py
@@ -114,18 +114,18 @@ class LoadWorker(tilus.Class):
                         transaction_bytes=s_a[pipe.producer_stage].nbytes
                         + s_b[pipe.producer_stage].nbytes,
                     )
-                    self.tma.global_to_shared(
-                        src=params.g_a,
-                        dst=s_a[pipe.producer_stage],
-                        offsets=[offset_m, offset_k],
-                        mbarrier=pipe.producer_release_barrier(),
-                    )
-                    self.tma.global_to_shared(
-                        src=params.g_b,
-                        dst=s_b[pipe.producer_stage],
-                        offsets=[offset_n, offset_k],
-                        mbarrier=pipe.producer_release_barrier(),
-                    )
+                self.tma.global_to_shared(
+                    src=params.g_a,
+                    dst=s_a[pipe.producer_stage],
+                    offsets=[offset_m, offset_k],
+                    mbarrier=pipe.producer_release_barrier(),
+                )
+                self.tma.global_to_shared(
+                    src=params.g_b,
+                    dst=s_b[pipe.producer_stage],
+                    offsets=[offset_n, offset_k],
+                    mbarrier=pipe.producer_release_barrier(),
+                )
                 pipe.producer_advance()
 
 
@@ -147,18 +147,16 @@ class MmaWorker(tilus.Class):
                 0, self.params.k_size, self.params.block_k, unroll=num_stages
             ):
                 pipe.consumer_acquire()
-                with self.single_thread():
-                    self.tcgen05.mma(
-                        s_a[pipe.consumer_stage],
-                        s_b[pipe.consumer_stage].transpose(),
-                        self.t_acc,
-                        enable_input_d=offset_k != 0,
-                    )
-                    self.tcgen05.commit(mbarrier=pipe.consumer_release_barrier())
+                self.tcgen05.mma(
+                    s_a[pipe.consumer_stage],
+                    s_b[pipe.consumer_stage].transpose(),
+                    self.t_acc,
+                    enable_input_d=offset_k != 0,
+                )
+                self.tcgen05.commit(mbarrier=pipe.consumer_release_barrier())
                 pipe.consumer_advance()
 
-            with self.single_thread():
-                self.tcgen05.commit(mbarrier=self.flush_barrier)
+            self.tcgen05.commit(mbarrier=self.flush_barrier)
             self.mbarrier.wait(self.flush_barrier, phase=0)
 
 

--- a/examples/blackwell_matmul/matmul_v5.py
+++ b/examples/blackwell_matmul/matmul_v5.py
@@ -117,18 +117,18 @@ class LoadWorker(tilus.Class):
                         transaction_bytes=s_a[pipe.producer_stage].nbytes
                         + s_b[pipe.producer_stage].nbytes,
                     )
-                    self.tma.global_to_shared(
-                        src=params.g_a,
-                        dst=s_a[pipe.producer_stage],
-                        offsets=[offset_m, offset_k],
-                        mbarrier=pipe.producer_release_barrier(),
-                    )
-                    self.tma.global_to_shared(
-                        src=params.g_b,
-                        dst=s_b[pipe.producer_stage],
-                        offsets=[offset_n, offset_k],
-                        mbarrier=pipe.producer_release_barrier(),
-                    )
+                self.tma.global_to_shared(
+                    src=params.g_a,
+                    dst=s_a[pipe.producer_stage],
+                    offsets=[offset_m, offset_k],
+                    mbarrier=pipe.producer_release_barrier(),
+                )
+                self.tma.global_to_shared(
+                    src=params.g_b,
+                    dst=s_b[pipe.producer_stage],
+                    offsets=[offset_n, offset_k],
+                    mbarrier=pipe.producer_release_barrier(),
+                )
                 pipe.producer_advance()
 
 
@@ -150,18 +150,16 @@ class MmaWorker(tilus.Class):
                 0, self.params.k_size, self.params.block_k, unroll=num_stages
             ):
                 pipe.consumer_acquire()
-                with self.single_thread():
-                    self.tcgen05.mma(
-                        s_a[pipe.consumer_stage],
-                        s_b[pipe.consumer_stage].transpose(),
-                        self.t_acc,
-                        enable_input_d=offset_k != 0,
-                    )
-                    self.tcgen05.commit(mbarrier=pipe.consumer_release_barrier())
+                self.tcgen05.mma(
+                    s_a[pipe.consumer_stage],
+                    s_b[pipe.consumer_stage].transpose(),
+                    self.t_acc,
+                    enable_input_d=offset_k != 0,
+                )
+                self.tcgen05.commit(mbarrier=pipe.consumer_release_barrier())
                 pipe.consumer_advance()
 
-            with self.single_thread():
-                self.tcgen05.commit(mbarrier=self.flush_barrier)
+            self.tcgen05.commit(mbarrier=self.flush_barrier)
             self.mbarrier.wait(self.flush_barrier, phase=0)
 
 
@@ -235,7 +233,7 @@ class BlackwellMatmulV5(tilus.Script):
             self.store_shared(s_c, r_acc.to(float16))
             self.fence.proxy_async()
             self.sync()
-            with self.single_thread():
+            with self.single_warp():
                 self.tma.shared_to_global(
                     s_c,
                     params.g_c,

--- a/examples/blackwell_matmul/matmul_v6.py
+++ b/examples/blackwell_matmul/matmul_v6.py
@@ -123,21 +123,20 @@ class LoadWorker(tilus.Class):
                 else:
                     # get the mbarrier address in the CTA0 to signal
                     mbarrier = self.cluster.map_shared_addr(mbarrier, target_rank=0)
-                with self.single_thread():
-                    self.tma.global_to_shared(
-                        src=params.g_a,
-                        dst=s_a[pipe.producer_stage],
-                        offsets=[offset_m, offset_k],
-                        mbarrier=mbarrier,
-                        cta_group=2,
-                    )
-                    self.tma.global_to_shared(
-                        src=params.g_b,
-                        dst=s_b[pipe.producer_stage],
-                        offsets=[offset_n, offset_k],
-                        mbarrier=mbarrier,
-                        cta_group=2,
-                    )
+                self.tma.global_to_shared(
+                    src=params.g_a,
+                    dst=s_a[pipe.producer_stage],
+                    offsets=[offset_m, offset_k],
+                    mbarrier=mbarrier,
+                    cta_group=2,
+                )
+                self.tma.global_to_shared(
+                    src=params.g_b,
+                    dst=s_b[pipe.producer_stage],
+                    offsets=[offset_n, offset_k],
+                    mbarrier=mbarrier,
+                    cta_group=2,
+                )
                 pipe.producer_advance()
 
 
@@ -158,7 +157,7 @@ class MmaWorker(tilus.Class):
         num_stages: int = pipe.num_stages
         cta_rank = self.cluster.blockRank
         if cta_rank == 0:
-            with self.thread_group(thread_begin=32, num_threads=1):
+            with self.thread_group(thread_begin=32, num_threads=32):
                 for offset_k in self.range(
                     0, self.params.k_size, self.params.block_k, unroll=num_stages
                 ):
@@ -280,7 +279,7 @@ class BlackwellMatmulV6(tilus.Script):
             self.store_shared(s_c, r_acc.to(float16))
             self.fence.proxy_async()
             self.sync()
-            with self.single_thread():
+            with self.single_warp():
                 self.tma.shared_to_global(
                     s_c,
                     params.g_c,
@@ -292,7 +291,7 @@ class BlackwellMatmulV6(tilus.Script):
             self.sync()
 
         # all allocated tensor memory must be deallocated
-        self.sync()
+        self.cluster_sync()
         self.tcgen05.dealloc(mma_worker.t_acc)
 
 
@@ -303,9 +302,9 @@ def main(bench=True):
     rows: list = []
 
     for m_size, n_size, k_size in [
-        [4096, 4096, 4096],
-        [4096, 4096, 14336],
-        [8192, 8192, 8192],
+        # [4096, 4096, 4096],
+        # [4096, 4096, 14336],
+        # [8192, 8192, 8192],
         [10240, 10240, 10240],
     ]:
         print(f"Running with m_size={m_size}, n_size={n_size}, k_size={k_size}")

--- a/examples/blackwell_matmul/matmul_v7.py
+++ b/examples/blackwell_matmul/matmul_v7.py
@@ -184,21 +184,20 @@ class BlackwellMatmulV7(tilus.Script):
                     else:
                         # get the mbarrier address in the CTA0 to signal
                         mbarrier = self.cluster.map_shared_addr(mbarrier, target_rank=0)
-                    with self.single_thread():
-                        self.tma.global_to_shared(
-                            src=g_a,
-                            dst=s_a[tma_pipe.producer_stage],
-                            offsets=[offset_m_a, offset_k],
-                            mbarrier=mbarrier,
-                            cta_group=2,
-                        )
-                        self.tma.global_to_shared(
-                            src=g_b,
-                            dst=s_b[tma_pipe.producer_stage],
-                            offsets=[offset_n_b, offset_k],
-                            mbarrier=mbarrier,
-                            cta_group=2,
-                        )
+                    self.tma.global_to_shared(
+                        src=g_a,
+                        dst=s_a[tma_pipe.producer_stage],
+                        offsets=[offset_m_a, offset_k],
+                        mbarrier=mbarrier,
+                        cta_group=2,
+                    )
+                    self.tma.global_to_shared(
+                        src=g_b,
+                        dst=s_b[tma_pipe.producer_stage],
+                        offsets=[offset_n_b, offset_k],
+                        mbarrier=mbarrier,
+                        cta_group=2,
+                    )
                     tma_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
@@ -209,30 +208,29 @@ class BlackwellMatmulV7(tilus.Script):
 
         with self.single_warp(1):  # mma worker (smem -> tmem)
             while True:
-                with self.single_thread():
-                    if cta_rank == 0:
-                        mma_pipe.producer_acquire()
-                        for offset_k in self.range(0, k_size, block_k, unroll=mma_stages):
-                            tma_pipe.consumer_acquire()
-                            self.tcgen05.mma(
-                                s_a[tma_pipe.consumer_stage],
-                                s_b[tma_pipe.consumer_stage].transpose(),
-                                t_acc[mma_pipe.producer_stage],
-                                enable_input_d=offset_k != 0,
-                                cta_group=2,
-                            )
-                            self.tcgen05.commit(
-                                mbarrier=tma_pipe.consumer_barrier(),
-                                cta_group=2,
-                                multicast_mask=0b11,
-                            )
-                            tma_pipe.consumer_advance()
+                if cta_rank == 0:
+                    mma_pipe.producer_acquire()
+                    for offset_k in self.range(0, k_size, block_k, unroll=mma_stages):
+                        tma_pipe.consumer_acquire()
+                        self.tcgen05.mma(
+                            s_a[tma_pipe.consumer_stage],
+                            s_b[tma_pipe.consumer_stage].transpose(),
+                            t_acc[mma_pipe.producer_stage],
+                            enable_input_d=offset_k != 0,
+                            cta_group=2,
+                        )
                         self.tcgen05.commit(
-                            mbarrier=mma_pipe.producer_barrier(),
+                            mbarrier=tma_pipe.consumer_barrier(),
                             cta_group=2,
                             multicast_mask=0b11,
                         )
-                        mma_pipe.producer_advance()
+                        tma_pipe.consumer_advance()
+                    self.tcgen05.commit(
+                        mbarrier=mma_pipe.producer_barrier(),
+                        cta_group=2,
+                        multicast_mask=0b11,
+                    )
+                    mma_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
                 if not is_valid:
@@ -249,12 +247,11 @@ class BlackwellMatmulV7(tilus.Script):
                         transaction_bytes=16,
                         multicast_mask=0b11,
                     )
-                    with self.single_thread():
-                        self.clc.try_cancel(
-                            s_clc_response[clc_pipe.producer_stage],
-                            mbarrier=clc_pipe.producer_barrier(),
-                            multicast=True,
-                        )
+                    self.clc.try_cancel(
+                        s_clc_response[clc_pipe.producer_stage],
+                        mbarrier=clc_pipe.producer_barrier(),
+                        multicast=True,
+                    )
                     clc_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
@@ -280,7 +277,7 @@ class BlackwellMatmulV7(tilus.Script):
                     self.store_shared(s_c, r_acc.to(float16))
                     self.fence.proxy_async(space="shared")
                     self.sync()
-                    with self.single_thread():
+                    with self.single_warp():
                         self.tma.shared_to_global(
                             s_c,
                             g_c,
@@ -301,7 +298,7 @@ class BlackwellMatmulV7(tilus.Script):
                 offset_n_c = new_blockIdx.y * block_n
 
         # all allocated tensor memory must be deallocated
-        self.sync()
+        self.cluster_sync()
         self.tcgen05.dealloc(t_acc)
 
 

--- a/examples/blackwell_matmul/matmul_v8.py
+++ b/examples/blackwell_matmul/matmul_v8.py
@@ -212,21 +212,22 @@ class BlackwellMatmulV8(tilus.Script):
                     else:
                         # get the mbarrier address in the CTA0 to signal
                         mbarrier = self.cluster.map_shared_addr(mbarrier, target_rank=0)
-                    with self.single_thread():
-                        self.tma.global_to_shared(
-                            src=g_a,
-                            dst=s_a[tma_pipe.producer_stage],
-                            offsets=[offset_m_a, offset_k],
-                            mbarrier=mbarrier,
-                            cta_group=2,
-                        )
-                        self.tma.global_to_shared(
-                            src=g_b,
-                            dst=s_b[tma_pipe.producer_stage],
-                            offsets=[offset_n_b, offset_k],
-                            mbarrier=mbarrier,
-                            cta_group=2,
-                        )
+                    # TMA loads are warp-cooperative: all 32 threads participate,
+                    # predication is handled internally by the emitter
+                    self.tma.global_to_shared(
+                        src=g_a,
+                        dst=s_a[tma_pipe.producer_stage],
+                        offsets=[offset_m_a, offset_k],
+                        mbarrier=mbarrier,
+                        cta_group=2,
+                    )
+                    self.tma.global_to_shared(
+                        src=g_b,
+                        dst=s_b[tma_pipe.producer_stage],
+                        offsets=[offset_n_b, offset_k],
+                        mbarrier=mbarrier,
+                        cta_group=2,
+                    )
                     tma_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
@@ -240,30 +241,31 @@ class BlackwellMatmulV8(tilus.Script):
 
         with self.single_warp(1):  # mma worker (smem -> tmem)
             while True:
-                with self.single_thread():
-                    if cta_rank == 0:
-                        mma_pipe.producer_acquire()
-                        for offset_k in range(0, k_size, block_k):
-                            tma_pipe.consumer_acquire()
-                            self.tcgen05.mma(
-                                s_a[tma_pipe.consumer_stage],
-                                s_b[tma_pipe.consumer_stage].transpose(),
-                                t_acc[mma_pipe.producer_stage],
-                                enable_input_d=offset_k != 0,
-                                cta_group=2,
-                            )
-                            self.tcgen05.commit(
-                                mbarrier=tma_pipe.consumer_barrier(),
-                                cta_group=2,
-                                multicast_mask=0b11,
-                            )
-                            tma_pipe.consumer_advance()
+                # tcgen05.mma and tcgen05.commit are warp-cooperative:
+                # all 32 threads participate, predication handled internally
+                if cta_rank == 0:
+                    mma_pipe.producer_acquire()
+                    for offset_k in range(0, k_size, block_k):
+                        tma_pipe.consumer_acquire()
+                        self.tcgen05.mma(
+                            s_a[tma_pipe.consumer_stage],
+                            s_b[tma_pipe.consumer_stage].transpose(),
+                            t_acc[mma_pipe.producer_stage],
+                            enable_input_d=offset_k != 0,
+                            cta_group=2,
+                        )
                         self.tcgen05.commit(
-                            mbarrier=mma_pipe.producer_barrier(),
+                            mbarrier=tma_pipe.consumer_barrier(),
                             cta_group=2,
                             multicast_mask=0b11,
                         )
-                        mma_pipe.producer_advance()
+                        tma_pipe.consumer_advance()
+                    self.tcgen05.commit(
+                        mbarrier=mma_pipe.producer_barrier(),
+                        cta_group=2,
+                        multicast_mask=0b11,
+                    )
+                    mma_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
                 if not is_valid:
@@ -278,12 +280,12 @@ class BlackwellMatmulV8(tilus.Script):
                         transaction_bytes=16,
                         multicast_mask=0b11,
                     )
-                    with self.single_thread():
-                        self.clc.try_cancel(
-                            s_clc_response[clc_pipe.producer_stage],
-                            mbarrier=clc_pipe.producer_barrier(),
-                            multicast=True,
-                        )
+                    # clc.try_cancel is warp-cooperative: predication handled internally
+                    self.clc.try_cancel(
+                        s_clc_response[clc_pipe.producer_stage],
+                        mbarrier=clc_pipe.producer_barrier(),
+                        multicast=True,
+                    )
                     clc_pipe.producer_advance()
 
                 is_valid, new_blockIdx = self.query_clc_response(s_clc_response, clc_pipe)
@@ -312,7 +314,9 @@ class BlackwellMatmulV8(tilus.Script):
                     self.store_shared(s_c, r_acc.to(float16))
                     self.fence.proxy_async(space="shared")
                     self.sync()
-                    with self.single_thread():
+                    # TMA store is warp-cooperative: use single_warp() to select
+                    # one warp, predication handled internally by the emitter
+                    with self.single_warp():
                         self.tma.shared_to_global(
                             s_c,
                             g_c,

--- a/python/tilus/backends/contexts/contexts.py
+++ b/python/tilus/backends/contexts/contexts.py
@@ -17,6 +17,7 @@ from tilus.backends.contexts.const_reg_ctx import ConstRegTensorEmitContext
 from tilus.backends.contexts.global_view_ctx import GlobalTensorViewContext
 from tilus.backends.contexts.gmem_alloc_ctx import GlobalMemoryAllocationContext
 from tilus.backends.contexts.invariant_ctx import InvariantTrackingContext
+from tilus.backends.contexts.leader_lane_ctx import LeaderLaneContext
 from tilus.backends.contexts.mbarrier_alloc_ctx import BarrierAllocContext
 from tilus.backends.contexts.smem_alloc_ctx import SharedMemoryAllocationContext
 from tilus.backends.contexts.sync_ctx import SyncContext
@@ -38,6 +39,7 @@ class EmitContexts:
         self.barrier_alloc_ctx: BarrierAllocContext = BarrierAllocContext(codegen)
         self.sync_ctx: SyncContext = SyncContext(codegen)
         self.const_reg_ctx: ConstRegTensorEmitContext = ConstRegTensorEmitContext(codegen)
+        self.leader_lane_ctx: LeaderLaneContext = LeaderLaneContext(codegen)
 
     def contexts(self) -> list[BaseEmitContext]:
         """Get all contexts as a list.

--- a/python/tilus/backends/contexts/leader_lane_ctx.py
+++ b/python/tilus/backends/contexts/leader_lane_ctx.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Optional
+
+from tilus.backends.context import BaseEmitContext
+from tilus.hidet.ir.expr import Var
+
+
+class LeaderLaneContext(BaseEmitContext):
+    """Context that manages a per-warp leader lane predicate for warp-cooperative instructions.
+
+    Many SASS instructions (UTMASTG, UTCMMA, CLC.TRY_CANCEL, TMA copy) are warp-cooperative:
+    all threads in a warp participate in their execution, but the PTX semantics require them to
+    be issued by a single thread. When emitting through PTX, wrapping these instructions in
+    an if-branch (via elect_sync) causes ptxas to generate BSSY/BSYNC divergence overhead.
+
+    This context provides a pre-computed `is_leader_lane` uint32 variable (1 for one elected
+    thread per warp, 0 for others) that can be passed as a predicate directly into PTX inline
+    asm via `@p` syntax, avoiding the if-branch entirely.
+
+    The variable is lazily initialized on first access and declared at the kernel's outermost scope.
+    """
+
+    def __post_init__(self):
+        self._leader_lane_var: Optional[Var] = None
+
+    @property
+    def leader_lane(self) -> Var:
+        """Get or lazily create the per-warp leader lane predicate variable.
+
+        Returns a Var reference. The actual declaration is emitted in finalize().
+
+        Returns
+        -------
+        Var
+            A uint32 variable: 1 for the elected leader thread in each warp, 0 for all others.
+        """
+        if self._leader_lane_var is None:
+            from tilus.hidet.ir.dtypes import uint32
+
+            self._leader_lane_var = Var("is_leader_lane", type=uint32)
+        return self._leader_lane_var
+
+    def finalize(self):
+        """Emit the leader lane declaration at the kernel's outermost scope if it was accessed."""
+        if self._leader_lane_var is not None:
+            from tilus.hidet.ir.primitives.cuda.elect import elect_one_sync
+            from tilus.hidet.ir.stmt import DeclareStmt
+
+            self.kernel_prepend(DeclareStmt(self._leader_lane_var, init=elect_one_sync()))

--- a/python/tilus/backends/emitter.py
+++ b/python/tilus/backends/emitter.py
@@ -51,6 +51,14 @@ class BaseInstEmitter(StmtBuilder):
         if self.current_num_threads != 32:
             raise ValueError(f"Instruction {inst} requires a warp (32 threads): {msg}.")
 
+    def assert_is_warp_aligned(self, inst: Instruction, msg: str) -> None:
+        if self.current_num_threads != 32 or self.current_thread_group_begin % 32 != 0:
+            raise ValueError(
+                f"Instruction {inst} requires exactly one warp-aligned warp "
+                f"(thread_begin % 32 == 0, num_threads == 32), "
+                f"got thread_begin={self.current_thread_group_begin}, num_threads={self.current_num_threads}: {msg}."
+            )
+
     def sync(self):
         optional_sync_call = self.contexts.sync_ctx.sync()
         if optional_sync_call is not None:

--- a/python/tilus/backends/emitters/cuda/blackwell/clc.py
+++ b/python/tilus/backends/emitters/cuda/blackwell/clc.py
@@ -24,15 +24,16 @@ from tilus.ir.tensor import SharedTensor
 @register_emitter(ClusterLaunchControlTryCancelInst)
 class ClusterLaunchControlTryCancelEmitter(BaseInstEmitter):
     def emit(self, inst: ClusterLaunchControlTryCancelInst) -> None:
+        self.assert_is_warp_aligned(inst, "CLC try_cancel is a warp-cooperative instruction")
         response: SharedTensor = inst.shared_input
-        with self.single_thread():
-            self.append(
-                cluster_launch_control_try_cancel(
-                    mbarrier=inst.mbarrier,
-                    response=self.shared_tensor_shared_space_addr[response],
-                    multicast=inst.multicast,
-                )
+        self.append(
+            cluster_launch_control_try_cancel(
+                mbarrier=inst.mbarrier,
+                response=self.shared_tensor_shared_space_addr[response],
+                multicast=inst.multicast,
+                predicate=self.contexts.leader_lane_ctx.leader_lane,
             )
+        )
 
 
 @register_emitter(ClusterLaunchControlQueryResponseInst)

--- a/python/tilus/backends/emitters/cuda/cp_async_tensor.py
+++ b/python/tilus/backends/emitters/cuda/cp_async_tensor.py
@@ -289,6 +289,7 @@ class CopyAsyncTensorBaseEmitter(BaseInstEmitter):
 @register_emitter(CopyAsyncTensorGlobalToSharedInst, target=nvgpu_sm90)
 class CopyAsyncTensorGlobalToSharedInstEmitter(CopyAsyncTensorBaseEmitter):
     def emit(self, inst: CopyAsyncTensorGlobalToSharedInst) -> None:
+        self.assert_is_warp_aligned(inst, "TMA global to shared is a warp-cooperative instruction")
         global_tensor: GlobalTensor = inst.inputs[1].as_global_tensor()
         shared_tensor: SharedTensor = inst.inputs[0].as_shared_tensor()
         assert global_tensor.dtype == shared_tensor.dtype
@@ -304,7 +305,7 @@ class CopyAsyncTensorGlobalToSharedInstEmitter(CopyAsyncTensorBaseEmitter):
         src_tensor_map = ~self.create_tensor_map(global_tensor_info, shared_tensor_info, dtype)
         coords = list(reversed(inst.offsets))
         optional_multicast_mask = inst.multicast_mask
-        self.assert_is_single_thread(inst, "TMA global to shared copy without multicast requires a single thread.")
+        predicate = self.contexts.leader_lane_ctx.leader_lane
 
         if optional_multicast_mask is None:
             self.append(
@@ -315,6 +316,7 @@ class CopyAsyncTensorGlobalToSharedInstEmitter(CopyAsyncTensorBaseEmitter):
                     mbarrier=inst.mbarrier,
                     cta_group=inst.cta_group,
                     cache_policy=inst.cache_policy,
+                    predicate=predicate,
                 )
             )
         else:
@@ -328,6 +330,7 @@ class CopyAsyncTensorGlobalToSharedInstEmitter(CopyAsyncTensorBaseEmitter):
                     multicast_mask=multicast_mask,
                     cta_group=inst.cta_group,
                     cache_policy=inst.cache_policy,
+                    predicate=predicate,
                 )
             )
 
@@ -335,6 +338,7 @@ class CopyAsyncTensorGlobalToSharedInstEmitter(CopyAsyncTensorBaseEmitter):
 @register_emitter(CopyAsyncTensorSharedToGlobalInst, target=nvgpu_sm90)
 class CopyAsyncTensorSharedToGlobalInstEmitter(CopyAsyncTensorBaseEmitter):
     def emit(self, inst: CopyAsyncTensorSharedToGlobalInst) -> None:
+        self.assert_is_warp_aligned(inst, "TMA shared to global is a warp-cooperative instruction")
         global_tensor: GlobalTensor = inst.inputs[0].as_global_tensor()
         shared_tensor: SharedTensor = inst.inputs[1].as_shared_tensor()
         assert global_tensor.dtype == shared_tensor.dtype
@@ -349,15 +353,15 @@ class CopyAsyncTensorSharedToGlobalInstEmitter(CopyAsyncTensorBaseEmitter):
         shared_addr = self.shared_tensor_shared_space_addr[shared_tensor]
         tensor_map = self.create_tensor_map(global_tensor_info, shared_tensor_info, dtype)
         tensor_coords = inst.offsets
-        with self.single_thread():
-            self.append(
-                cp_async_tensor_shared_to_global(
-                    dst_tensor_map=~tensor_map,
-                    src=shared_addr,
-                    coords=list(reversed(tensor_coords)),
-                    cache_policy=inst.cache_policy,
-                )
+        self.append(
+            cp_async_tensor_shared_to_global(
+                dst_tensor_map=~tensor_map,
+                src=shared_addr,
+                coords=list(reversed(tensor_coords)),
+                cache_policy=inst.cache_policy,
+                predicate=self.contexts.leader_lane_ctx.leader_lane,
             )
+        )
 
 
 @register_emitter(CopyAsyncTensorCommitGroupInst, target=nvgpu_sm90)

--- a/python/tilus/backends/emitters/cuda/tcgen05/copy.py
+++ b/python/tilus/backends/emitters/cuda/tcgen05/copy.py
@@ -187,15 +187,11 @@ class Tcgen05CopyEmitter(BaseInstEmitter):
 
         raise ValueError("No valid instructions generated")
 
-    def check_single_thread(self) -> None:
-        if self.current_num_threads != 1:
-            raise ValueError("The number of threads must be 1 to emit tcgen05.copy instruction")
-
     def emit(self, inst: Tcgen05CopyInst) -> None:
         shared_tensor = inst.inputs[1].as_shared_tensor()
         tmem_tensor = inst.inputs[0].as_tmemory_tensor()
 
-        self.check_single_thread()
+        self.assert_is_warp_aligned(inst, "tcgen05.copy is a warp-cooperative instruction")
 
         if len(shared_tensor.shape) != 2:
             raise ValueError("The shared tensor must be a 2D tensor, got shape {}".format(shared_tensor.shape))
@@ -221,5 +217,6 @@ class Tcgen05CopyEmitter(BaseInstEmitter):
                         cta_group=inst_meta.cta_group,
                         shape=inst_meta.shape_kind,
                         multicast=inst_meta.multicast,
+                        predicate=self.contexts.leader_lane_ctx.leader_lane,
                     )
                 )

--- a/python/tilus/backends/emitters/cuda/tcgen05/mma.py
+++ b/python/tilus/backends/emitters/cuda/tcgen05/mma.py
@@ -181,8 +181,6 @@ class Tcgen05MmaSSInstMeta:
         i_desc = sb.declare_var("i_desc", tp=uint32, init=as_expr(self.i_desc.encoded()))
         a_desc = sb.declare_var("a_desc", tp=uint64, init=self.a_desc.encoded())
         b_desc = sb.declare_var("b_desc", tp=uint64, init=self.b_desc.encoded())
-        # tcgen05.mma has single-thread semantics — the caller (emitter) already
-        # asserts current_num_threads == 1, so no guard needed here.
         sb.append(
             tcgen05_mma_with_shared_a(
                 d_tmem=self.d_tmem_addr,
@@ -192,6 +190,7 @@ class Tcgen05MmaSSInstMeta:
                 enable_input_d=self.enable_input_d,
                 cta_group=self.cta_group,
                 mma_kind=self.kind,
+                predicate=sb.contexts.leader_lane_ctx.leader_lane,
             )
         )
 
@@ -295,7 +294,7 @@ class TMemoryMmaSSEmitter(BaseInstEmitter):
             raise CodeGenerationFailed(f"The given majorness is not supported: {a_major_kind} and {b_major_kind}.")
 
     def emit(self, inst: Tcgen05MmaSSInst) -> None:
-        assert self.current_num_threads == 1, "tcgen05.mma.ss must be called by a single thread"
+        self.assert_is_warp_aligned(inst, "tcgen05.mma is a warp-cooperative instruction")
         a_tensor: SharedTensor = inst.inputs[0].as_shared_tensor()
         b_tensor: SharedTensor = inst.inputs[1].as_shared_tensor()
         d_tensor: TMemoryTensor = inst.inputs[2].as_tmemory_tensor()

--- a/python/tilus/backends/emitters/cuda/tcgen05/sync.py
+++ b/python/tilus/backends/emitters/cuda/tcgen05/sync.py
@@ -28,11 +28,12 @@ from tilus.target import nvgpu_sm100
 @register_emitter(Tcgen05CommitInst, target=nvgpu_sm100)
 class TMemoryCommitEmitter(BaseInstEmitter):
     def emit(self, inst: Tcgen05CommitInst) -> None:
-        assert self.current_num_threads == 1, "tcgen05 commit must be called by a single thread"
+        self.assert_is_warp_aligned(inst, "tcgen05 commit is a warp-cooperative instruction")
         self.append(
             tcgen05_commit(
                 mbarrier=inst.mbarrier,
                 cta_mask=inst.multicast_mask,
                 cta_group=Tcgen05CtaGroupKind.from_int(inst.cta_group),
+                predicate=self.contexts.leader_lane_ctx.leader_lane,
             )
         )

--- a/python/tilus/hidet/ir/primitives/cuda/clc.py
+++ b/python/tilus/hidet/ir/primitives/cuda/clc.py
@@ -26,21 +26,31 @@ def register_functions():
 
     @no_type_check
     @script
-    def cuda_cluster_launch_control_try_cancel(mbarrier_addr: uint32, response_smem_addr: uint32, multicast: bool):
+    def cuda_cluster_launch_control_try_cancel(
+        mbarrier_addr: uint32, response_smem_addr: uint32, multicast: bool, predicate: uint32
+    ):
         attrs.func_kind = "cuda_internal"
 
         if multicast:
             asm(
-                template="clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%0], [%1];",
+                template=(
+                    "{.reg.pred __pred; setp.ne.u32 __pred, %2, 0;"
+                    " @__pred clusterlaunchcontrol.try_cancel.async.shared::cta"
+                    ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [%0], [%1];}"
+                ),
                 outputs=[],
-                inputs=[response_smem_addr, mbarrier_addr],
+                inputs=[response_smem_addr, mbarrier_addr, predicate],
                 is_volatile=True,
             )
         else:
             asm(
-                template="clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128 [%0], [%1];",
+                template=(
+                    "{.reg.pred __pred; setp.ne.u32 __pred, %2, 0;"
+                    " @__pred clusterlaunchcontrol.try_cancel.async.shared::cta"
+                    ".mbarrier::complete_tx::bytes.b128 [%0], [%1];}"
+                ),
                 outputs=[],
-                inputs=[response_smem_addr, mbarrier_addr],
+                inputs=[response_smem_addr, mbarrier_addr, predicate],
                 is_volatile=True,
             )
 
@@ -68,7 +78,9 @@ def register_functions():
         register_primitive_function(name=func.name, func_or_type=func)
 
 
-def cluster_launch_control_try_cancel(mbarrier: Expr, response: Expr, multicast: Expr | bool) -> Expr:
+def cluster_launch_control_try_cancel(
+    mbarrier: Expr, response: Expr, multicast: Expr | bool, predicate: Expr = uint32(1)
+) -> Expr:
     """Request cancellation of a cluster that has not launched yet.
 
     This function requests atomically cancelling the launch of a cluster that has not started running yet.
@@ -91,7 +103,9 @@ def cluster_launch_control_try_cancel(mbarrier: Expr, response: Expr, multicast:
     Expr
         An expression representing the primitive function call.
     """
-    return call_primitive_func("cuda_cluster_launch_control_try_cancel", args=[mbarrier, response, uint32(multicast)])
+    return call_primitive_func(
+        "cuda_cluster_launch_control_try_cancel", args=[mbarrier, response, uint32(multicast), predicate]
+    )
 
 
 def cluster_launch_control_query_response(response: Expr, outputs: Expr) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/copy_async_tensor.py
+++ b/python/tilus/hidet/ir/primitives/cuda/copy_async_tensor.py
@@ -62,7 +62,7 @@ def register_copy_async_tensor():
                 )
                 cta_group_item = "" if cta_group is None else ".cta_group::{}".format(cta_group)
                 cache_hint_item = "" if not has_cache_hint else "::L2::cache_hint"
-                inst = "cp.async.bulk.tensor.{}d.shared::cta.global.tile.mbarrier::complete_tx::bytes{}{}".format(
+                bare_inst = "cp.async.bulk.tensor.{}d.shared::cta.global.tile.mbarrier::complete_tx::bytes{}{}".format(
                     dim, cta_group_item, cache_hint_item
                 )
                 if has_cache_hint:
@@ -71,7 +71,14 @@ def register_copy_async_tensor():
                     )
                 else:
                     operands = "[%0], [%1, {{{}}}], [%2]".format(", ".join(["%{}".format(i + 3) for i in range(dim)]))
-                template = inst + " " + operands + ";"
+                # predicate is the last input
+                pred_idx = (
+                    1 + 1 + dim + (1 if has_cache_hint else 0) + 1
+                )  # dst, tmap, coords..., mbarrier, [cache_hint]
+                bare_template = bare_inst + " " + operands + ";"
+                template = "{{.reg.pred __pred; setp.ne.u32 __pred, %{pred}, 0; @__pred {inst}}}".format(
+                    pred=pred_idx, inst=bare_template
+                )
                 coords_type = meta.types([int32 for _ in range(dim)])
                 cache_hint_type = meta.types([uint64] if has_cache_hint else [])
 
@@ -84,12 +91,13 @@ def register_copy_async_tensor():
                     coords: coords_type,
                     mbarrier: uint32,
                     cache_hint: cache_hint_type,
+                    predicate: uint32,
                 ):
                     attrs.func_name = func_name
                     attrs.func_kind = "cuda_internal"
                     asm(
                         template=template,
-                        inputs=[dst, tensor_map, mbarrier, *cache_hint, *coords],
+                        inputs=[dst, tensor_map, mbarrier, *cache_hint, *coords, predicate],
                         is_volatile=True,
                         memory_fence=True,
                     )
@@ -104,7 +112,7 @@ def register_copy_async_tensor():
                     multicast_item = "" if not multicast else ".multicast::cluster"
                     cta_group_item = "" if cta_group is None else ".cta_group::{}".format(cta_group)
                     cache_hint_item = "" if not has_cache_hint else "::L2::cache_hint"
-                    inst = "cp.async.bulk.tensor.{}d.shared::cluster.global.tile.mbarrier::complete_tx::bytes{}{}{}".format(
+                    bare_inst = "cp.async.bulk.tensor.{}d.shared::cluster.global.tile.mbarrier::complete_tx::bytes{}{}{}".format(
                         dim, multicast_item, cta_group_item, cache_hint_item
                     )
                     cnt = 0
@@ -122,7 +130,11 @@ def register_copy_async_tensor():
                     if has_cache_hint:
                         operands += ", %{}".format(cnt)  # cache hint
                         cnt += 1
-                    template = inst + " " + operands + ";"
+                    pred_idx = cnt  # predicate is the last input
+                    bare_template = bare_inst + " " + operands + ";"
+                    template = "{{.reg.pred __pred; setp.ne.u32 __pred, %{pred}, 0; @__pred {inst}}}".format(
+                        pred=pred_idx, inst=bare_template
+                    )
                     coords_type = meta.types([int32 for _ in range(dim)])
                     cta_mask_type = meta.types([uint16] if multicast else [])
                     cache_hint_type = meta.types([uint64] if has_cache_hint else [])
@@ -137,12 +149,13 @@ def register_copy_async_tensor():
                         mbarrier: uint32,
                         cta_mask: cta_mask_type,
                         cache_hint: cache_hint_type,
+                        predicate: uint32,
                     ):
                         attrs.func_name = func_name
                         attrs.func_kind = "cuda_internal"
                         asm(
                             template=template,
-                            inputs=[dst, tensor_map, *coords, mbarrier, *cta_mask, *cache_hint],
+                            inputs=[dst, tensor_map, *coords, mbarrier, *cta_mask, *cache_hint, predicate],
                             is_volatile=True,
                             memory_fence=True,
                         )
@@ -151,12 +164,17 @@ def register_copy_async_tensor():
         for has_cache_hint in [False, True]:
             func_name = resolve_cp_async_bulk_tensor_shared_to_global(dim=dim, cache_hint=has_cache_hint)
             cache_hint_item = "" if not has_cache_hint else "::L2::cache_hint"
-            inst = "cp.async.bulk.tensor.{}d.global.shared::cta.tile.bulk_group{}".format(dim, cache_hint_item)
+            bare_inst = "cp.async.bulk.tensor.{}d.global.shared::cta.tile.bulk_group{}".format(dim, cache_hint_item)
             if has_cache_hint:
                 operands = "[%0, {{{}}}], [%1], %2".format(", ".join(["%{}".format(i + 3) for i in range(dim)]))
             else:
                 operands = "[%0, {{{}}}], [%1]".format(", ".join(["%{}".format(i + 2) for i in range(dim)]))
-            template = inst + " " + operands + ";"
+            # predicate is the last input: tmap, src, [cache_hint], coords...
+            pred_idx = 1 + 1 + (1 if has_cache_hint else 0) + dim  # dst_tmap, src, [cache], coords
+            bare_template = bare_inst + " " + operands + ";"
+            template = "{{.reg.pred __pred; setp.ne.u32 __pred, %{pred}, 0; @__pred {inst}}}".format(
+                pred=pred_idx, inst=bare_template
+            )
             coords_type = meta.types([int32 for _ in range(dim)])
             cache_hint_type = meta.types([uint64] if has_cache_hint else [])
 
@@ -164,13 +182,17 @@ def register_copy_async_tensor():
             @register_primitive_function_decorator
             @script
             def cp_async_tensor_shared_to_global_device(
-                dst_tensor_map: CUTensorMapPointerType, src: uint32, coords: coords_type, cache_hint: cache_hint_type
+                dst_tensor_map: CUTensorMapPointerType,
+                src: uint32,
+                coords: coords_type,
+                cache_hint: cache_hint_type,
+                predicate: uint32,
             ):
                 attrs.func_name = func_name
                 attrs.func_kind = "cuda_internal"
                 asm(
                     template=template,
-                    inputs=[dst_tensor_map, src, *cache_hint, *coords],
+                    inputs=[dst_tensor_map, src, *cache_hint, *coords, predicate],
                     is_volatile=True,
                     memory_fence=True,
                 )
@@ -216,13 +238,16 @@ def cp_async_tensor_global_to_shared(
     mbarrier: Expr,
     cta_group: Optional[int] = None,
     cache_policy: Optional[Expr] = None,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     assert cache_policy is None, "cache_policy is not supported yet"
     func_name = resolve_cp_async_bulk_tensor_global_to_shared(
         dim=len(coords), cta_group=cta_group, cache_hint=cache_policy is not None
     )
     optional_cache_policy: list[Expr] = [cache_policy] if cache_policy is not None else []
-    return call_primitive_func(func_name, args=[dst, src_tensor_map, *coords, mbarrier, *optional_cache_policy])
+    return call_primitive_func(
+        func_name, args=[dst, src_tensor_map, *coords, mbarrier, *optional_cache_policy, predicate]
+    )
 
 
 def cp_async_tensor_global_to_cluster_shared(
@@ -233,6 +258,7 @@ def cp_async_tensor_global_to_cluster_shared(
     multicast_mask: Expr,
     cta_group: Optional[int] = None,
     cache_policy: Optional[Expr] = None,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     assert cache_policy is None, "cache_policy is not supported yet"
     func_name = resolve_cp_async_bulk_tensor_global_to_cluster_shared(
@@ -244,17 +270,21 @@ def cp_async_tensor_global_to_cluster_shared(
     optional_cache_policy: list[Expr] = [cache_policy] if cache_policy is not None else []
     return call_primitive_func(
         func_name,
-        args=[dst, src_tensor_map, *coords, mbarrier, multicast_mask, *optional_cache_policy],
+        args=[dst, src_tensor_map, *coords, mbarrier, multicast_mask, *optional_cache_policy, predicate],
     )
 
 
 def cp_async_tensor_shared_to_global(
-    dst_tensor_map: Expr, src: Expr, coords: Sequence[Expr], cache_policy: Optional[Expr] = None
+    dst_tensor_map: Expr,
+    src: Expr,
+    coords: Sequence[Expr],
+    cache_policy: Optional[Expr] = None,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     assert cache_policy is None, "cache_policy is not supported yet"
     func_name = resolve_cp_async_bulk_tensor_shared_to_global(dim=len(coords), cache_hint=cache_policy is not None)
     optional_cache_policy: list[Expr] = [cache_policy] if cache_policy is not None else []
-    return call_primitive_func(func_name, args=[dst_tensor_map, src, *coords, *optional_cache_policy])
+    return call_primitive_func(func_name, args=[dst_tensor_map, src, *optional_cache_policy, *coords, predicate])
 
 
 def cp_async_tensor_commit_group() -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/tcgen05.py
+++ b/python/tilus/hidet/ir/primitives/cuda/tcgen05.py
@@ -390,15 +390,16 @@ def register_tcgen05_instructions():
                 Tcgen05CopyMulticastKind.WARP_X2_01_23,
                 Tcgen05CopyMulticastKind.WARP_X4,
             ]:
-                template = f"tcgen05.cp{cta_group.value}{shape_kind.value}{multicast.value} [%0], %1;"
+                bare_inst = f"tcgen05.cp{cta_group.value}{shape_kind.value}{multicast.value} [%0], %1;"
+                template = f"{{{{.reg.pred __pred; setp.ne.u32 __pred, %2, 0; @__pred {bare_inst}}}}}"
 
                 @register_primitive_function_decorator
                 @no_type_check
                 @script
-                def tcgen05_copy_(taddr: int32, sdesc: uint64):
+                def tcgen05_copy_(taddr: int32, sdesc: uint64, predicate: uint32):
                     attrs.func_name = resolve_tcgen05_copy(cta_group, shape_kind, multicast)
                     attrs.func_kind = "cuda_internal"
-                    asm(template, inputs=[taddr, sdesc], is_volatile=True)
+                    asm(template, inputs=[taddr, sdesc, predicate], is_volatile=True)
 
     # commit
     for cta_group in [Tcgen05CtaGroupKind.CTA_1, Tcgen05CtaGroupKind.CTA_2]:
@@ -407,16 +408,18 @@ def register_tcgen05_instructions():
             Tcgen05CommitMulticastKind.CLUSTER,
         ]:
             has_mask = multicast == Tcgen05CommitMulticastKind.CLUSTER
-            template = f"tcgen05.commit{cta_group.value}.mbarrier::arrive::one.shared::cluster{multicast.value}.b64 [%0]{', %1' if has_mask else ''};"
+            commit_inst = f"tcgen05.commit{cta_group.value}.mbarrier::arrive::one.shared::cluster{multicast.value}.b64 [%0]{', %1' if has_mask else ''};"
+            pred_idx = 1 + (1 if has_mask else 0)
+            template = f"{{{{.reg.pred __pred; setp.ne.u32 __pred, %{pred_idx}, 0; @__pred {commit_inst}}}}}"
             cta_mask_type = meta.types(arg_types=[uint16]) if has_mask else meta.types(arg_types=[])
 
             @register_primitive_function_decorator
             @no_type_check
             @script
-            def tcgen05_commit_(mbarrier: int32, cta_mask: cta_mask_type):
+            def tcgen05_commit_(mbarrier: int32, cta_mask: cta_mask_type, predicate: uint32):
                 attrs.func_name = resolve_tcgen05_commit(cta_group, multicast)
                 attrs.func_kind = "cuda_internal"
-                asm(template, inputs=[mbarrier, *cta_mask], is_volatile=True)
+                asm(template, inputs=[mbarrier, *cta_mask, predicate], is_volatile=True)
 
     # encode_smem_descriptor
     @register_primitive_function_decorator
@@ -447,7 +450,8 @@ def register_tcgen05_instructions():
         for mma_kind in [Tcgen05MmaKind.F16, Tcgen05MmaKind.TF32, Tcgen05MmaKind.F8F6F4, Tcgen05MmaKind.I8]:
             # a: shared memory
             template = (
-                "{{.reg.pred p; setp.ne.u32 p, %4, 0; tcgen05.mma{cta_group}{mma_kind} [%0], %1, %2, %3, p;}}".format(
+                "{{{{.reg.pred __pred; .reg.pred p; setp.ne.u32 __pred, %5, 0; setp.ne.u32 p, %4, 0;"
+                " @__pred tcgen05.mma{cta_group}{mma_kind} [%0], %1, %2, %3, p;}}}}".format(
                     cta_group=cta_group.value, mma_kind=mma_kind.value
                 )
             )
@@ -456,15 +460,21 @@ def register_tcgen05_instructions():
             @no_type_check
             @script
             def tcgen05_mma_shared_a_(
-                d_tmem: uint32, a_desc: uint64, b_desc: uint64, i_desc: uint32, enable_input_d: uint32
+                d_tmem: uint32,
+                a_desc: uint64,
+                b_desc: uint64,
+                i_desc: uint32,
+                enable_input_d: uint32,
+                predicate: uint32,
             ):
                 attrs.func_name = resolve_tcgen05_mma(cta_group, mma_kind, a_is_shared=True)
                 attrs.func_kind = "cuda_internal"
-                asm(template, inputs=[d_tmem, a_desc, b_desc, i_desc, enable_input_d], is_volatile=True)
+                asm(template, inputs=[d_tmem, a_desc, b_desc, i_desc, enable_input_d, predicate], is_volatile=True)
 
             # a: tensor memory
             template = (
-                "{{.reg.pred p; setp.ne.u32 p, %4, 0; tcgen05.mma{cta_group}{mma_kind} [%0], [%1], %2, %3, p;}}".format(
+                "{{{{.reg.pred __pred; .reg.pred p; setp.ne.u32 __pred, %5, 0; setp.ne.u32 p, %4, 0;"
+                " @__pred tcgen05.mma{cta_group}{mma_kind} [%0], [%1], %2, %3, p;}}}}".format(
                     cta_group=cta_group.value, mma_kind=mma_kind.value
                 )
             )
@@ -473,11 +483,16 @@ def register_tcgen05_instructions():
             @no_type_check
             @script
             def tcgen05_mma_tmem_a_(
-                d_tmem: uint32, a_tmem: uint32, b_desc: uint64, i_desc: uint32, enable_input_d: uint32
+                d_tmem: uint32,
+                a_tmem: uint32,
+                b_desc: uint64,
+                i_desc: uint32,
+                enable_input_d: uint32,
+                predicate: uint32,
             ):
                 attrs.func_name = resolve_tcgen05_mma(cta_group, mma_kind, a_is_shared=False)
                 attrs.func_kind = "cuda_internal"
-                asm(template, inputs=[d_tmem, a_tmem, b_desc, i_desc, enable_input_d], is_volatile=True)
+                asm(template, inputs=[d_tmem, a_tmem, b_desc, i_desc, enable_input_d, predicate], is_volatile=True)
 
 
 def tcgen05_relinquish_alloc_permit(cta_group: Tcgen05CtaGroupKind) -> Expr:
@@ -580,21 +595,23 @@ def tcgen05_copy(
     cta_group: Tcgen05CtaGroupKind,
     shape: Tcgen05CopyShapeKind,
     multicast: Tcgen05CopyMulticastKind,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     func_name = resolve_tcgen05_copy(cta_group, shape, multicast)
-    return call_primitive_func(func_name, [taddr, sdesc])
+    return call_primitive_func(func_name, [taddr, sdesc, predicate])
 
 
 def tcgen05_commit(
     mbarrier: Expr,
     cta_mask: Optional[int],
     cta_group: Tcgen05CtaGroupKind,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     if cta_mask is None:
-        args = [mbarrier]
+        args = [mbarrier, predicate]
         multicast = Tcgen05CommitMulticastKind.NONE
     else:
-        args = [mbarrier, uint16(cta_mask)]
+        args = [mbarrier, uint16(cta_mask), predicate]
         multicast = Tcgen05CommitMulticastKind.CLUSTER
     func_name = resolve_tcgen05_commit(cta_group, multicast)
     return call_primitive_func(func_name, args)
@@ -608,9 +625,10 @@ def tcgen05_mma_with_shared_a(
     enable_input_d: Expr | bool,
     cta_group: Tcgen05CtaGroupKind,
     mma_kind: Tcgen05MmaKind,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     func_name = resolve_tcgen05_mma(cta_group, mma_kind, a_is_shared=True)
-    return call_primitive_func(func_name, [d_tmem, a_desc, b_desc, i_desc, as_expr(enable_input_d)])
+    return call_primitive_func(func_name, [d_tmem, a_desc, b_desc, i_desc, as_expr(enable_input_d), predicate])
 
 
 def tcgen05_mma_with_tmem_a(
@@ -621,6 +639,7 @@ def tcgen05_mma_with_tmem_a(
     enable_input_d: Expr,
     cta_group: Tcgen05CtaGroupKind,
     mma_kind: Tcgen05MmaKind,
+    predicate: Expr = uint32(1),
 ) -> Expr:
     func_name = resolve_tcgen05_mma(cta_group, mma_kind, a_is_shared=False)
-    return call_primitive_func(func_name, [d_tmem, a_tmem, b_desc, i_desc, enable_input_d])
+    return call_primitive_func(func_name, [d_tmem, a_tmem, b_desc, i_desc, enable_input_d, predicate])

--- a/python/tilus/hidet/lang/transpiler.py
+++ b/python/tilus/hidet/lang/transpiler.py
@@ -72,7 +72,6 @@ from ast import (
     If,
     IfExp,
     In,
-    Index,
     Invert,
     Lambda,
     List,
@@ -85,12 +84,10 @@ from ast import (
     Module,
     Mult,
     Name,
-    NameConstant,
     Nonlocal,
     Not,
     NotEq,
     NotIn,
-    Num,
     Or,
     Pass,
     Pow,
@@ -100,7 +97,6 @@ from ast import (
     Slice,
     Starred,
     Store,
-    Str,
     Sub,
     Subscript,
     Tuple,
@@ -268,13 +264,13 @@ class PythonAstFunctor:
     def visit_Constant(self, expr: Constant):
         raise NotImplementedError()
 
-    def visit_Num(self, expr: Num):
+    def visit_Num(self, expr):
         return self.visit(ast.copy_location(Constant(expr.n), expr))
 
-    def visit_Str(self, expr: Str):
+    def visit_Str(self, expr):
         return self.visit(ast.copy_location(Constant(expr.s), expr))
 
-    def visit_NameConstant(self, expr: NameConstant):
+    def visit_NameConstant(self, expr):
         return self.visit(ast.copy_location(Constant(expr.value), expr))
 
     def visit_Attribute(self, expr: Attribute):
@@ -298,10 +294,10 @@ class PythonAstFunctor:
     def visit_Slice(self, expr: Slice):
         raise NotImplementedError()
 
-    def visit_ExtSlice(self, expr: ExtSlice):
+    def visit_ExtSlice(self, expr):
         raise NotImplementedError()
 
-    def visit_Index(self, expr: Index):
+    def visit_Index(self, expr):
         raise NotImplementedError()
 
     def visit_ListComp(self, expr: ListComp):
@@ -880,7 +876,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
             else_body = else_scope.flush_stmts() if len(stmt.orelse) > 0 else None
             self.current_scope.append(ir.IfStmt(cond=cond, then_body=then_body, else_body=else_body))
 
-    def visit_Index(self, expr: Index):
+    def visit_Index(self, expr):
         return self.visit(expr.value)
 
     def visit_Constant(self, expr: Constant):
@@ -1209,7 +1205,7 @@ class PythonToHidetTranslator(PythonAstFunctor):
     def visit_Starred(self, expr: Starred):
         raise HidetProgramError(self, expr, "Hidet do not support unpack operator.")
 
-    def visit_ExtSlice(self, expr: ExtSlice):
+    def visit_ExtSlice(self, expr):
         return [self.visit(v) for v in expr.dims]
 
     def visit_Slice(self, expr: Slice):

--- a/python/tilus/lang/instructions/tcgen05.py
+++ b/python/tilus/lang/instructions/tcgen05.py
@@ -75,8 +75,11 @@ class Tcgen05InstructionGroup(InstructionGroup):
         self._builder.tcgen05_copy(src, dst)
 
     def commit(self, mbarrier: Expr | RegisterTensor, cta_group: int = 1, multicast_mask: Optional[int] = None) -> None:
-        if self._builder.tg_stack.current_num_threads != 1:
-            raise InstructionError("tcgen05.commit must be called by a single thread")
+        num_threads = self._builder.tg_stack.current_num_threads
+        if num_threads != 32:
+            raise InstructionError(
+                "tcgen05.commit must be called by a warp (32 threads), got {} threads".format(num_threads)
+            )
         self._builder.tcgen05_commit(mbarrier, cta_group, multicast_mask)
 
     def mma(
@@ -131,8 +134,11 @@ class Tcgen05InstructionGroup(InstructionGroup):
         cta_group: int
             The CTA group that executes the MMA operation. Must be either 1 or 2.
         """
-        if self._builder.tg_stack.current_num_threads != 1:
-            raise InstructionError("tcgen05.mma must be called by a single thread")
+        num_threads = self._builder.tg_stack.current_num_threads
+        if num_threads != 32:
+            raise InstructionError(
+                "tcgen05.mma must be called by a warp (32 threads), got {} threads".format(num_threads)
+            )
         if cta_group not in (1, 2):
             raise InstructionError("cta_group must be 1 or 2, got {}".format(cta_group))
         if isinstance(a, SharedTensor):

--- a/python/tilus/utils/__init__.py
+++ b/python/tilus/utils/__init__.py
@@ -16,6 +16,7 @@ from . import stats
 from .bench_utils import benchmark_func
 from .cache_utils import clear_cache
 from .multiprocess import parallel_imap, parallel_map
+from .ncu_utils import ncu_run
 from .py import (
     cdiv,
     floor_log2,

--- a/tests/instructions/test_cluster_launch_control.py
+++ b/tests/instructions/test_cluster_launch_control.py
@@ -75,10 +75,9 @@ class ClusterLaunchControlExample(tilus.Script):
                     self.mbarrier.arrive_and_expect_tx_multicast(
                         consumer_mbarriers[producer_stage], transaction_bytes=16, multicast_mask=self.multicast_mask
                     )
-                    with self.single_thread():
-                        self.clc.try_cancel(
-                            cancel_response[producer_stage], mbarrier=consumer_mbarriers[producer_stage], multicast=True
-                        )
+                    self.clc.try_cancel(
+                        cancel_response[producer_stage], mbarrier=consumer_mbarriers[producer_stage], multicast=True
+                    )
                     producer_stage = (1 + producer_stage) % self.num_stages
                     producer_phase = producer_phase ^ (producer_stage == 0)
 

--- a/tests/instructions/test_copy_async_tensor.py
+++ b/tests/instructions/test_copy_async_tensor.py
@@ -42,8 +42,9 @@ class CopyAsyncTensorExample(tilus.Script):
         load_barrier = self.mbarrier.alloc(counts=1)
         self.sync()
 
-        with self.single_thread():
-            self.mbarrier.arrive_and_expect_tx(load_barrier, transaction_bytes=s_x.nbytes)
+        with self.single_warp():
+            with self.single_thread():
+                self.mbarrier.arrive_and_expect_tx(load_barrier, transaction_bytes=s_x.nbytes)
             self.tma.global_to_shared(
                 src=g_x,
                 dst=s_x,
@@ -60,7 +61,7 @@ class CopyAsyncTensorExample(tilus.Script):
         self.fence.proxy_async()
         self.sync()
 
-        with self.single_thread():
+        with self.single_warp():
             self.tma.shared_to_global(
                 src=s_y,
                 dst=g_y,

--- a/tests/instructions/test_tcgen05_copy.py
+++ b/tests/instructions/test_tcgen05_copy.py
@@ -59,7 +59,7 @@ class TmemCopyExample(tilus.Script):
         self.sync()
 
         # copy x from shared to tmem
-        with self.single_thread():
+        with self.single_warp():
             self.tcgen05.copy(src=s_x, dst=t_x)
             self.tcgen05.commit(mbarrier=barriers[0])
         self.mbarrier.wait(barriers[0], phase=0)

--- a/tests/instructions/test_tcgen05_mma.py
+++ b/tests/instructions/test_tcgen05_mma.py
@@ -58,8 +58,9 @@ class Tcgen05MmaExample(tilus.Script):
         self.sync()
 
         # load a and b from global to shared
-        with self.single_thread():
-            self.mbarrier.arrive_and_expect_tx(tma_mbarrier, transaction_bytes=s_a.nbytes + s_b.nbytes)
+        with self.single_warp():
+            with self.single_thread():
+                self.mbarrier.arrive_and_expect_tx(tma_mbarrier, transaction_bytes=s_a.nbytes + s_b.nbytes)
             self.tma.global_to_shared(
                 src=g_a,
                 dst=s_a,
@@ -75,7 +76,7 @@ class Tcgen05MmaExample(tilus.Script):
         self.mbarrier.wait(tma_mbarrier, phase=0)
 
         # perform mma
-        with self.single_thread():
+        with self.single_warp():
             self.tcgen05.mma(a=s_a, b=s_b.transpose(), d=t_d, enable_input_d=False)
             self.tcgen05.commit(mma_mbarrier)
         self.mbarrier.wait(mma_mbarrier, phase=0)
@@ -159,7 +160,7 @@ class Tcgen05Mma2CTAExample(tilus.Script):
         # load a and b from global to shared
         m_offset = self.mma_m // 2 * cta_rank
         n_offset = self.mma_n // 2 * cta_rank
-        with self.single_thread():
+        with self.single_warp():
             self.tma.global_to_shared(
                 src=g_a,
                 dst=s_a,
@@ -178,7 +179,7 @@ class Tcgen05Mma2CTAExample(tilus.Script):
         # perform mma
         if cta_rank == 0:
             self.mbarrier.wait(tma_mbarrier, phase=0)
-            with self.single_thread():
+            with self.single_warp():
                 self.tcgen05.mma(a=s_a, b=s_b.transpose(), d=t_d, cta_group=2, enable_input_d=False)
                 self.tcgen05.commit(mma_mbarrier, cta_group=2, multicast_mask=0b11)
         self.mbarrier.wait(mma_mbarrier, phase=0)


### PR DESCRIPTION
Several PTX instructions (`tcgen05.mma`, `tcgen05.commit`, `tcgen05.cp`, TMA copy, `clc.try_cancel`) are warp-cooperative at the SASS level — all 32 threads participate and hardware issues a single operation. However, the previous codegen wrapped them in `if (elect_sync()) { asm(...); }` which caused ptxas to emit BSSY/BSYNC divergence pairs around every call.

This change introduces a pre-computed `is_leader_lane` predicate (via elect.sync at kernel start) and passes it directly into the PTX inline asm as `@__pred <instruction>`. This lets ptxas emit predicated instructions without divergent branches.

Before (per warp-cooperative instruction):
```
    ELECT P0, ...
    BSSY.RECONVERGENT B0, skip
    @!P0 BRA skip
    UTMASTG.2D / TCGEN05.MMA / ...
    BSYNC.RECONVERGENT B0
```
After:
```
    @!P0 UTMASTG.2D / TCGEN05.MMA / ...
```

In the matmul_v8 GEMM kernel, this reduces BSSY/BSYNC count from ~50 to 6, with the remaining pairs only in the one-time prologue (barrier init, arrive_and_expect_tx) and the epilogue inter-warp dispatch.