### PR TITLE
[Example] Use relaxed semantics for CLC pipeline barriers in matmul_v8

### DIFF
--- a/examples/blackwell_matmul/matmul_v8.py
+++ b/examples/blackwell_matmul/matmul_v8.py
@@ -118,9 +118,12 @@ class BlackwellMatmulV8(tilus.Script):
         pipe.consumer_acquire()
         response = s_clc_response[pipe.consumer_stage]
         is_valid, new_blockIdx = self.clc.query_response(response)
-        self.fence.proxy_async(space="shared")
         self.mbarrier.arrive_and_expect_tx_remote(
-            pipe.consumer_barrier(), transaction_bytes=0, target_rank=0
+            pipe.consumer_barrier(),
+            transaction_bytes=0,
+            target_rank=0,
+            sem="relaxed",
+            scope="cluster",
         )
         pipe.consumer_advance()
         return is_valid, new_blockIdx
@@ -279,6 +282,8 @@ class BlackwellMatmulV8(tilus.Script):
                         clc_pipe.producer_barrier(),
                         transaction_bytes=16,
                         multicast_mask=0b11,
+                        sem="relaxed",
+                        scope="cluster",
                     )
                     # clc.try_cancel is warp-cooperative: predication handled internally
                     self.clc.try_cancel(


### PR DESCRIPTION
The CLC persistent kernel pipeline uses mbarrier arrives with cluster scope for cross-CTA synchronization (arrive_and_expect_tx_multicast and arrive_and_expect_tx_remote). The default release semantics caused ptxas to emit MEMBAR.ALL.GPU + ERRBAR + CGAERRBAR before each SYNCS.ARRIVE, adding overhead on the hot path of every tile iteration.

Switching to relaxed semantics eliminates these memory ordering instructions, matching nvjet's pattern of bare SYNCS.ARRIVE. This is safe because the SYNCS barrier system provides its own ordering guarantees through the hardware sibling path.

Also removes the unnecessary fence.proxy.async before arrive_and_expect_tx_remote in query_clc_response.