### PR TITLE
[Codegen] Support fast divmod

### DIFF
--- a/examples/blackwell_matmul/matmul_v8.py
+++ b/examples/blackwell_matmul/matmul_v8.py
@@ -104,14 +104,23 @@ class BlackwellMatmulV8(tilus.Script):
     ):
         swizzle_size = self.swizzle_size
         tiles_per_group = num_m_blocks * swizzle_size
-        group_idx = linear_idx // tiles_per_group
-        in_group_idx = linear_idx % tiles_per_group
+        group_idx, in_group_idx = self.fast_divmod(linear_idx, tiles_per_group)
         first_n = group_idx * swizzle_size
-        group_width = num_n_blocks - first_n
-        if group_width > swizzle_size:
-            group_width = swizzle_size
-        m_block = in_group_idx // group_width
-        n_block = first_n + in_group_idx % group_width
+        m_block: int32 = 0
+        n_block: int32 = 0
+        # When num_n_blocks is divisible by swizzle_size, all groups are full and
+        # last_group_width is never used. Use swizzle_size as a safe fallback to
+        # avoid division-by-zero in the precompute.
+        remainder = num_n_blocks - num_n_blocks // swizzle_size * swizzle_size
+        last_group_width = remainder if remainder > 0 else swizzle_size
+        if first_n + swizzle_size <= num_n_blocks:
+            # Full group: swizzle_size is a compile-time constant
+            m_block, r = self.fast_divmod(in_group_idx, swizzle_size)
+            n_block = first_n + r
+        else:
+            # Last group: divisor is num_n_blocks % swizzle_size, which is grid-constant
+            m_block, r = self.fast_divmod(in_group_idx, last_group_width)
+            n_block = first_n + r
         return m_block, n_block
 
     def query_clc_response(self, s_clc_response: SharedTensor, pipe: Pipeline):
@@ -394,3 +403,4 @@ if __name__ == "__main__":
     main(bench=True)
     # main(bench=False)
     # ncu_run(main, bench=False, kernel_regex="tilus|nvjet")
+    # nsys_run(main, bench=True)

--- a/python/tilus/backends/codegen.py
+++ b/python/tilus/backends/codegen.py
@@ -481,23 +481,8 @@ class ProgramCodegen(IRFunctor):
             sub_ir_module = func_codegen(func)
             ir_module = merge_ir_modules([ir_module, sub_ir_module])
 
-        # if there is only one public function, we copy it and generate a function named 'launch', which is used as the
-        # entry point of the module
-        public_functions = [func for func in ir_module.functions.values() if func.kind == "public"]
-
-        if len(public_functions) == 1 and "launch" not in ir_module.functions:
-            public_func: HidetFunction = public_functions[0]
-            ir_module.add_function(
-                name="launch",
-                func=HidetFunction(
-                    name="launch",
-                    params=public_func.params,
-                    body=public_func.body,
-                    ret_type=public_func.ret_type,
-                    kind=public_func.kind,
-                    attrs=public_func.attrs,
-                ),
-            )
+        # The 'launch' entry point is handled by GenerateLaunchFuncPass which runs later
+        # in the optimization pipeline.
         return ir_module
 
 

--- a/python/tilus/drivers.py
+++ b/python/tilus/drivers.py
@@ -134,6 +134,7 @@ def optimize_ir_module(ir_module: IRModule, cache_dir: Path) -> IRModule:
     from tilus.hidet.transforms.instantiate_symbols import instantiate_symbols_pass
     from tilus.hidet.transforms.instruments import PassInstrument, ProfileInstrument, SaveIRInstrument
     from tilus.hidet.transforms.lower_affine_to_recurence import lower_affine_to_recurrence_pass
+    from tilus.hidet.transforms.lower_fast_div import lower_fast_div_pass
     from tilus.hidet.transforms.lower_integer_subbyte import lower_integer_subbyte_pass
     from tilus.hidet.transforms.lower_special_cast import lower_special_cast_pass
     from tilus.hidet.transforms.lower_subbyte_type import lower_subbyte_type_pass
@@ -153,6 +154,7 @@ def optimize_ir_module(ir_module: IRModule, cache_dir: Path) -> IRModule:
         tilus_add_explicit_cast_pass(),
         lower_subbyte_type_pass(),
         generate_launch_func_pass(),
+        lower_fast_div_pass(),
         propagate_launch_bound_pass(),
         flatten_tensor_slice_pass(),
         flatten_tensor_index_pass(),

--- a/python/tilus/hidet/ir/primitives/cuda/fast_divmod.py
+++ b/python/tilus/hidet/ir/primitives/cuda/fast_divmod.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+FastDivmod primitives for replacing integer division with multiply-high + shift.
+
+Two primitive functions are registered:
+
+1. ``fastdiv(a, b)`` — semantic placeholder for ``floor(a / b)`` where a >= 0 and b > 0.
+   A Hidet IR pass (LowerFastDivPass) replaces this with the runtime computation using
+   precomputed magic multiplier and shift.
+
+2. ``fastdiv_runtime(a, multiplier, shift)`` — the actual runtime computation:
+   ``__umulhi(a, multiplier) >> shift``. Emitted on the device side.
+
+Host-side precomputation of (multiplier, shift) is done using plain C functions
+(``fastdiv_precompute_m`` and ``fastdiv_precompute_s``) that run in the launch function.
+"""
+
+from typing import no_type_check
+
+from tilus.hidet.ir.dtypes import uint32, uint64
+from tilus.hidet.ir.expr import Expr
+from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
+from tilus.hidet.ir.stmt import asm
+from tilus.hidet.lang import attrs, script
+from tilus.hidet.utils import initialize
+
+
+@initialize()
+def register_fast_divmod_primitives():
+    @no_type_check
+    @script
+    def cuda_fastdiv(a: uint32, b: uint32) -> uint32:
+        """Semantic placeholder for floor(a / b) where a >= 0 and b > 0.
+
+        This function will be lowered by LowerFastDivPass to use precomputed
+        magic multiplier and shift. It should never survive to codegen.
+        """
+        attrs.func_kind = "cuda_internal"
+        return a / b  # fallback (should be lowered before codegen)
+
+    @no_type_check
+    @script
+    def cuda_fastdiv_runtime(a: uint32, multiplier: uint32, shift: uint32) -> uint32:
+        """Runtime fast division: __umulhi(a, multiplier) >> shift.
+
+        When multiplier == 0, the divisor is a power of 2 and we use a simple shift.
+        This runs on the device.
+        """
+        attrs.func_kind = "cuda_internal"
+        ret: uint32 = 0
+        if multiplier == uint32(0):
+            ret = a >> shift
+        else:
+            asm(
+                template="mul.hi.u32 %0, %1, %2; shr.u32 %0, %0, %3;",
+                outputs=[ret],
+                inputs=[a, multiplier, shift],
+            )
+        return ret
+
+    @no_type_check
+    @script
+    def cuda_fastdiv_precompute_m(b: uint32) -> uint32:
+        """Host-side: compute magic multiplier for divisor b.
+
+        Uses the Hacker's Delight algorithm for unsigned division by constant.
+        For power-of-2 divisors, returns 0 (sentinel) and the runtime uses a simple shift.
+        For non-power-of-2 divisors, finds the smallest p >= 32 such that
+        2^p > nc * (d - 2^p % d), then m = (2^p + d - 2^p % d) / d.
+        """
+        attrs.func_kind = "cpu_internal"
+        # Check power of 2: b & (b - 1) == 0
+        if (b & (b - uint32(1))) == uint32(0):
+            return uint32(0)
+        nc: uint64 = (uint64(1) << uint64(32)) - uint64(1) - uint64((uint64(1) << uint64(32)) % uint64(b))
+        p: uint32 = 32
+        while (uint64(1) << uint64(p)) <= nc * uint64(uint64(b) - (uint64(1) << uint64(p)) % uint64(b)):
+            p = p + uint32(1)
+        m: uint64 = ((uint64(1) << uint64(p)) + uint64(b) - (uint64(1) << uint64(p)) % uint64(b)) / uint64(b)
+        return uint32(m)
+
+    @no_type_check
+    @script
+    def cuda_fastdiv_precompute_s(b: uint32) -> uint32:
+        """Host-side: compute shift for divisor b.
+
+        For power-of-2 divisors, returns log2(b).
+        For non-power-of-2 divisors, returns p - 32 where p is from the Hacker's Delight algorithm.
+        """
+        attrs.func_kind = "cpu_internal"
+        if (b & (b - uint32(1))) == uint32(0):
+            # Power of 2: return log2(b)
+            s: uint32 = 0
+            tmp: uint32 = b >> uint32(1)
+            while tmp > uint32(0):
+                tmp = tmp >> uint32(1)
+                s = s + uint32(1)
+            return s
+        nc: uint64 = (uint64(1) << uint64(32)) - uint64(1) - uint64((uint64(1) << uint64(32)) % uint64(b))
+        p: uint32 = 32
+        while (uint64(1) << uint64(p)) <= nc * uint64(uint64(b) - (uint64(1) << uint64(p)) % uint64(b)):
+            p = p + uint32(1)
+        return p - uint32(32)
+
+    for func in [cuda_fastdiv, cuda_fastdiv_runtime, cuda_fastdiv_precompute_m, cuda_fastdiv_precompute_s]:
+        register_primitive_function(name=func.name, func_or_type=func)
+
+
+def fastdiv(a: Expr, b: Expr) -> Expr:
+    """Semantic floor division: floor(a / b) for a >= 0, b > 0.
+
+    Will be lowered by LowerFastDivPass to use precomputed multiplier and shift.
+    """
+    return call_primitive_func("cuda_fastdiv", args=[a, b])
+
+
+def fastdiv_runtime(a: Expr, multiplier: Expr, shift: Expr) -> Expr:
+    """Runtime fast division using precomputed multiplier and shift (device-side)."""
+    return call_primitive_func("cuda_fastdiv_runtime", args=[a, multiplier, shift])
+
+
+def fastdiv_precompute_m(b: Expr) -> Expr:
+    """Precompute magic multiplier for divisor b (host-side)."""
+    return call_primitive_func("cuda_fastdiv_precompute_m", args=[b])
+
+
+def fastdiv_precompute_s(b: Expr) -> Expr:
+    """Precompute shift amount for divisor b (host-side)."""
+    return call_primitive_func("cuda_fastdiv_precompute_s", args=[b])

--- a/python/tilus/hidet/transforms/generate_launch_func.py
+++ b/python/tilus/hidet/transforms/generate_launch_func.py
@@ -105,15 +105,40 @@ def add_launch_func(ir_module: IRModule, kernel_func: Function):
 class GenerateLaunchFuncPass(Pass):
     def process_module(self, ir_module: IRModule) -> IRModule:
         if any(func.name.startswith("launch") for func in ir_module.functions.values() if func.kind == "public"):
-            # the launch function has already existed
             return ir_module
+
+        # Find existing codegen host functions (public, not "launch")
+        host_funcs = [
+            (name, func)
+            for name, func in ir_module.functions.items()
+            if func.kind == "public" and not name.startswith("launch")
+        ]
+
+        if len(host_funcs) == 1:
+            # Single host function: rename it to "launch" so the runtime can find it.
+            # This avoids creating a duplicate function.
+            old_name, host_func = host_funcs[0]
+            renamed = Function(
+                name="launch",
+                params=host_func.params,
+                body=host_func.body,
+                ret_type=host_func.ret_type,
+                kind=host_func.kind,
+                attrs=host_func.attrs,
+            )
+            del ir_module.functions[old_name]
+            if old_name in ir_module.global_vars:
+                del ir_module.global_vars[old_name]
+            ir_module.add_function("launch", renamed)
+            return ir_module
+
+        # Multiple or no host functions: generate a launch function from the kernel
         kernel_functions: Dict[str, Function] = {
             name: func
             for name, func in ir_module.functions.items()
             if func.kind in ["cuda_kernel", "hip_kernel", "cpu_kernel"]
         }
         if len(kernel_functions) == 0:
-            # no kernel function found in the module, do nothing
             return ir_module
         if len(kernel_functions) > 1:
             raise NotImplementedError("Can only handle one kernel function in a module")

--- a/python/tilus/hidet/transforms/lower_fast_div.py
+++ b/python/tilus/hidet/transforms/lower_fast_div.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Lower fastdiv(a, b) calls to use precomputed magic multiplier and shift.
+
+This pass:
+1. Scans the kernel function for fastdiv(a, b) calls
+2. Checks that b is a grid-constant expression (composed only of kernel parameters and grid dimensions)
+3. For each unique grid-constant b, adds two new kernel parameters (multiplier, shift)
+4. Replaces fastdiv(a, b) with fastdiv_runtime(a, multiplier, shift) in the kernel
+5. Adds host-side precomputation of (multiplier, shift) from b in the launch function
+"""
+
+from typing import Dict, List, Optional, Set, Tuple
+
+from tilus.hidet.ir.dtypes import uint32
+from tilus.hidet.ir.expr import Call, Expr, Var
+from tilus.hidet.ir.func import Function
+from tilus.hidet.ir.functors import IRRewriter
+from tilus.hidet.ir.module import IRModule
+from tilus.hidet.ir.primitives import is_primitive_function
+from tilus.hidet.ir.primitives.cuda.fast_divmod import fastdiv_precompute_m, fastdiv_precompute_s, fastdiv_runtime
+from tilus.hidet.ir.stmt import DeclareStmt, LaunchKernelStmt, LetStmt, SeqStmt
+from tilus.hidet.ir.tools import collect, rewrite
+from tilus.hidet.ir.tools.printer import IRPrinter
+from tilus.hidet.transforms.base import Pass
+
+
+class GridConstantTracker:
+    """Tracks which variables are grid-constant (known at kernel launch time).
+
+    A variable is grid-constant if it is a kernel parameter or is defined as an expression
+    composed entirely of other grid-constant variables.
+    """
+
+    def __init__(self, kernel_params: List[Var]):
+        self.grid_constants: Set[Var] = set(kernel_params)
+        self.var2expr: Dict[Var, Expr] = {p: p for p in kernel_params}
+
+    def bind(self, var: Var, value: Expr) -> None:
+        """Record a variable binding. If the value is grid-constant, mark the variable as grid-constant."""
+        used_vars = collect(value, Var, stop_when_found=True)
+        if all(v in self.grid_constants for v in used_vars):
+            self.grid_constants.add(var)
+            self.var2expr[var] = rewrite(value, self.var2expr)
+
+    def is_grid_constant(self, expr: Expr) -> bool:
+        """Check if an expression is composed entirely of grid-constant variables."""
+        used_vars = collect(expr, Var, stop_when_found=True)
+        return all(v in self.grid_constants for v in used_vars)
+
+    def expand(self, expr: Expr) -> Expr:
+        """Expand an expression by replacing all variables with their grid-constant definitions."""
+        return rewrite(expr, self.var2expr)
+
+
+class FastDivRewriter(IRRewriter):
+    """First pass: collect all fastdiv calls and track grid-constant expressions."""
+
+    def __init__(self, tracker: GridConstantTracker):
+        super().__init__()
+        self.tracker = tracker
+        self.printer = IRPrinter()
+        # Map from expanded grid-constant divisor expression (as string) to (divisor_expr, m_var, s_var)
+        self.divisor_map: Dict[str, Tuple[Expr, Var, Var]] = {}
+        self.found_fastdiv = False
+
+    def visit_DeclareStmt(self, stmt: DeclareStmt):
+        if stmt.init is not None:
+            self.tracker.bind(stmt.var, stmt.init)
+        return IRRewriter.visit_DeclareStmt(self, stmt)
+
+    def visit_LetStmt(self, stmt: LetStmt):
+        for var, value in zip(stmt.bind_vars, stmt.bind_values):
+            self.tracker.bind(var, value)
+        return IRRewriter.visit_LetStmt(self, stmt)
+
+    def visit_Call(self, e: Call):
+        if e.func_var.name == "cuda_fastdiv":
+            self.found_fastdiv = True
+            a, b = e.args
+            # Check b is grid-constant
+            if not self.tracker.is_grid_constant(b):
+                raise ValueError(
+                    "fastdiv divisor must be a grid-constant expression (composed only of kernel "
+                    "parameters and grid dimensions), but got: {}".format(b)
+                )
+            # Expand b to canonical form for dedup
+            expanded_b = self.tracker.expand(b)
+            key = str(self.printer(expanded_b))
+            if key not in self.divisor_map:
+                m_var = Var("fast_div_m", type=uint32)
+                s_var = Var("fast_div_s", type=uint32)
+                self.divisor_map[key] = (expanded_b, m_var, s_var)
+            _, m_var, s_var = self.divisor_map[key]
+            # Replace fastdiv(a, b) with fastdiv_runtime(a, m, s)
+            new_a = self.visit(a)
+            return fastdiv_runtime(new_a, m_var, s_var)
+        return IRRewriter.visit_Call(self, e)
+
+
+class LaunchStmtRewriter(IRRewriter):
+    """Rewrites LaunchKernelStmt to insert precompute stmts and extra args.
+
+    Only rewrites launch statements that target a kernel in the provided mapping.
+    """
+
+    def __init__(self, kernel_launch_info: Dict[str, Tuple[Function, List, List[Var]]]):
+        """
+        Parameters
+        ----------
+        kernel_launch_info : dict
+            Maps kernel func_var name -> (old_kernel, precompute_stmts, extra_launch_args)
+        """
+        super().__init__()
+        self.kernel_launch_info = kernel_launch_info
+
+    def visit_LaunchKernelStmt(self, stmt: LaunchKernelStmt):
+        kernel_name = stmt.func_var.name
+        if kernel_name not in self.kernel_launch_info:
+            return stmt
+        old_kernel, precompute_stmts_template, extra_launch_args_template = self.kernel_launch_info[kernel_name]
+
+        # The launch stmt args correspond to the old kernel's params.
+        # Remap the precompute stmts (which reference kernel params) to use the launch args.
+        param_remap: Dict[Var, Expr] = {kp: arg for kp, arg in zip(old_kernel.params, stmt.args)}
+
+        # Create fresh vars and remap the precompute expressions for this call site
+        precompute_stmts = []
+        extra_launch_args = []
+        for tmpl_stmt, tmpl_arg in zip(precompute_stmts_template, extra_launch_args_template):
+            fresh_var = Var(tmpl_arg.hint, type=tmpl_arg.type)
+            precompute_stmts.append(DeclareStmt(fresh_var, init=rewrite(tmpl_stmt.init, param_remap)))
+            extra_launch_args.append(fresh_var)
+
+        new_launch = LaunchKernelStmt(
+            func_var=stmt.func_var,
+            args=list(stmt.args) + extra_launch_args,
+            grid_dim=stmt.grid_dim,
+            cluster_dim=stmt.cluster_dim,
+            block_dim=stmt.block_dim,
+            shared_mem=stmt.shared_mem_bytes,
+            target=stmt.target,
+        )
+        return SeqStmt(precompute_stmts + [new_launch])
+
+
+class LowerFastDivPass(Pass):
+    def process_module(self, ir_module: IRModule) -> IRModule:
+        kernel_funcs: Dict[str, Function] = {}
+        host_funcs: Dict[str, Function] = {}
+        for name, func in ir_module.functions.items():
+            if func.kind in ("cuda_kernel", "hip_kernel"):
+                kernel_funcs[name] = func
+            elif func.kind == "public":
+                host_funcs[name] = func
+
+        if len(kernel_funcs) == 0:
+            return ir_module
+
+        # Process each kernel independently
+        new_funcs = dict(ir_module.functions)
+        # Maps kernel func_var name -> (old_kernel, precompute_stmts, extra_launch_args)
+        # Used later to rewrite all host functions in a single pass.
+        kernel_launch_info: Dict[str, Tuple[Function, List, List[Var]]] = {}
+
+        for kernel_name, kernel_func in kernel_funcs.items():
+            tracker = GridConstantTracker(kernel_func.params)
+            rewriter = FastDivRewriter(tracker)
+            new_kernel_body = rewriter.visit(kernel_func.body)
+
+            if not rewriter.found_fastdiv:
+                continue
+
+            # Build new kernel params
+            new_kernel_params = list(kernel_func.params)
+            divisor_entries = list(rewriter.divisor_map.values())
+            for _, m_var, s_var in divisor_entries:
+                new_kernel_params.append(m_var)
+                new_kernel_params.append(s_var)
+
+            new_kernel = Function(
+                name=kernel_func.name,
+                params=new_kernel_params,
+                body=new_kernel_body,
+                ret_type=kernel_func.ret_type,
+                kind=kernel_func.kind,
+                attrs=kernel_func.attrs,
+            )
+            new_funcs[kernel_name] = new_kernel
+
+            # Build precompute stmts for host functions
+            precompute_stmts, extra_launch_args = self._build_precompute(kernel_func, divisor_entries)
+            kernel_launch_info[kernel_name] = (kernel_func, precompute_stmts, extra_launch_args)
+
+        if not kernel_launch_info:
+            return ir_module  # no fastdiv found in any kernel
+
+        # Rewrite all host functions in one pass
+        launch_rewriter = LaunchStmtRewriter(kernel_launch_info)
+        for name, func in host_funcs.items():
+            new_body = launch_rewriter.visit(func.body)
+            if new_body is not func.body:
+                new_funcs[name] = Function(
+                    name=func.name,
+                    params=func.params,
+                    body=new_body,
+                    ret_type=func.ret_type,
+                    kind=func.kind,
+                    attrs=func.attrs,
+                )
+
+        return ir_module.copy().reset_funcs(new_funcs, ir_module.global_vars)
+
+    @staticmethod
+    def _build_precompute(
+        old_kernel: Function,
+        divisor_entries: List[Tuple[Expr, Var, Var]],
+    ) -> Tuple[List, List[Var]]:
+        """Build precompute DeclareStmts and extra launch args for a kernel's divisors.
+
+        The precompute stmts use the old kernel's param variables. The LaunchStmtRewriter
+        will place them before each LaunchKernelStmt, where the old kernel's params are
+        in scope (the launch function's params mirror the kernel's params).
+        """
+        precompute_stmts = []
+        extra_launch_args = []
+        for divisor_expr, _, _ in divisor_entries:
+            launch_m = Var("fast_div_m", type=uint32)
+            launch_s = Var("fast_div_s", type=uint32)
+            precompute_stmts.append(DeclareStmt(launch_m, init=fastdiv_precompute_m(divisor_expr)))
+            precompute_stmts.append(DeclareStmt(launch_s, init=fastdiv_precompute_s(divisor_expr)))
+            extra_launch_args.append(launch_m)
+            extra_launch_args.append(launch_s)
+        return precompute_stmts, extra_launch_args
+
+
+def lower_fast_div_pass() -> Pass:
+    return LowerFastDivPass()

--- a/python/tilus/lang/instructions/root.py
+++ b/python/tilus/lang/instructions/root.py
@@ -1736,3 +1736,37 @@ class RootInstructionGroup(InstructionGroup):
         if dst.dtype != src.dtype:
             raise InstructionError("The dtypes of dst and src must match, got {} and {}".format(dst.dtype, src.dtype))
         self._builder.assign_register(dst, src)
+
+    def fast_divmod(self, a: Union[Expr, int], b: Union[Expr, int]) -> tuple:
+        """Fast integer division and modulo using precomputed magic multiplier.
+
+        Computes ``(a // b, a % b)`` for ``a >= 0`` and ``b > 0`` using the
+        FastDivmod algorithm. The divisor ``b`` must be a grid-constant expression
+        (known at kernel launch time). A Hidet IR pass will lower this to
+        ``__umulhi(a, magic) >> shift`` with host-side precomputation of
+        ``(magic, shift)`` from ``b``.
+
+        Parameters
+        ----------
+        a : Expr
+            The dividend (int32, must be >= 0).
+        b : Expr
+            The divisor (int32, must be > 0 and grid-constant).
+
+        Returns
+        -------
+        quotient : Expr
+            floor(a / b)
+        remainder : Expr
+            a % b (computed as a - quotient * b)
+        """
+        from tilus.hidet.ir.primitives.cuda.fast_divmod import fastdiv
+
+        if isinstance(b, Constant):
+            q = a // b
+            r = a % b
+            return q, r
+        else:
+            q = fastdiv(a, b)
+            r = a - q * b
+            return q, r


### PR DESCRIPTION
Integer division on GPU uses a float-reciprocal sequence (I2F, MUFU.RCP, F2I, IMAD) that is ~8 instructions with high latency. For divisors known at kernel launch time (grid-constants), we can precompute a magic multiplier and shift on the host and use a single mul.hi + shift on the device.

This commit adds:
- `self.fast_divmod(a, b)` API at the Script layer returning (q, r)
- `fastdiv` semantic primitive lowered by a new Hidet IR pass
- `LowerFastDivPass` that tracks grid-constant expressions, precomputes (multiplier, shift) on the host, and replaces fastdiv with mul.hi+shr
- Power-of-2 divisor handling (simple shift, no multiply)

Also cleans up duplicate host function generation: `GenerateLaunchFuncPass` now renames the existing codegen host function to "launch" instead of creating a copy, and the redundant launch function creation in `FunctionCodegen` is removed.

In matmul_v8, applying fast_divmod to all divisions in compute_block_coord eliminates all 8 MUFU.RCP instructions from the kernel.