### PR TITLE
[Codegen] Enable more uniform instructions in codegen

### DIFF
--- a/examples/blackwell_matmul/matmul_v8.py
+++ b/examples/blackwell_matmul/matmul_v8.py
@@ -376,10 +376,10 @@ def main(bench=True):
         c_actual = torch.empty(m_size, n_size, dtype=torch.float16, device="cuda")
         c_expected = torch.empty(m_size, n_size, dtype=torch.float16, device="cuda")
 
-        matmul(m_size, n_size, k_size, a, b, c_actual)
+        torch.matmul(a, b.T, out=c_expected)
         torch.cuda.synchronize()
 
-        torch.matmul(a, b.T, out=c_expected)
+        matmul(m_size, n_size, k_size, a, b, c_actual)
         torch.cuda.synchronize()
 
         torch.testing.assert_close(c_actual, c_expected, atol=1e-2, rtol=1e-2)

--- a/python/tilus/backends/emitters/cuda/tcgen05/ldst.py
+++ b/python/tilus/backends/emitters/cuda/tcgen05/ldst.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from tilus.backends.emitter import BaseInstEmitter, register_emitter
 from tilus.hidet.ir.dtypes import int32, uint32
 from tilus.hidet.ir.expr import Expr, cast
+from tilus.hidet.ir.primitives.cuda.elect import shfl_sync_i32
 from tilus.hidet.ir.primitives.cuda.tcgen05 import (
     COLUMN_STRIDE,
     LANE_STRIDE,
@@ -112,8 +113,15 @@ class TMemoryLoadStoreBaseEmitter(BaseInstEmitter):
             regs_buf = self.declare_var(
                 "regs_buf", tp=~uint32, init=cast(~self.get_or_allocate_var(regs_tensor)[0], ~uint32)
             )
+            # Broadcast warp index via shfl so ptxas recognizes it as warp-uniform
+            # and can keep the tmem address in uniform registers (UR).
+            warp_idx = self.declare_var(
+                "warp_idx",
+                tp=int32,
+                init=shfl_sync_i32(uint32(0xFFFFFFFF), self.current_thread // 32, int32(0)),
+            )
             warp_tmem_base_addr = self.declare_var(
-                "warp_tmem_base_addr", tp=~int32, init=tmem_base_addr + self.current_thread // 32 * 32 * LANE_STRIDE
+                "warp_tmem_base_addr", tp=~int32, init=tmem_base_addr + warp_idx * 32 * LANE_STRIDE
             )
 
             with self.for_range(warp_repeat_m, attr="u") as warp_repeat_i:

--- a/python/tilus/hidet/ir/primitives/cuda/fast_divmod.py
+++ b/python/tilus/hidet/ir/primitives/cuda/fast_divmod.py
@@ -30,11 +30,11 @@ Host-side precomputation of (multiplier, shift) is done using plain C functions
 
 from typing import no_type_check
 
-from tilus.hidet.ir.dtypes import uint32, uint64
+from tilus.hidet.ir.dtypes import int32, uint32, uint64
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
 from tilus.hidet.ir.stmt import asm
-from tilus.hidet.lang import attrs, script
+from tilus.hidet.lang import attrs, i32, script, u32
 from tilus.hidet.utils import initialize
 
 
@@ -42,7 +42,7 @@ from tilus.hidet.utils import initialize
 def register_fast_divmod_primitives():
     @no_type_check
     @script
-    def cuda_fastdiv(a: uint32, b: uint32) -> uint32:
+    def cuda_fastdiv(a: i32, b: i32) -> i32:
         """Semantic placeholder for floor(a / b) where a >= 0 and b > 0.
 
         This function will be lowered by LowerFastDivPass to use precomputed
@@ -53,15 +53,17 @@ def register_fast_divmod_primitives():
 
     @no_type_check
     @script
-    def cuda_fastdiv_runtime(a: uint32, multiplier: uint32, shift: uint32) -> uint32:
+    def cuda_fastdiv_runtime(a: i32, multiplier: i32, shift: i32) -> i32:
         """Runtime fast division: __umulhi(a, multiplier) >> shift.
 
         When multiplier == 0, the divisor is a power of 2 and we use a simple shift.
-        This runs on the device.
+        This runs on the device. The operands are int32 to avoid signed/unsigned casts
+        that prevent ptxas from using uniform registers. The asm uses unsigned operations
+        which is correct since a >= 0 and multiplier/shift are bit patterns.
         """
         attrs.func_kind = "cuda_internal"
-        ret: uint32 = 0
-        if multiplier == uint32(0):
+        ret: i32 = 0
+        if multiplier == i32(0):
             ret = a >> shift
         else:
             asm(
@@ -128,7 +130,11 @@ def fastdiv(a: Expr, b: Expr) -> Expr:
 
 
 def fastdiv_runtime(a: Expr, multiplier: Expr, shift: Expr) -> Expr:
-    """Runtime fast division using precomputed multiplier and shift (device-side)."""
+    """Runtime fast division using precomputed multiplier and shift (device-side).
+
+    Takes int32 operands to avoid signed/unsigned casts that prevent ptxas
+    from using uniform registers for block-constant computations.
+    """
     return call_primitive_func("cuda_fastdiv_runtime", args=[a, multiplier, shift])
 
 

--- a/python/tilus/hidet/ir/primitives/cuda/mbarrier.py
+++ b/python/tilus/hidet/ir/primitives/cuda/mbarrier.py
@@ -15,11 +15,11 @@
 # pylint: disable=cell-var-from-loop
 from typing import Union, no_type_check
 
-from tilus.hidet.ir.dtypes import boolean
+from tilus.hidet.ir.dtypes import boolean, int32
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
 from tilus.hidet.ir.stmt import asm
-from tilus.hidet.lang import attrs, script, u32
+from tilus.hidet.lang import attrs, i32, script, u32
 from tilus.hidet.utils import initialize
 
 
@@ -93,7 +93,7 @@ def register_mbarrier_primitives():
 
             @no_type_check
             @script
-            def cuda_mbarrier_wait(mbarrier_addr: u32, phase: u32):
+            def cuda_mbarrier_wait(mbarrier_addr: u32, phase: i32):
                 attrs.func_kind = "cuda_internal"
                 attrs.func_name = func_name
                 ticks = u32(50_000)
@@ -109,7 +109,7 @@ def register_mbarrier_primitives():
     # Legacy primitives (no sem/scope qualifiers) kept for backward compatibility
     @no_type_check
     @script
-    def cuda_mbarrier_wait_shared(mbarrier_addr: u32, phase: u32):
+    def cuda_mbarrier_wait_shared(mbarrier_addr: u32, phase: i32):
         attrs.func_kind = "cuda_internal"
         ticks = u32(50_000)
         asm(
@@ -219,12 +219,12 @@ def mbarrier_init_shared(mbarrier_addr: Expr, arrive_count: Union[int, Expr]) ->
 
 
 def mbarrier_wait_shared(mbarrier_addr: Expr, phase: Union[int, Expr]) -> Expr:
-    return call_primitive_func("cuda_mbarrier_wait_shared", args=[mbarrier_addr, u32(phase)])
+    return call_primitive_func("cuda_mbarrier_wait_shared", args=[mbarrier_addr, int32(phase)])
 
 
 def mbarrier_wait(mbarrier_addr: Expr, phase: Union[int, Expr], sem: str, scope: str) -> Expr:
     func_name = resolve_mbarrier_wait_name(sem, scope)
-    return call_primitive_func(func_name, args=[mbarrier_addr, u32(phase)])
+    return call_primitive_func(func_name, args=[mbarrier_addr, int32(phase)])
 
 
 def mbarrier_arrive(mbarrier_addr: Expr, count: Union[int, Expr], sem: str, scope: str, space: str) -> Expr:

--- a/python/tilus/hidet/transforms/lower_fast_div.py
+++ b/python/tilus/hidet/transforms/lower_fast_div.py
@@ -25,8 +25,8 @@ This pass:
 
 from typing import Dict, List, Optional, Set, Tuple
 
-from tilus.hidet.ir.dtypes import uint32
-from tilus.hidet.ir.expr import Call, Expr, Var
+from tilus.hidet.ir.dtypes import int32, uint32
+from tilus.hidet.ir.expr import Call, Cast, Expr, Var
 from tilus.hidet.ir.func import Function
 from tilus.hidet.ir.functors import IRRewriter
 from tilus.hidet.ir.module import IRModule
@@ -101,8 +101,8 @@ class FastDivRewriter(IRRewriter):
             expanded_b = self.tracker.expand(b)
             key = str(self.printer(expanded_b))
             if key not in self.divisor_map:
-                m_var = Var("fast_div_m", type=uint32)
-                s_var = Var("fast_div_s", type=uint32)
+                m_var = Var("fast_div_m", type=int32)
+                s_var = Var("fast_div_s", type=int32)
                 self.divisor_map[key] = (expanded_b, m_var, s_var)
             _, m_var, s_var = self.divisor_map[key]
             # Replace fastdiv(a, b) with fastdiv_runtime(a, m, s)
@@ -238,10 +238,13 @@ class LowerFastDivPass(Pass):
         precompute_stmts = []
         extra_launch_args = []
         for divisor_expr, _, _ in divisor_entries:
-            launch_m = Var("fast_div_m", type=uint32)
-            launch_s = Var("fast_div_s", type=uint32)
-            precompute_stmts.append(DeclareStmt(launch_m, init=fastdiv_precompute_m(divisor_expr)))
-            precompute_stmts.append(DeclareStmt(launch_s, init=fastdiv_precompute_s(divisor_expr)))
+            launch_m = Var("fast_div_m", type=int32)
+            launch_s = Var("fast_div_s", type=int32)
+            # Precompute functions return uint32; cast to int32 for the kernel params
+            # to keep everything in int32 and avoid signed/unsigned casts that prevent
+            # ptxas from using uniform registers.
+            precompute_stmts.append(DeclareStmt(launch_m, init=Cast(fastdiv_precompute_m(divisor_expr), int32)))
+            precompute_stmts.append(DeclareStmt(launch_s, init=Cast(fastdiv_precompute_s(divisor_expr), int32)))
             extra_launch_args.append(launch_m)
             extra_launch_args.append(launch_s)
         return precompute_stmts, extra_launch_args


### PR DESCRIPTION
- Change mbarrier phase parameter from uint32 to int32 to avoid sign-extension (SHF.L.U32) instructions generated by ptxas
- Change fastdiv primitives from uint32 to int32 so block coordinate computation stays in int32 without int64 promotion, enabling ptxas to use uniform registers (UR) for block-constant expressions
- Use shfl broadcast for warp_tmem_base_addr in tcgen05 load/store emitter so ptxas recognizes the warp index as warp-uniform and keeps the tmem address in UR registers across epilogue iterations