### PR TITLE
[Docs] Fix Sphinx warnings and reorganize the instructions

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Build docs
         run: |
           cd docs
-          make html
+          sphinx-build -W source build/html
 
       - name: Determine version directory
         id: version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Build docs
         run: |
           cd docs
-          make html
+          sphinx-build -W source build/html
 
   test-examples:
     needs: check-changes

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,15 @@ make html
 
 The output will be in `docs/build/html/`. Open `docs/build/html/index.html` in a browser to view.
 
+## Live preview
+
+```bash
+cd docs
+sphinx-autobuild source build/html
+```
+
+Opens a local server at `http://localhost:8000` that auto-rebuilds and refreshes the browser when you edit RST files.
+
 ## Clean build
 
 ```bash

--- a/docs/autobuild.sh
+++ b/docs/autobuild.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Live-preview server for Sphinx documentation using sphinx-autobuild.
+# Rebuilds and refreshes the browser automatically when source files change.
+#
+# Usage:
+#   ./docs/autobuild.sh [--clean] [-- <sphinx-autobuild args>]
+#
+# Options:
+#   --clean   Remove build and generated directories before starting
+#
+# Any arguments after "--" are forwarded to sphinx-autobuild.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$SCRIPT_DIR/source"
+BUILD_DIR="$SCRIPT_DIR/build/html"
+
+CLEAN=0
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --clean)
+            CLEAN=1
+            shift
+            ;;
+        --)
+            shift
+            EXTRA_ARGS=("$@")
+            break
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! command -v sphinx-autobuild &>/dev/null; then
+    echo "Error: sphinx-autobuild not found. Install with: pip install -e \".[dev]\"" >&2
+    exit 1
+fi
+
+if [[ "$CLEAN" -eq 1 ]]; then
+    echo "Cleaning build directory..."
+    rm -rf "$SCRIPT_DIR/build"
+    find "$SOURCE_DIR" -type d -name generated -exec rm -rf {} + 2>/dev/null || true
+fi
+
+exec sphinx-autobuild "$SOURCE_DIR" "$BUILD_DIR" \
+    --watch "$SOURCE_DIR" \
+    --open-browser \
+    "${EXTRA_ARGS[@]}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,3 +64,101 @@ html_css_files = [
     "custom.css",
 ]
 html_permalinks_icon = "<span>¶</span>"
+
+# -- Rewrite autosummary stub titles for instruction groups -------------------
+
+
+def _build_instruction_group_map():
+    """Auto-extract the class-name -> attribute-name mapping from InstructionInterface."""
+    from tilus.lang.instructions import InstructionInterface
+    from tilus.lang.instructions.base import InstructionGroup
+
+    return {
+        type(obj).__name__: attr_name
+        for attr_name, obj in vars(InstructionInterface).items()
+        if isinstance(obj, InstructionGroup)
+    }
+
+
+_INSTRUCTION_GROUP_MAP = _build_instruction_group_map()
+
+
+def _rewrite_autosummary_title(app, docname, source):
+    """Rewrite page titles of auto-generated stubs.
+
+    The ``source-read`` event fires after autosummary generates stubs but
+    before Sphinx parses them, so we can rewrite the RST title in-place.
+
+    - ``tilus.Script.abs`` → ``Script.abs``
+    - ``tilus.lang.instructions.mbarrier.BarrierInstructionGroup.arrive`` →
+      ``Script.mbarrier.arrive``
+    """
+    import re
+
+    # Instruction group members: BarrierInstructionGroup.X -> Script.mbarrier.X
+    for cls_name, group_name in _INSTRUCTION_GROUP_MAP.items():
+        if cls_name + "." in docname:
+            member = docname.rsplit(".", 1)[-1]
+            new_title = f"Script.{group_name}.{member}"
+            source[0] = re.sub(
+                r"^.*?\n=+\n",
+                new_title + "\n" + "=" * len(new_title) + "\n",
+                source[0],
+                count=1,
+            )
+            return
+
+    # Script members: tilus.Script.abs -> Script.abs
+    prefix = "tilus.Script."
+    if prefix in docname:
+        short_name = docname.rsplit(".", 1)[-1]
+        new_title = f"Script.{short_name}"
+        source[0] = re.sub(
+            r"^.*?\n=+\n",
+            new_title + "\n" + "=" * len(new_title) + "\n",
+            source[0],
+            count=1,
+        )
+        return
+
+
+def _rewrite_instruction_group_signatures(app, doctree, docname):
+    """Rewrite instruction group names in rendered signatures.
+
+    - Class signatures: ``class tilus.lang.instructions.mbarrier.BarrierInstructionGroup``
+      → ``class Script.mbarrier``
+    - Method signatures: ``BarrierInstructionGroup.arrive(...)``
+      → ``Script.mbarrier.arrive(...)``
+    """
+    from docutils import nodes
+
+    for node in doctree.findall(nodes.Element):
+        if node.tagname == "desc_addname":
+            text = node.astext()
+            for cls_name, group_name in _INSTRUCTION_GROUP_MAP.items():
+                if cls_name in text:
+                    new_text = text.replace(cls_name, f"Script.{group_name}")
+                    node.clear()
+                    node += nodes.Text(new_text)
+                    break
+        elif node.tagname == "desc" and node.get("objtype") == "class":
+            # Check if this is an instruction group class
+            for sig in node.findall(nodes.Element):
+                if sig.tagname != "desc_signature":
+                    continue
+                for name_node in sig.findall(nodes.Element):
+                    if name_node.tagname == "desc_name" and name_node.astext() in _INSTRUCTION_GROUP_MAP:
+                        # Replace the desc node with a container holding just the docstring
+                        for content in node.findall(nodes.Element):
+                            if content.tagname == "desc_content":
+                                wrapper = nodes.container()
+                                wrapper.extend(content.children)
+                                node.replace_self(wrapper)
+                                break
+                        break
+                break
+
+
+def setup(app):
+    app.connect("source-read", _rewrite_autosummary_title)
+    app.connect("doctree-resolved", _rewrite_instruction_group_signatures)

--- a/docs/source/programming-guides/instructions.rst
+++ b/docs/source/programming-guides/instructions.rst
@@ -43,25 +43,6 @@ Asynchronous Copy (SM80+)
    copy_async_wait_group
    copy_async_wait_all
 
-
-Bulk Asynchronous Copy (SM90+)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-
-   copy_async_bulk_global_to_shared
-   copy_async_bulk_global_to_cluster_shared
-   copy_async_bulk_shared_to_global
-
-TMA Asynchronous Copy (SM90+)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-
-   copy_async_tensor_global_to_shared
-   copy_async_tensor_shared_to_global
-   copy_async_tensor_commit_group
-   copy_async_tensor_wait_group
-   fence_proxy_copy_async
-
 Linear Algebra
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -106,16 +87,6 @@ Reduction
    sum
 
 
-Barrier
-~~~~~~~
-
-.. autosummary::
-
-   init_barrier
-   arrive_barrier
-   arrive_remote_barrier
-   wait_barrier
-
 Atomic and Semaphore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -142,3 +113,22 @@ Miscellaneous
    annotate_layout
    print_tensor
    printf
+
+
+Barrier
+~~~~~~~
+
+.. currentmodule:: tilus.lang.instructions.mbarrier.BarrierInstructionGroup
+
+.. autosummary::
+
+   alloc
+   arrive
+   arrive_and_expect_tx
+   arrive_and_expect_tx_multicast
+   arrive_and_expect_tx_remote
+   wait
+   consumer_initial_phase
+   producer_initial_phase
+
+.. currentmodule:: tilus.Script

--- a/docs/source/programming-guides/layout-system/register-layout.rst
+++ b/docs/source/programming-guides/layout-system/register-layout.rst
@@ -318,7 +318,7 @@ We can treat layouts as a special kind of tensors, where each element in the lay
 locations with the element. We have a list of operations that can be performed on layouts to transform the layouts. All of them are defined
 under the :py:mod:`tilus.ir.layout` module. Here is a list of the operations:
 
-.. currentmodule:: tilus.ir.layout
+.. currentmodule:: tilus.ir.layout.ops
 
 Layout Creation
 ~~~~~~~~~~~~~~~

--- a/docs/source/programming-guides/layout-system/shared-layout.rst
+++ b/docs/source/programming-guides/layout-system/shared-layout.rst
@@ -14,9 +14,9 @@ We support the following functions to create a global layout:
 
 .. autosummary::
 
-    tilus.ir.layout.shared_row_major
-    tilus.ir.layout.shared_column_major
-    tilus.ir.layout.shared_compose
+    tilus.ir.layout.ops.shared_row_major
+    tilus.ir.layout.ops.shared_column_major
+    tilus.ir.layout.ops.shared_compose
     tilus.ir.SharedLayout.create
 
 Please refer to the :py:class:`~tilus.ir.SharedLayout` class for internals of the shared layout.

--- a/docs/source/programming-guides/overview.rst
+++ b/docs/source/programming-guides/overview.rst
@@ -50,4 +50,3 @@ explore the following sections:
 - :doc:`control-flow`
 - :doc:`cache`
 - :doc:`autotuning`
-- :doc:`low-precision-support`

--- a/docs/source/python-api/instruction-groups/fence.rst
+++ b/docs/source/python-api/instruction-groups/fence.rst
@@ -1,0 +1,18 @@
+Script.fence
+============
+
+.. currentmodule:: tilus.lang.instructions.fence
+
+.. autoclass:: FenceInstructionGroup
+   :no-autosummary:
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.fence.FenceInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   proxy_async
+   proxy_async_release

--- a/docs/source/python-api/instruction-groups/mbarrier.rst
+++ b/docs/source/python-api/instruction-groups/mbarrier.rst
@@ -1,0 +1,33 @@
+Script.mbarrier
+===============
+
+.. currentmodule:: tilus.lang.instructions.mbarrier
+
+.. autoclass:: BarrierInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.mbarrier.BarrierInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   alloc
+   arrive
+   arrive_and_expect_tx
+   arrive_and_expect_tx_multicast
+   arrive_and_expect_tx_remote
+   wait
+
+.. rubric:: Attributes
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   producer_initial_phase
+   consumer_initial_phase

--- a/docs/source/python-api/tilus-ir/register_layout.rst
+++ b/docs/source/python-api/tilus-ir/register_layout.rst
@@ -9,7 +9,7 @@ tilus.ir.RegisterLayout
 Register Layout Operations
 --------------------------
 
-.. currentmodule:: tilus.ir.layout
+.. currentmodule:: tilus.ir.layout.ops
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/python-api/tilus-ir/shared_layout.rst
+++ b/docs/source/python-api/tilus-ir/shared_layout.rst
@@ -3,7 +3,7 @@ tilus.ir.SharedLayout
 
 
 .. autoclass:: tilus.ir.SharedLayout
-   :members: shape, size, axes, offset, __call__, create
+   :members: shape, __call__, create
    :exclude-members: __init__, __new__
 
 Shared Layout Creation
@@ -11,7 +11,7 @@ Shared Layout Creation
 
 We can use the following functions to create a shared layout:
 
-.. currentmodule:: tilus.ir.layout
+.. currentmodule:: tilus.ir.layout.ops
 
 .. autosummary::
     :toctree: generated/

--- a/docs/source/python-api/tilus-option.rst
+++ b/docs/source/python-api/tilus-option.rst
@@ -7,4 +7,4 @@ tilus.option
     tilus.option.cache_dir
     tilus.option.parallel_workers
     tilus.option.debug.dump_ir
-    tilus.option.debug.launch_blocking
+    tilus.option.debug.disable_ptxas_opt

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -56,22 +56,12 @@ Instructions
    abs
    add
    annotate_layout
-   arrive_barrier
-   arrive_remote_barrier
    assign
    cast
    copy_async
    copy_async_commit_group
    copy_async_wait_all
    copy_async_wait_group
-   copy_async_bulk_global_to_shared
-   copy_async_bulk_global_to_cluster_shared
-   copy_async_bulk_shared_to_global
-   copy_async_tensor_global_to_shared
-   copy_async_tensor_shared_to_global
-   copy_async_tensor_commit_group
-   copy_async_tensor_wait_group
-   fence_proxy_copy_async
    cluster_sync
    dot
    exp
@@ -79,7 +69,6 @@ Instructions
    free_shared
    global_tensor
    global_view
-   init_barrier
    load_global
    load_shared
    lock_semaphore
@@ -102,8 +91,17 @@ Instructions
    transpose
    unsqueeze
    view
-   wait_barrier
    where
+
+
+Instruction Groups
+------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   instruction-groups/mbarrier
+   instruction-groups/fence
 
 
 Script Attributes
@@ -113,10 +111,14 @@ Script Attributes
 
 .. class:: Attributes
 
-.. currentmodule:: tilus.lang.Attributes
+   The ``attrs`` object on a :class:`~tilus.Script` instance is used to set kernel launch configuration.
 
-.. autosummary::
-   :toctree: generated
+   .. attribute:: blocks
+      :type: list[int]
 
-   blocks
-   warps
+      The grid dimensions of the kernel launch. Set as a list of up to 3 integers, e.g., ``self.attrs.blocks = [grid_x, grid_y]``.
+
+   .. attribute:: warps
+      :type: int
+
+      The number of warps per thread block. Must be a compile-time constant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,10 @@ dev = [
 
     # for documentation
     "jinja2",
-    "sphinx",
-    "sphinx-copybutton",
-    "autodocsumm",
+    "sphinx==8.1.3",
+    "sphinx-autobuild==2024.10.3",
+    "sphinx-copybutton==0.5.2",
+    "autodocsumm==0.2.14",
     "sphinx-book-theme==1.1.4",
     "matplotlib",
 ]


### PR DESCRIPTION
- Fix all 97 Sphinx build warnings and add -W flag to fail CI on warnings
- Add manual RST pages for mbarrier and fence instruction groups under python-api/instruction-groups/ with autoclass + autosummary for methods
- Add Sphinx hooks in conf.py to rewrite auto-generated page titles (tilus.Script.abs -> Script.abs, BarrierInstructionGroup.arrive -> Script.mbarrier.arrive) and method signature prefixes
- Auto-extract instruction group mapping from InstructionInterface so no manual updates needed when adding new groups
- Add autobuild.sh script for live-preview sphinx-autobuild workflow