### PR TITLE
[Docs] Add instruction documentation and revise programming guides

### DIFF
--- a/.claude/skills/write-docs/SKILL.md
+++ b/.claude/skills/write-docs/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: write-docs
+description: >
+  Convention and format for writing instruction docstrings in
+  python/tilus/lang/instructions/. TRIGGER when: user asks to add, update, or
+  write documentation for tilus instructions or instruction groups.
+  DO NOT TRIGGER when: user is working on Sphinx RST files or non-instruction docs.
+---
+
+# Writing Instruction Documentation
+
+## Docstring Format
+
+All instruction docstrings use **NumPy-style** format with the following structure:
+
+```python
+def method_name(self, param1: Type1, param2: Type2) -> ReturnType:
+    """One-line summary of what the instruction does.
+
+    Extended description explaining the behavior, semantics, and constraints
+    of the instruction. This can be multiple paragraphs.
+
+    Parameters
+    ----------
+    param1: Type1
+        Description of the parameter. Include constraints and valid ranges
+        (e.g., "must be evaluated to a positive int32").
+    param2: Type2
+        Description. For parameters with defaults, explain the default behavior
+        (e.g., "By default, it is 1.").
+
+    Returns
+    -------
+    ret: ReturnType
+        Description of the return value including shape, dtype, and relationship
+        to inputs.
+    """
+```
+
+## Conventions
+
+### Summary line
+- Start with a verb: "Allocate...", "Arrive at...", "Compute the...", "Load...", "Wait at..."
+- Keep it to one line
+
+### Extended description
+- Explain what the instruction does at the hardware level when relevant
+- Document state transitions (e.g., barrier phase switching)
+- Describe relationships between parameters
+- Explain multicast/cluster behavior for distributed instructions
+- Scale detail to complexity: simple methods (load, cast) need minimal description; complex methods (mbarrier.alloc, tma.global_to_shared) need thorough explanation
+
+### Parameters section
+- Document in the same order as the function signature
+- Use full type annotations: `RegisterTensor`, `Expr | int`, `Optional[Type]`
+- Include constraints: "must be in the range of [0, N)", "must be evaluated to a non-negative int32"
+- Document valid candidates for string parameters: `Candidates: 'relaxed', 'release'.`
+- Explain default values: "By default, it is 1."
+
+### Returns section
+- Use `ret: Type` format
+- Describe shape, dtype, and semantic meaning
+
+### Notes section (required)
+Every instruction must have a Notes section with these items as a compact bullet list:
+
+```python
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``mbarrier.init.shared::cta.b64``
+```
+
+The three standard note items:
+
+- **Thread group**: Execution requirements. Common values:
+  - "Can be executed by any sized thread group."
+  - "Must be executed by a warp group (4 warps)."
+  - "Must be executed by a single thread (use ``self.single_thread()``)."
+  - "Must be executed by a single warp (use ``self.single_warp()`)"
+- **Hardware**: Minimum compute capability. Format: "Requires compute capability X.Y+ (sm_XY)."
+  - sm_80 = Ampere (A100), sm_89 = Ada Lovelace (L4/L40), sm_90 = Hopper (H100), sm_100 = Blackwell (B200)
+- **PTX**: The underlying PTX instruction(s) this maps to. Use double backticks for inline code.
+  If the instruction maps to multiple PTX instructions depending on parameters, list them:
+  ```
+  - **PTX**: ``mbarrier.arrive.shared::cta.b64`` or ``mbarrier.arrive.noComplete.shared::cta.b64``
+  ```
+  If the instruction does not lower to a specific PTX instruction (e.g., it's a high-level
+  construct), omit the PTX line.
+
+### Other optional sections
+- **Examples**: Use `.. code-block:: python` for usage examples
+- **See Also**: Cross-reference related methods with `:py:meth:` or `:py:func:`
+
+### Memory ordering parameters
+For synchronization instructions, document `sem` and `scope` parameters consistently:
+```python
+sem: str
+    The memory ordering semantics for the operation. Candidates: 'relaxed', 'release'.
+scope: str
+    The synchronization scope for the operation. Candidates: 'cta', 'cluster'.
+```
+
+## Reference examples
+- Simple instruction: `root.py:load_global`, `root.py:cast`
+- Complex instruction: `mbarrier.py:alloc`, `mbarrier.py:arrive_and_expect_tx`
+- With PTX reference: `fence.py:proxy_async`, `fence.py:proxy_async_release`
+- With code example: `root.py:range`, `root.py:thread_group`
+- TMA instruction: `tma.py:global_to_shared`

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,6 +57,8 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update && apt-get install -y git cmake nodejs software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
@@ -66,10 +68,21 @@ jobs:
             python3.13 python3.13-venv python3.13-dev
 
       - name: Mark repo as safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run smoke tests across Python versions
+        shell: bash
         run: |
+          # Derive version from git so setuptools-scm doesn't need git access during build
+          export SETUPTOOLS_SCM_PRETEND_VERSION=$(python3.10 -c "
+          from setuptools_scm import get_version
+          print(get_version())
+          " 2>/dev/null || git describe --tags --always 2>/dev/null || echo "0.0.0")
+
+          echo "Using version: $SETUPTOOLS_SCM_PRETEND_VERSION"
+
           for pyver in 3.10 3.11 3.12 3.13; do
             echo "========================================="
             echo "Testing Python $pyver"
@@ -77,12 +90,10 @@ jobs:
             python${pyver} -m venv /tmp/venv-${pyver}
             source /tmp/venv-${pyver}/bin/activate
             pip install --upgrade pip
-            pip install build
-            python -m build .
-            pip install dist/*.whl[dev]
+            pip install ".[dev]"
             pytest tests/kernels/matmul/test_matmul_v2.py -v
             deactivate
-            rm -rf /tmp/venv-${pyver} dist/
+            rm -rf /tmp/venv-${pyver}
           done
 
   test-core:

--- a/docs/serve.sh
+++ b/docs/serve.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Serve the built documentation locally.
+# Usage: ./docs/serve.sh [port]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HTML_DIR="$SCRIPT_DIR/build/html"
+PORT="${1:-8000}"
+
+if [ ! -d "$HTML_DIR" ]; then
+    echo "Error: $HTML_DIR does not exist. Run 'make html' first." >&2
+    exit 1
+fi
+
+echo "Serving docs at http://localhost:$PORT"
+python3 -m http.server "$PORT" --directory "$HTML_DIR"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,6 +108,18 @@ def _rewrite_autosummary_title(app, docname, source):
             )
             return
 
+    # Attributes members: Attributes.blocks -> Script.attrs.blocks
+    if "Attributes." in docname:
+        member = docname.rsplit(".", 1)[-1]
+        new_title = f"Script.attrs.{member}"
+        source[0] = re.sub(
+            r"^.*?\n=+\n",
+            new_title + "\n" + "=" * len(new_title) + "\n",
+            source[0],
+            count=1,
+        )
+        return
+
     # Script members: tilus.Script.abs -> Script.abs
     prefix = "tilus.Script."
     if prefix in docname:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,7 @@ def _rewrite_autosummary_title(app, docname, source):
     prefix = "tilus.Script."
     if prefix in docname:
         short_name = docname.rsplit(".", 1)[-1]
+
         new_title = f"Script.{short_name}"
         source[0] = re.sub(
             r"^.*?\n=+\n",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Additional features include automatic tuning, caching, and a Pythonic interface 
    :maxdepth: 1
    :caption: Live Demos
 
-   Layout Demo <https://nvidia.github.io/tilus/_static/layout-demo/index.html>
+   Layout Demo <https://nvidia.github.io/tilus/latest/_static/layout-demo/index.html>
 
 .. toctree::
    :maxdepth: 1
@@ -45,5 +45,6 @@ Additional features include automatic tuning, caching, and a Pythonic interface 
 
    python-api/tilus
    python-api/tilus-option
+   python-api/tilus-target
    python-api/tilus-script
    python-api/tilus-ir/__index__

--- a/docs/source/programming-guides/instructions.rst
+++ b/docs/source/programming-guides/instructions.rst
@@ -1,11 +1,19 @@
 Instructions
 ============
 
-Tilus provides a set of instructions for working with tensors maintained by the thread block. These instructions allow
-you to create, copy, and compute tensors in global, shared, and register memory.
+Tilus provides a set of instructions for writing GPU kernels. Instructions are available as methods
+on the :class:`~tilus.Script` class and are called within the ``__call__`` method of a script.
 
-Tensor Creation and Free
-~~~~~~~~~~~~~~~~~~~~~~~~
+Instructions fall into two categories:
+
+- **Generic instructions** (``self.<instruction>``) — common operations available on all GPUs, such as
+  tensor creation, load/store, arithmetic, and synchronization.
+- **Instruction groups** (``self.<group>.<instruction>``) — specialized hardware-specific operations
+  organized by the hardware unit they target, such as TMA, WGMMA, and TCGEN05.
+
+
+Generic Instructions
+--------------------
 
 .. hint::
    :class: margin
@@ -14,17 +22,29 @@ Tensor Creation and Free
 
 .. currentmodule:: tilus.Script
 
+
+Tensor Creation and Free
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create and manage tensors in register, shared, and global memory. Register tensors hold per-thread
+data, shared tensors are visible to all threads in a block, and global tensors are accessible by all
+blocks.
+
 .. autosummary::
 
-   global_view
    register_tensor
    shared_tensor
    global_tensor
+   global_view
    free_shared
+   reshape_shared
 
 
 Load and Store
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
+
+Transfer data between memory spaces. Load instructions copy data from global or shared memory into
+register tensors; store instructions write register data back.
 
 .. autosummary::
 
@@ -35,7 +55,12 @@ Load and Store
 
 
 Asynchronous Copy (SM80+)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Copy data from global to shared memory asynchronously using the ``cp.async`` hardware path.
+Operations are grouped with ``copy_async_commit_group`` and waited on with ``copy_async_wait_group``.
+For Hopper+ GPUs, prefer ``tma.global_to_shared`` which uses the TMA engine.
+
 .. autosummary::
 
    copy_async
@@ -43,80 +68,127 @@ Asynchronous Copy (SM80+)
    copy_async_wait_group
    copy_async_wait_all
 
+
 Linear Algebra
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
+
+Matrix multiplication using tensor cores. The ``dot`` instruction automatically selects the
+appropriate MMA instruction based on the data types and GPU architecture. For explicit control
+over Hopper or Blackwell tensor cores, use ``wgmma.mma`` or ``tcgen05.mma`` instead.
 
 .. autosummary::
 
    dot
 
+
 Elementwise Arithmetic
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
+
+Per-element unary and binary operations on register tensors. All elementwise operations support
+an optional ``out`` parameter to write results into an existing tensor, and binary operations
+support NumPy-style broadcasting.
 
 .. autosummary::
 
+   abs
    add
+   clip
    exp
    exp2
-   abs
+   log
    maximum
    round
+   rsqrt
+   sqrt
+   square
    where
 
-Transform
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-
-   assign
-   cast
-   squeeze
-   unsqueeze
-   repeat
-   repeat_interleave
-   view
-   transpose
 
 Reduction
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~
+
+Reduce a register tensor along one or more dimensions. Each reduction supports ``dim`` to specify
+which dimensions to reduce, ``keepdim`` to preserve the reduced dimension with size 1, and ``out``
+for in-place output.
 
 .. autosummary::
 
+   all
+   any
    max
    min
    sum
 
 
-Atomic and Semaphore
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Transform
+~~~~~~~~~
+
+Reshape, reinterpret, or rearrange register tensor data without changing the underlying values.
 
 .. autosummary::
 
-    lock_semaphore
-    release_semaphore
+   assign
+   cast
+   repeat
+   repeat_interleave
+   squeeze
+   transpose
+   unsqueeze
+   view
+
 
 Synchronization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
+
+Synchronize threads within a block or across a cluster. ``sync`` is the block-level barrier
+(equivalent to ``__syncthreads()``). For cluster-wide synchronization, use ``self.cluster.sync()``.
 
 .. autosummary::
 
    sync
-   cluster_sync
+
+
+Atomic and Semaphore
+~~~~~~~~~~~~~~~~~~~~
+
+Inter-block synchronization using global memory semaphores. ``lock_semaphore`` spins until the
+semaphore reaches a target value; ``release_semaphore`` sets it to signal other blocks. Both
+must be called from a single thread (``self.single_thread()``).
+
+.. autosummary::
+
+   lock_semaphore
+   release_semaphore
 
 
 Miscellaneous
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
+
+Compiler hints, debugging aids, and layout annotations.
 
 .. autosummary::
 
    assume
+   static_assert
    annotate_layout
+   fast_divmod
    print_tensor
    printf
 
 
-Barrier
-~~~~~~~
+Instruction Groups
+------------------
+
+Instruction groups provide access to specialized hardware units. Each group is accessed as an
+attribute of the script (e.g., ``self.tma.global_to_shared(...)``).
+
+
+Memory Barrier (``self.mbarrier``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mbarriers are synchronization primitives in shared memory that track pending arrivals and
+asynchronous transaction bytes (tx-count). They coordinate producer-consumer patterns in pipelined
+kernels, particularly with TMA and TCGEN05 async operations. See :doc:`../python-api/instruction-groups/mbarrier`.
 
 .. currentmodule:: tilus.lang.instructions.mbarrier.BarrierInstructionGroup
 
@@ -128,7 +200,124 @@ Barrier
    arrive_and_expect_tx_multicast
    arrive_and_expect_tx_remote
    wait
-   consumer_initial_phase
-   producer_initial_phase
+
+.. currentmodule:: tilus.Script
+
+
+Fence (``self.fence``)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Proxy fences ensure memory ordering between different memory access paths (generic proxy vs.
+async proxy). Required when generic writes (e.g., ``store_shared``) must be visible to async
+reads (e.g., ``tma.shared_to_global``). See :doc:`../python-api/instruction-groups/fence`.
+
+.. currentmodule:: tilus.lang.instructions.fence.FenceInstructionGroup
+
+.. autosummary::
+
+   proxy_async
+   proxy_async_release
+
+.. currentmodule:: tilus.Script
+
+
+TMA (``self.tma``)
+~~~~~~~~~~~~~~~~~~
+
+The Tensor Memory Accelerator (TMA) on Hopper+ GPUs performs asynchronous bulk data transfers
+between global and shared memory without occupying SM compute resources. Completion is tracked
+via mbarriers. See :doc:`../python-api/instruction-groups/tma`.
+
+.. currentmodule:: tilus.lang.instructions.tma.TmaInstructionGroup
+
+.. autosummary::
+
+   global_to_shared
+   shared_to_global
+   commit_group
+   wait_group
+
+.. currentmodule:: tilus.Script
+
+
+WGMMA (``self.wgmma``)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Warp Group Matrix Multiply-Accumulate on Hopper GPUs. Executes asynchronous MMA using a warp group
+(4 warps, 128 threads) with operands in shared memory or registers. Requires a strict
+fence → mma → commit → wait protocol. See :doc:`../python-api/instruction-groups/wgmma`.
+
+.. currentmodule:: tilus.lang.instructions.wgmma.WgmmaInstructionGroup
+
+.. autosummary::
+
+   fence
+   commit_group
+   wait_group
+   mma
+
+.. currentmodule:: tilus.Script
+
+
+TCGEN05 (``self.tcgen05``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tensor Core Generation 05 on Blackwell GPUs. Introduces tensor memory (TMEM) — a dedicated
+on-chip accumulator space for MMA operations. Supports the full TMEM lifecycle: allocation,
+data movement (load/store/copy), MMA compute, and deallocation. See :doc:`../python-api/instruction-groups/tcgen05`.
+
+.. currentmodule:: tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup
+
+.. autosummary::
+
+   alloc
+   dealloc
+   slice
+   view
+   relinquish_alloc_permit
+   load
+   store
+   wait_load
+   wait_store
+   copy
+   commit
+   mma
+
+.. currentmodule:: tilus.Script
+
+
+Cluster (``self.cluster``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Block cluster operations for multi-CTA coordination on Hopper+ GPUs. Provides cluster-wide
+synchronization, introspection (block index/rank within the cluster), and cross-CTA shared memory
+addressing. See :doc:`../python-api/instruction-groups/cluster`.
+
+.. currentmodule:: tilus.lang.instructions.cluster.BlockClusterInstructionGroup
+
+.. autosummary::
+
+   sync
+   map_shared_addr
+   blockIdx
+   blockRank
+   clusterDim
+
+.. currentmodule:: tilus.Script
+
+
+CLC (``self.clc``)
+~~~~~~~~~~~~~~~~~~
+
+Cluster Launch Control on Blackwell GPUs enables dynamic work scheduling by canceling
+not-yet-launched clusters. A scheduler CTA requests cancellation, then queries the result to
+take over the canceled cluster's work. See :doc:`../python-api/instruction-groups/clc`.
+
+.. currentmodule:: tilus.lang.instructions.clc.ClusterLaunchControlInstructionGroup
+
+.. autosummary::
+
+   try_cancel
+   query_response
 
 .. currentmodule:: tilus.Script

--- a/docs/source/programming-guides/thread-group.rst
+++ b/docs/source/programming-guides/thread-group.rst
@@ -1,163 +1,172 @@
 Thread Group
 ============
 
-In Tilus Script, you can partition the threads in a thread block into smaller **thread groups** and define instructions that execute only within specific thread groups. This provides fine-grained control over thread execution and enables efficient parallel programming patterns.
-
-Overview
---------
-
-At the root level of a kernel, there is one thread group that includes all threads in the thread block. Using the ``thread_group`` context manager, you can:
-
-- Partition threads into multiple sub-groups
-- Execute instructions on specific thread groups only
-- Create nested thread group hierarchies
-- Synchronize threads within a group
-
-The ``thread_group`` Context Manager
-------------------------------------
-
-**Syntax:**
+In a GPU kernel, all threads in a thread block execute the same code. But in practice, different
+threads often need to do different things — one warp loads data while another computes, or a single
+thread updates a barrier while the rest wait. **Thread groups** let you partition threads within a
+block and assign different work to each partition.
 
 .. code-block:: python
 
-    with self.thread_group(thread_begin, num_threads):
-        # Instructions executed by threads in the specified thread group
+    def __call__(self, ...):
+        self.attrs.warps = 4  # 128 threads total
+
+        # All 128 threads execute this
+        acc = self.register_tensor(dtype=float32, shape=[64, 64], init=0.0)
+
+        with self.thread_group(thread_begin=0, num_threads=32):
+            # Only threads 0–31 (one warp) execute this
+            self.tma.global_to_shared(...)
+
+        with self.thread_group(thread_begin=32, num_threads=32):
+            # Only threads 32–63 execute this
+            self.tcgen05.mma(...)
+
+        # All 128 threads execute this again
+        self.sync()
+
+
+Why Thread Groups?
+------------------
+
+Thread groups serve three purposes:
+
+1. **Hardware requirements** — Some instructions require a specific number of threads. TMA operations
+   need a warp-aligned group (32 threads). WGMMA needs a full warp group (128 threads). Mbarrier
+   arrive/expect-tx-multicast needs at least 16 threads. Semaphore operations need exactly one thread.
+
+2. **Parallel pipelines** — In high-performance kernels, you often want one set of threads loading
+   data while another set computes. Thread groups let you express this naturally.
+
+3. **Avoiding redundant work** — Operations like barrier signaling or TMA setup only need one thread.
+   Running them on all threads wastes cycles and can cause incorrect behavior (e.g., decrementing
+   a barrier count 128 times instead of once).
+
+
+The ``thread_group`` Context Manager
+-------------------------------------
+
+The core API is ``self.thread_group(thread_begin, num_threads)``:
+
+.. code-block:: python
+
+    with self.thread_group(thread_begin=0, num_threads=32):
+        # Only threads 0–31 execute instructions here
         ...
 
-**Parameters:**
-
-- ``thread_begin`` (int): The index of the first thread in the thread group (relative to the parent thread group).
-- ``num_threads`` (int): The number of threads in this thread group.
+- ``thread_begin``: index of the first thread (relative to the **parent** group, not the block).
+- ``num_threads``: how many consecutive threads are in this group.
 
 **Constraints:**
 
-- ``thread_begin`` must be non-negative and within the parent thread group's range.
-- ``thread_begin + num_threads`` must not exceed the parent thread group's size.
-- ``num_threads`` must divide evenly into the parent thread group's size.
+- ``thread_begin >= 0``
+- ``thread_begin + num_threads <= parent group size``
 
-How Thread Partitioning Works
-------------------------------
-
-Thread groups partition the current thread group by specifying:
-
-1. **thread_begin**: The starting thread index (relative to the parent group)
-2. **num_threads**: How many consecutive threads to include
-
-This allows you to create non-overlapping thread groups that cover different ranges of threads within the parent group.
-
-**Examples:**
-
-- If you have 128 threads and specify ``thread_begin=0, num_threads=32``, threads 0-31 execute
-- If you have 128 threads and specify ``thread_begin=32, num_threads=32``, threads 32-63 execute
-- If you have 128 threads and specify ``thread_begin=64, num_threads=64``, threads 64-127 execute
-
-Basic Usage Examples
---------------------
-
-**Example 1: Simple Thread Group Partitioning**
+Thread groups can be **nested** — each level partitions the parent group further:
 
 .. code-block:: python
 
-    class MyScript(tilus.Script):
-        def __init__(self):
-            super().__init__()
+    with self.thread_group(thread_begin=0, num_threads=64):
+        # Threads 0–63
 
-        def __call__(self, ...):
-            # Specify 4 warps = 128 threads total
-            self.attrs.warps = 4
+        with self.thread_group(thread_begin=0, num_threads=32):
+            # Threads 0–31 (relative to parent = absolute 0–31)
+            ...
 
-            # All threads execute this
-            data = self.register_tensor(dtype=f32, shape=[16])
+        with self.thread_group(thread_begin=32, num_threads=32):
+            # Threads 32–63 (relative to parent = absolute 32–63)
+            ...
 
-            # Only threads 0-31 execute this block
-            with self.thread_group(thread_begin=0, num_threads=32):
-                # Instructions for first 32 threads
-                result = self.load_global(src, offsets=[0, 0])
 
-            # Only threads 32-63 execute this block
-            with self.thread_group(thread_begin=32, num_threads=32):
-                # Instructions for second 32 threads
-                result = self.load_global(src, offsets=[16, 0])
+Shortcuts
+---------
 
-            # All threads execute this again
-            self.sync()
+Tilus provides convenience methods for common thread group patterns:
 
-**Example 2: Using Different Thread Ranges**
+``self.single_thread(thread=-1)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Execute with exactly one thread. By default (``thread=-1``), the hardware picks any thread
+using elect-any semantics, which generates efficient uniform-predicate code. Pass an explicit
+index to pin execution to a specific thread.
 
 .. code-block:: python
 
-    class MyScript(tilus.Script):
-        def __init__(self):
-            super().__init__()
+    with self.single_thread():
+        # One thread signals the barrier
+        self.mbarrier.arrive_and_expect_tx(barrier, transaction_bytes=tile_bytes)
 
-        def __call__(self, ...):
-            # Specify 4 warps = 128 threads total
-            self.attrs.warps = 4
+``self.single_warp(warp=0)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-            # Only threads 0-31 execute this
-            with self.thread_group(thread_begin=0, num_threads=32):
-                # First group of 32 threads processes first chunk
-                data = self.load_global(src, offsets=[0, 0])
-
-            # Only threads 32-63 execute this
-            with self.thread_group(thread_begin=32, num_threads=32):
-                # Second group of 32 threads processes second chunk
-                data = self.load_global(src, offsets=[32, 0])
-
-**Example 3: Nested Thread Groups**
+Execute with one warp (32 threads). Equivalent to ``thread_group(warp * 32, 32)``.
 
 .. code-block:: python
 
-    class MyScript(tilus.Script):
-        def __init__(self):
-            super().__init__()
+    with self.single_warp():
+        # One warp issues the TMA copy
+        self.tma.global_to_shared(src=ga, dst=sa, offsets=..., mbarrier=barrier)
 
-        def __call__(self, ...):
-            # Specify 4 warps = 128 threads total
-            self.attrs.warps = 4
+``self.warp_group(warp_begin, num_warps)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-            # First level: first 32 threads (threads 0-31)
-            with self.thread_group(thread_begin=0, num_threads=32):
-                # Only threads 0-31 enter here
-
-                # Second level: further split into threads 0-15
-                with self.thread_group(thread_begin=0, num_threads=16):
-                    # Only threads 0-15 execute this
-                    fine_grained_work()
-
-                # Second level: threads 16-31
-                with self.thread_group(thread_begin=16, num_threads=16):
-                    # Only threads 16-31 execute this
-                    different_fine_grained_work()
-
-                # Back to first level - all threads 0-31 execute this
-                self.sync()
-
-Synchronization Within Thread Groups
-------------------------------------
-
-The ``self.sync()`` instruction synchronizes all threads in the **current thread group**, not the entire thread block.
+Execute with multiple warps. Equivalent to ``thread_group(warp_begin * 32, num_warps * 32)``.
+Commonly used with ``num_warps=4`` for WGMMA (which requires 128 threads).
 
 .. code-block:: python
 
-    class MyScript(tilus.Script):
-        def __init__(self):
-            super().__init__()
+    with self.warp_group(warp_begin=0, num_warps=4):
+        # 128 threads (warps 0–3) perform WGMMA
+        self.wgmma.fence()
+        self.wgmma.mma(sa, sb, acc)
+        self.wgmma.commit_group()
+        self.wgmma.wait_group(0)
 
-        def __call__(self, ...):
-            # Specify 4 warps = 128 threads total
-            self.attrs.warps = 4
 
-            # First 64 threads
-            with self.thread_group(thread_begin=0, num_threads=64):
-                # Some work by first 64 threads (threads 0-63)
-                work_part_1()
+Producer-Consumer Pipelines
+----------------------------
 
-                # Synchronize only threads 0-63
-                self.sync()  # Only waits for threads 0-63
+The most common use of thread groups is building **producer-consumer pipelines** where one group
+loads data and another group computes. Barriers synchronize between them:
 
-                # Continue with synchronized work
-                work_part_2()
+.. code-block:: python
 
-            # Synchronize all threads in the thread block
-            self.sync()
+    def __call__(self, ...):
+        self.attrs.warps = 2  # 64 threads
+
+        barriers = self.mbarrier.alloc(num_stages)
+
+        with self.thread_group(thread_begin=0, num_threads=32):
+            # Producer warp: loads tiles via TMA
+            for stage in self.range(num_stages):
+                with self.single_thread():
+                    self.mbarrier.arrive_and_expect_tx(barriers[stage], tile_bytes)
+                self.tma.global_to_shared(src=g_a, dst=s_a[stage], ..., mbarrier=barriers[stage])
+
+        with self.thread_group(thread_begin=32, num_threads=32):
+            # Consumer warp: waits for data, then computes
+            for stage in self.range(num_stages):
+                self.mbarrier.wait(barriers[stage], phase=0)
+                self.tcgen05.mma(s_a[stage], s_b[stage], acc)
+                self.tcgen05.commit(mbarrier=...)
+
+The producer and consumer warps run **in parallel** — the producer starts loading the next tile
+while the consumer is still computing on the current one. Barriers prevent the consumer from
+reading data that hasn't arrived yet.
+
+
+Synchronization Scope
+---------------------
+
+``self.sync()`` synchronizes all threads in the **current thread group**, not the entire block:
+
+.. code-block:: python
+
+    with self.thread_group(thread_begin=0, num_threads=64):
+        work_phase_1()
+        self.sync()    # Syncs only threads 0–63
+        work_phase_2()
+
+    self.sync()        # Syncs all threads in the block
+
+This means you can synchronize within a warp group without stalling threads in other groups.

--- a/docs/source/programming-guides/type-system/__init__.rst
+++ b/docs/source/programming-guides/type-system/__init__.rst
@@ -3,7 +3,7 @@ Type System
 
 This section provides an overview of the type system of Tilus Script. There are three categories of types in Tilus Script:
 
-1. **Scalar Types**: represent basic data types such as integers, floats, and booleans.
+1. **Basic Data Types**: represent basic data types such as integers, floats, and booleans.
 2. **Pointer Types**: represent addresses of data in memory.
 3. **Tensor Types**: represent multi-dimensional arrays of data in global, shared, or register memory.
 
@@ -16,7 +16,7 @@ For a complete list of types for each category, refer to the following sections:
    :maxdepth: 1
    :titlesonly:
 
-   scalar-types
+   data-types
    pointer-types
    register-tensor
    shared-tensor

--- a/docs/source/programming-guides/type-system/data-types.rst
+++ b/docs/source/programming-guides/type-system/data-types.rst
@@ -1,5 +1,5 @@
-Scalar Types
-============
+Data Types
+==========
 
 Tilus supports the following data types. All of them are instances of the :class:`tilus.ir.DataType` class.
 

--- a/docs/source/programming-guides/type-system/pointer-types.rst
+++ b/docs/source/programming-guides/type-system/pointer-types.rst
@@ -11,7 +11,7 @@ The syntax to define a pointer type is as follows:
 
     ~<dtype>
 
-Where ``dtype`` is one of the scalar types (e.g., :py:data:`~tilus.float32`) in :doc:`scalar-types`, or a pointer type itself.
+Where ``dtype`` is one of the scalar types (e.g., :py:data:`~tilus.float32`) in :doc:`data-types`, or a pointer type itself.
 
 **Pointer to Scalar** We can define a pointer to a scalar type like ``~float32``.
 

--- a/docs/source/python-api/attrs.rst
+++ b/docs/source/python-api/attrs.rst
@@ -1,21 +1,20 @@
 Script.attrs
 ============
 
-The ``attrs`` object on a :class:`~tilus.Script` instance is used to set kernel launch configuration.
+.. currentmodule:: tilus.lang.script
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 25 50
+.. autoclass:: Attributes
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
 
-   * - Attribute
-     - Type
-     - Description
-   * - ``blocks``
-     - ``Sequence[int] | int | None``
-     - The grid dimensions of the kernel launch. Set as a list of up to 3 integers, e.g., ``self.attrs.blocks = [grid_x, grid_y]``.
-   * - ``cluster_blocks``
-     - ``Sequence[int] | int``
-     - The cluster dimensions. Defaults to ``(1, 1, 1)``.
-   * - ``warps``
-     - ``int | None``
-     - The number of warps per thread block. Must be a compile-time constant.
+.. currentmodule:: tilus.lang.script.Attributes
+
+.. rubric:: Properties
+
+.. autosummary::
+   :toctree: generated
+
+   blocks
+   cluster_blocks
+   warps

--- a/docs/source/python-api/attrs.rst
+++ b/docs/source/python-api/attrs.rst
@@ -1,0 +1,21 @@
+Script.attrs
+============
+
+The ``attrs`` object on a :class:`~tilus.Script` instance is used to set kernel launch configuration.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 50
+
+   * - Attribute
+     - Type
+     - Description
+   * - ``blocks``
+     - ``Sequence[int] | int | None``
+     - The grid dimensions of the kernel launch. Set as a list of up to 3 integers, e.g., ``self.attrs.blocks = [grid_x, grid_y]``.
+   * - ``cluster_blocks``
+     - ``Sequence[int] | int``
+     - The cluster dimensions. Defaults to ``(1, 1, 1)``.
+   * - ``warps``
+     - ``int | None``
+     - The number of warps per thread block. Must be a compile-time constant.

--- a/docs/source/python-api/instruction-groups/clc.rst
+++ b/docs/source/python-api/instruction-groups/clc.rst
@@ -1,0 +1,20 @@
+Script.clc
+==========
+
+.. currentmodule:: tilus.lang.instructions.clc
+
+.. autoclass:: ClusterLaunchControlInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.clc.ClusterLaunchControlInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   try_cancel
+   query_response

--- a/docs/source/python-api/instruction-groups/clc.rst
+++ b/docs/source/python-api/instruction-groups/clc.rst
@@ -14,7 +14,6 @@ Script.clc
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    try_cancel
    query_response

--- a/docs/source/python-api/instruction-groups/cluster.rst
+++ b/docs/source/python-api/instruction-groups/cluster.rst
@@ -14,7 +14,6 @@ Script.cluster
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    sync
    map_shared_addr
@@ -23,7 +22,6 @@ Script.cluster
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    blockIdx
    blockRank

--- a/docs/source/python-api/instruction-groups/cluster.rst
+++ b/docs/source/python-api/instruction-groups/cluster.rst
@@ -1,0 +1,30 @@
+Script.cluster
+==============
+
+.. currentmodule:: tilus.lang.instructions.cluster
+
+.. autoclass:: BlockClusterInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.cluster.BlockClusterInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   sync
+   map_shared_addr
+
+.. rubric:: Properties
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   blockIdx
+   blockRank
+   clusterDim

--- a/docs/source/python-api/instruction-groups/fence.rst
+++ b/docs/source/python-api/instruction-groups/fence.rst
@@ -5,6 +5,8 @@ Script.fence
 
 .. autoclass:: FenceInstructionGroup
    :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
 
 .. rubric:: Instructions
 
@@ -12,7 +14,6 @@ Script.fence
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    proxy_async
    proxy_async_release

--- a/docs/source/python-api/instruction-groups/mbarrier.rst
+++ b/docs/source/python-api/instruction-groups/mbarrier.rst
@@ -14,7 +14,6 @@ Script.mbarrier
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    alloc
    arrive
@@ -27,7 +26,6 @@ Script.mbarrier
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    producer_initial_phase
    consumer_initial_phase

--- a/docs/source/python-api/instruction-groups/tcgen05.rst
+++ b/docs/source/python-api/instruction-groups/tcgen05.rst
@@ -14,7 +14,6 @@ Script.tcgen05
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    alloc
    dealloc

--- a/docs/source/python-api/instruction-groups/tcgen05.rst
+++ b/docs/source/python-api/instruction-groups/tcgen05.rst
@@ -1,0 +1,30 @@
+Script.tcgen05
+==============
+
+.. currentmodule:: tilus.lang.instructions.tcgen05
+
+.. autoclass:: Tcgen05InstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   alloc
+   dealloc
+   slice
+   view
+   relinquish_alloc_permit
+   load
+   store
+   wait_load
+   wait_store
+   commit
+   copy
+   mma

--- a/docs/source/python-api/instruction-groups/tma.rst
+++ b/docs/source/python-api/instruction-groups/tma.rst
@@ -1,0 +1,22 @@
+Script.tma
+==========
+
+.. currentmodule:: tilus.lang.instructions.tma
+
+.. autoclass:: TmaInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.tma.TmaInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   global_to_shared
+   shared_to_global
+   commit_group
+   wait_group

--- a/docs/source/python-api/instruction-groups/tma.rst
+++ b/docs/source/python-api/instruction-groups/tma.rst
@@ -14,7 +14,6 @@ Script.tma
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    global_to_shared
    shared_to_global

--- a/docs/source/python-api/instruction-groups/wgmma.rst
+++ b/docs/source/python-api/instruction-groups/wgmma.rst
@@ -14,7 +14,6 @@ Script.wgmma
 
 .. autosummary::
    :toctree: generated
-   :template: instruction_group_member.rst
 
    fence
    commit_group

--- a/docs/source/python-api/instruction-groups/wgmma.rst
+++ b/docs/source/python-api/instruction-groups/wgmma.rst
@@ -1,0 +1,22 @@
+Script.wgmma
+============
+
+.. currentmodule:: tilus.lang.instructions.wgmma
+
+.. autoclass:: WgmmaInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+.. rubric:: Instructions
+
+.. currentmodule:: tilus.lang.instructions.wgmma.WgmmaInstructionGroup
+
+.. autosummary::
+   :toctree: generated
+   :template: instruction_group_member.rst
+
+   fence
+   commit_group
+   wait_group
+   mma

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -32,12 +32,11 @@ Attributes and Variables
 .. autosummary::
    :toctree: generated
 
-   attrs
    blockIdx
+   gridDim
    current_num_threads
    current_thread_begin
    current_thread_end
-   gridDim
 
 Language Constructs
 -------------------
@@ -68,7 +67,6 @@ Instructions
    assign
    cast
    clip
-   cluster_sync
    copy_async
    copy_async_commit_group
    copy_async_wait_all

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -34,6 +34,9 @@ Attributes and Variables
 
    attrs
    blockIdx
+   current_num_threads
+   current_thread_begin
+   current_thread_end
    gridDim
 
 Language Constructs
@@ -44,7 +47,11 @@ Language Constructs
 
    assume
    range
+   single_thread
+   single_warp
+   static_assert
    thread_group
+   warp_group
 
 
 Instructions
@@ -55,23 +62,29 @@ Instructions
 
    abs
    add
+   all
    annotate_layout
+   any
    assign
    cast
+   clip
+   cluster_sync
    copy_async
    copy_async_commit_group
    copy_async_wait_all
    copy_async_wait_group
-   cluster_sync
    dot
    exp
    exp2
+   fast_divmod
+   flatten
    free_shared
    global_tensor
    global_view
    load_global
    load_shared
    lock_semaphore
+   log
    max
    maximum
    min
@@ -81,8 +94,12 @@ Instructions
    release_semaphore
    repeat
    repeat_interleave
+   reshape_shared
    round
+   rsqrt
    shared_tensor
+   sqrt
+   square
    squeeze
    store_global
    store_shared
@@ -98,27 +115,45 @@ Instruction Groups
 ------------------
 
 .. toctree::
-   :maxdepth: 1
+   :hidden:
 
    instruction-groups/mbarrier
    instruction-groups/fence
+   instruction-groups/tma
+   instruction-groups/tcgen05
+   instruction-groups/clc
+   instruction-groups/cluster
+   instruction-groups/wgmma
+
+.. list-table::
+   :widths: 20 80
+
+   * - :doc:`mbarrier <instruction-groups/mbarrier>`
+     - Memory barrier instructions for synchronizing async memory transactions.
+   * - :doc:`fence <instruction-groups/fence>`
+     - Fence instructions for memory ordering between proxies.
+   * - :doc:`tma <instruction-groups/tma>`
+     - Tensor Memory Accelerator (TMA) async copy instructions.
+   * - :doc:`tcgen05 <instruction-groups/tcgen05>`
+     - Tensor Core Generation 05 (Blackwell) instructions.
+   * - :doc:`clc <instruction-groups/clc>`
+     - Cluster Launch Control instructions.
+   * - :doc:`cluster <instruction-groups/cluster>`
+     - Block cluster synchronization and shared memory access.
+   * - :doc:`wgmma <instruction-groups/wgmma>`
+     - Warp Group Matrix Multiply-Accumulate (Hopper) instructions.
 
 
 Script Attributes
 -----------------
 
-.. currentmodule:: tilus.lang
+.. toctree::
+   :hidden:
 
-.. class:: Attributes
+   attrs
 
-   The ``attrs`` object on a :class:`~tilus.Script` instance is used to set kernel launch configuration.
+.. list-table::
+   :widths: 20 80
 
-   .. attribute:: blocks
-      :type: list[int]
-
-      The grid dimensions of the kernel launch. Set as a list of up to 3 integers, e.g., ``self.attrs.blocks = [grid_x, grid_y]``.
-
-   .. attribute:: warps
-      :type: int
-
-      The number of warps per thread block. Must be a compile-time constant.
+   * - :doc:`attrs <attrs>`
+     - Kernel launch configuration (blocks, warps, cluster).

--- a/docs/source/python-api/tilus-target.rst
+++ b/docs/source/python-api/tilus-target.rst
@@ -1,0 +1,67 @@
+tilus.target
+============
+
+Tilus automatically detects the GPU at runtime and selects the appropriate compilation target.
+You can query or override the target using the functions below.
+
+.. autosummary::
+    :toctree: generated/
+
+    tilus.target.get_current_target
+    tilus.target.set_current_target
+
+Predefined Targets
+------------------
+
+Each target represents a GPU architecture with its compute capability and feature suffix.
+Tilus uses these to determine which instructions and optimizations are available.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 30
+
+   * - Target
+     - SM
+     - GPU Examples
+   * - ``nvgpu_sm70``
+     - 7.0
+     - V100
+   * - ``nvgpu_sm75``
+     - 7.5
+     - T4, RTX 2080
+   * - ``nvgpu_sm80``
+     - 8.0
+     - A100
+   * - ``nvgpu_sm86``
+     - 8.6
+     - RTX 3090, A40
+   * - ``nvgpu_sm89``
+     - 8.9
+     - L4, L40, RTX 4090
+   * - ``nvgpu_sm90`` / ``nvgpu_sm90a``
+     - 9.0
+     - H100, H200
+   * - ``nvgpu_sm100`` / ``nvgpu_sm100a``
+     - 10.0
+     - B200, GB200
+
+**Feature suffixes:**
+
+- No suffix: base architecture (instructions available on all chips with that SM version)
+- ``a``: architecture-specific (e.g., ``sm_90a`` for Hopper-only features like WGMMA)
+- ``f``: family variant
+
+Usage
+-----
+
+.. code-block:: python
+
+    import tilus
+    from tilus.target import set_current_target, nvgpu_sm90a
+
+    # Query the auto-detected target
+    target = tilus.get_current_target()
+    print(target)  # e.g., nvgpu/sm90a
+
+    # Override the target (e.g., for cross-compilation)
+    set_current_target(nvgpu_sm90a)

--- a/examples/blackwell_matmul/matmul_v6.py
+++ b/examples/blackwell_matmul/matmul_v6.py
@@ -291,7 +291,7 @@ class BlackwellMatmulV6(tilus.Script):
             self.sync()
 
         # all allocated tensor memory must be deallocated
-        self.cluster_sync()
+        self.cluster.sync()
         self.tcgen05.dealloc(mma_worker.t_acc)
 
 

--- a/examples/blackwell_matmul/matmul_v7.py
+++ b/examples/blackwell_matmul/matmul_v7.py
@@ -165,7 +165,7 @@ class BlackwellMatmulV7(tilus.Script):
 
         cta_rank = self.cluster.blockRank
 
-        self.cluster_sync()
+        self.cluster.sync()
 
         with self.single_warp(0):  # tma worker (gmem -> smem)
             offset_m_a = self.blockIdx.x * (block_m // 2)
@@ -298,7 +298,7 @@ class BlackwellMatmulV7(tilus.Script):
                 offset_n_c = new_blockIdx.y * block_n
 
         # all allocated tensor memory must be deallocated
-        self.cluster_sync()
+        self.cluster.sync()
         self.tcgen05.dealloc(t_acc)
 
 

--- a/examples/blackwell_matmul/matmul_v8.py
+++ b/examples/blackwell_matmul/matmul_v8.py
@@ -202,7 +202,7 @@ class BlackwellMatmulV8(tilus.Script):
 
         cta_rank = self.cluster.blockRank
 
-        self.cluster_sync()
+        self.cluster.sync()
 
         with self.single_warp(0):  # tma worker (gmem -> smem)
             m_block_0, n_block_0 = self.compute_block_coord(
@@ -354,7 +354,7 @@ class BlackwellMatmulV8(tilus.Script):
                 offset_n_c = n_block_e * block_n
 
         # all allocated tensor memory must be deallocated
-        self.cluster_sync()
+        self.cluster.sync()
         self.tcgen05.dealloc(t_acc)
 
 

--- a/python/tilus/lang/instructions/clc.py
+++ b/python/tilus/lang/instructions/clc.py
@@ -20,6 +20,30 @@ from .root import InstructionGroup
 
 
 class ClusterLaunchControlInstructionGroup(InstructionGroup):
+    """Cluster Launch Control (CLC) instructions for dynamic work scheduling on Blackwell GPUs.
+
+    CLC enables a running kernel to **cancel clusters that have not yet started**, effectively
+    implementing dynamic grid scheduling and work-stealing patterns. A scheduler CTA can
+    request cancellation of a pending cluster, and if successful, take over that cluster's
+    work.
+
+    The workflow is:
+
+    1. ``try_cancel()`` — asynchronously request cancellation. An opaque 16-byte response is
+       written to shared memory, tracked by an mbarrier.
+    2. ``mbarrier.wait()`` — wait for the response to arrive.
+    3. ``query_response()`` — decode the response to check if cancellation succeeded and
+       retrieve the canceled cluster's CTA coordinates.
+
+    If cancellation succeeds, the scheduler can use the returned CTA ID to compute the
+    work tile that the canceled cluster would have processed, and execute that work itself.
+    If it fails (the cluster already started), the scheduler can retry or proceed with
+    other work.
+
+    With ``multicast=True``, the response is broadcast to all CTAs in the requesting cluster,
+    so all CTAs can independently query the result.
+    """
+
     def try_cancel(self, response: SharedTensor, mbarrier: Expr | RegisterTensor, multicast: Expr | bool) -> None:
         """Request cancellation of a cluster that has not yet been launched.
 
@@ -61,11 +85,12 @@ class ClusterLaunchControlInstructionGroup(InstructionGroup):
 
         Notes
         -----
-        - Requires sm_100 or higher.
+        - **Thread group**: Can be executed by any sized thread group (at least 32 threads if ``multicast=True``).
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``clusterlaunchcontrol.try_cancel``
         - This instruction performs an mbarrier arrive operation combined with an expect-tx operation (16 bytes)
           before issuing the cancellation request. The mbarrier's tx-count is increased by 16 bytes when the
           instruction is issued, and decreased by 16 bytes when the response write completes asynchronously.
-        - The mbarrier phase will complete when both the pending arrival count and tx-count reach zero.
         """
         self._builder.cluster_launch_control_try_cancel(response, mbarrier, multicast)
 
@@ -99,12 +124,12 @@ class ClusterLaunchControlInstructionGroup(InstructionGroup):
 
         Notes
         -----
-        - Requires sm_100 or higher.
-        - The behavior is undefined if called before the `try_cancel` operation has completed (i.e., before
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``clusterlaunchcontrol.query_cancel.is_canceled`` and
+          ``clusterlaunchcontrol.query_cancel.get_first_ctaid``
+        - The behavior is undefined if called before the ``try_cancel`` operation has completed (i.e., before
           the associated mbarrier has signaled completion).
-        - Maps to PTX instructions:
-          - `clusterlaunchcontrol.query_cancel.is_canceled.pred.b128`
-          - `clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128`
         """
         ret = self._builder.cluster_launch_control_query_response(response)
         items = []

--- a/python/tilus/lang/instructions/cluster.py
+++ b/python/tilus/lang/instructions/cluster.py
@@ -22,13 +22,50 @@ from .root import InstructionGroup
 
 
 class BlockClusterInstructionGroup(InstructionGroup):
+    """Block cluster instructions for multi-CTA coordination on Hopper+ GPUs.
+
+    A **cluster** is a group of thread blocks (CTAs) that can directly access each other's
+    shared memory and synchronize collectively. Clusters are configured at launch time via
+    ``self.attrs.cluster_blocks``.
+
+    This instruction group provides:
+
+    - **Synchronization**: ``sync()`` is a cluster-wide barrier — all threads across all CTAs
+      in the cluster must arrive before any can proceed.
+    - **Introspection**: ``blockIdx``, ``clusterDim``, and ``blockRank`` provide the current
+      CTA's position and rank within the cluster.
+    - **Cross-CTA addressing**: ``map_shared_addr()`` translates a shared memory address from
+      the current CTA's address space to another CTA's, enabling direct remote shared memory
+      access (e.g., signaling a peer CTA's mbarrier).
+    """
+
     def sync(self) -> None:
+        """Synchronize all thread blocks in the current cluster.
+
+        All threads in all CTAs of the cluster must reach this barrier before any thread can
+        proceed past it. This is the cluster-level equivalent of ``__syncthreads()``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``barrier.cluster.arrive`` / ``barrier.cluster.wait``
+        """
         from tilus.hidet.ir.primitives.cuda.cluster import cluster_sync
 
         self._builder.evaluate(pred=None, expr=cluster_sync())
 
     @property
     def blockIdx(self) -> Dim3:
+        """The block index within the cluster.
+
+        Returns a ``Dim3`` with ``x``, ``y``, ``z`` components representing the position
+        of the current block within the cluster grid.
+
+        Notes
+        -----
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        """
         from tilus.hidet.ir.primitives.cuda.vars import clusterBlockIdx
 
         return Dim3(
@@ -39,6 +76,15 @@ class BlockClusterInstructionGroup(InstructionGroup):
 
     @property
     def clusterDim(self) -> Dim3:
+        """The dimensions of the cluster.
+
+        Returns a ``Dim3`` with ``x``, ``y``, ``z`` components representing the
+        number of blocks in each dimension of the cluster.
+
+        Notes
+        -----
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        """
         from tilus.hidet.ir.primitives.cuda.vars import clusterDim
 
         return Dim3(
@@ -49,6 +95,14 @@ class BlockClusterInstructionGroup(InstructionGroup):
 
     @property
     def blockRank(self) -> Var:
+        """The linear rank of the current block within the cluster.
+
+        Returns a scalar ``uint32`` value in the range ``[0, clusterSize)``.
+
+        Notes
+        -----
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        """
         from tilus.hidet.ir.primitives.cuda.vars import clusterBlockRank
 
         return clusterBlockRank
@@ -70,6 +124,12 @@ class BlockClusterInstructionGroup(InstructionGroup):
         -------
         RegisterTensor
             A register tensor with the same shape and dtype as ``addr``, containing the mapped addresses.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``mapa.shared::cluster``
         """
         if not isinstance(addr, RegisterTensor):
             raise InstructionError("addr must be a RegisterTensor, got {}".format(type(addr)))

--- a/python/tilus/lang/instructions/fence.py
+++ b/python/tilus/lang/instructions/fence.py
@@ -18,47 +18,43 @@ from .root import InstructionGroup
 
 
 class FenceInstructionGroup(InstructionGroup):
-    """Fence instructions for memory ordering.
+    """Fence instructions for memory ordering between memory proxies.
 
-    Naming convention follows the PTX fence instruction taxonomy
-    (PTX ISA 9.7.13.4: membar / fence). Each tilus method corresponds
-    to one PTX instruction template with parameters for meaningful variation.
+    CUDA GPUs have multiple memory proxies (generic, async, alias, tensormap) that can access
+    the same memory through different paths. When one proxy writes data that another proxy needs
+    to read, a **proxy fence** is required to ensure the writes are visible.
 
-    Implemented
-    -----------
-    proxy_async(space)
-        Bidirectional async proxy fence: ``fence.proxy.async.{space}``
-    proxy_async_release()
-        Unidirectional generic-to-async release:
-        ``fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster``
+    The most common scenario is coordinating between:
 
-    TODO
-    ----
-    thread(sem, scope, sync_restrict=None)
-        Thread fence: ``fence.{sem}.{scope}``
-        When sync_restrict is set:
-        - ``fence.acquire.sync_restrict::shared::cluster.cluster``
-        - ``fence.release.sync_restrict::shared::cta.cluster``
-    proxy_alias()
-        Bidirectional alias proxy fence: ``fence.proxy.alias``
-    proxy_async_acquire()
-        Unidirectional generic-to-async acquire:
-        ``fence.proxy.async::generic.acquire.sync_restrict::shared::cluster.cluster``
-    proxy_tensormap_release(scope)
-        Unidirectional tensormap release:
-        ``fence.proxy.tensormap::generic.release.{scope}``
-    proxy_tensormap_acquire(addr, scope)
-        Unidirectional tensormap acquire:
-        ``fence.proxy.tensormap::generic.acquire.{scope} [addr], 128``
+    - **Generic proxy** writes: ``store_shared()``, register-to-shared stores
+    - **Async proxy** reads/writes: TMA operations (``tma.global_to_shared()``, ``tma.shared_to_global()``)
+
+    For example, after writing to shared memory with ``store_shared()`` and before issuing
+    ``tma.shared_to_global()``, a ``proxy_async()`` or ``proxy_async_release()`` fence is needed
+    to ensure the TMA engine sees the updated data.
+
+    ``proxy_async_release()`` is a lighter-weight alternative to ``proxy_async()`` when only
+    generic-to-async ordering is needed (not bidirectional).
     """
 
     def proxy_async(self, space: str = "shared") -> None:
         """Bidirectional async proxy fence.
 
-        PTX: ``fence.proxy.async.{space}``
+        Establishes ordering between the async proxy and the generic proxy for memory
+        operations in the specified state space. Required when both proxies access the
+        same memory (e.g., generic writes followed by TMA reads, or TMA writes followed
+        by generic reads).
 
-        Establishes ordering between the async proxy and the generic proxy
-        for memory operations in the specified state space.
+        Parameters
+        ----------
+        space: str
+            The state space for the fence. Candidates: ``'shared'``, ``'global'``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``fence.proxy.async.shared::cta`` or ``fence.proxy.async.global``
         """
         if space not in ("shared", "global"):
             raise ValueError(
@@ -69,12 +65,14 @@ class FenceInstructionGroup(InstructionGroup):
     def proxy_async_release(self) -> None:
         """Unidirectional generic-to-async release proxy fence for shared memory.
 
-        PTX: ``fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster``
+        A lighter-weight alternative to ``proxy_async()``. Only ensures that prior generic proxy
+        writes to shared memory are visible to subsequent async proxy reads (e.g.,
+        ``store_shared()`` followed by ``tma.shared_to_global()``).
 
-        A lighter-weight alternative to proxy_async(). Only ensures that prior
-        generic proxy writes to shared::cta memory are visible to subsequent
-        async proxy reads (e.g., stmatrix followed by tma.shared_to_global).
-
-        Requires sm_90 or higher.
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``fence.proxy.async::generic.release.sync_restrict::shared::cta.cluster``
         """
         self._builder.fence_proxy_async_release()

--- a/python/tilus/lang/instructions/mbarrier.py
+++ b/python/tilus/lang/instructions/mbarrier.py
@@ -21,68 +21,55 @@ from .root import InstructionGroup
 
 
 class BarrierInstructionGroup(InstructionGroup):
+    """Memory barrier (mbarrier) instructions for synchronizing asynchronous operations.
+
+    An mbarrier is a 64-bit synchronization primitive in shared memory that tracks two counts:
+    **pending arrivals** and **pending transaction bytes (tx-count)**. A barrier transitions to the
+    next phase when both counts reach zero.
+
+    Mbarriers coordinate producer-consumer patterns in pipelined GPU kernels. The typical workflow is:
+
+    1. **Allocate** barriers with ``alloc()``, specifying expected arrival counts per stage.
+    2. **Producers** call ``arrive()`` or ``arrive_and_expect_tx()`` to signal progress and declare
+       expected async data transfers (e.g., TMA copies). The TMA engine automatically decrements
+       the tx-count as transfers complete.
+    3. **Consumers** call ``wait()`` to block until the barrier's current phase finishes (both
+       pending arrivals and tx-count reach zero).
+
+    The barrier alternates between phase 0 and phase 1. Use ``producer_initial_phase`` and
+    ``consumer_initial_phase`` as starting phase values for multi-stage pipelines.
+
+    For cluster-wide synchronization, ``arrive_and_expect_tx_multicast()`` signals barriers across
+    multiple CTAs, and ``arrive_and_expect_tx_remote()`` signals a specific peer CTA's barrier.
+    """
+
     producer_initial_phase = 1
     consumer_initial_phase = 0
 
     def alloc(self, counts: Sequence[Expr | int] | Expr | int) -> RegisterTensor:
-        """Allocate barriers in shared memory and get its address in shared space.
+        """Allocate and initialize one or more mbarriers in shared memory.
 
-         A barrier is an 64-bit data structure, encoded as uint64, in shared memory, which
-         contains the following information in the 64 bits:
-
-         - The current phase of the barrier (i.e., phase): 0 or 1.
-         - The count of pending arrivals in the current phase: 1 to 2^20 - 1.
-         - The count of expected arrivals in the next phase: 0 to 2^20 - 1.
-         - The count of pending asynchronous memory transactions in the current phase (i.e., `tx-count`):
-           -(2^20 - 1) to 2^20 - 1.
-
-         This instruction allocates one or multiple uint64 elements in shared memory to be used as mbarrier(s).
-         The parameter `counts` specifies the expected arrivals for the barrier(s).
-         After initialization, the barrier will have the following initial state:
-
-         - phase = 0
-         - pending arrivals = counts[i]
-         - expected arrivals = counts[i]
-         - tx-count = 0
-
-         When `counts` is not provided, it defaults to [NUM_THREADS] where NUM_THREADS is the number of threads in the current thread group.
-
-         Some instructions (e.g., tma copy instructions) that take a barrier as an argument might:
-
-         - increase the `tx-count` by the number of bytes to be copied before the copy starts.
-         - decrease the `tx-count` by the number of bytes copied after the copy completes asynchronously.
-
-         The `mbarrier.arrive` instruction will decrease the pending arrivals by the number of threads in the thread
-         group that call the instruction.
-
-         The `mbarrier.wait` instruction will make the thread group wait until the given phase has finished.
-
-         Once the following conditions are met for the current phase:
-
-         - pending arrivals == 0
-         - tx-count == 0
-
-         The barrier will switch to the next phase, and the following will happen:
-
-         - phase = phase ^ 1
-         - pending arrivals = expected arrivals in the next phase
-         - expected arrivals does not change
-         - tx-count = 0
+        Each barrier is initialized with phase 0, the specified expected arrival count, and
+        tx-count of 0. When a single value is provided, one barrier is allocated; when a
+        sequence is provided, multiple barriers are allocated with the corresponding counts.
 
         Parameters
         ----------
         counts: Sequence[Expr | int] | Expr | int, optional
-            The sequence of expected arrival counts for the allocated barriers. Each count must be evaluated to a positive int32 integer.
-            When not provided, it defaults to [NUM_THREADS] where NUM_THREADS is the number of threads in the current thread group.
-            Multiple barriers will be allocated with each barrier initialized with the corresponding expected arrivals specified in the sequence.
-            When a single Expr or int is provided, it will be treated as a sequence with one element, and one barrier will be allocated and initialized
-            with the given expected arrival count.
+            Expected arrival counts for the barriers. Each count must evaluate to a positive
+            int32. A single value allocates one barrier; a sequence allocates multiple.
 
         Returns
         -------
         ret: RegisterTensor
-            A register tensor of dtype uint32 containing the address of the allocated barrier(s) in shared memory.
-            The i-th element corresponds to the address of the barrier with expected arrivals specified by counts[i].
+            A register tensor of dtype uint32 containing the shared memory address(es) of
+            the allocated barrier(s). Element *i* holds the address for ``counts[i]``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``mbarrier.init.shared::cta.b64``
         """
         if isinstance(counts, (Expr, int)):
             processed_counts = [as_expr(counts)]
@@ -112,6 +99,12 @@ class BarrierInstructionGroup(InstructionGroup):
             The memory ordering semantics for the arrive operation. Candidates: 'relaxed', 'release'.
         scope: str
             The syncrhonization scope for the arrive operation. Candidates: 'cta', 'cluster'.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``mbarrier.arrive.shared::cta.b64``
         """
         if sem not in ("relaxed", "release"):
             raise ValueError(
@@ -147,6 +140,12 @@ class BarrierInstructionGroup(InstructionGroup):
             The memory ordering semantics for the arrive operation. Candidates: 'relaxed', 'release'.
         scope: str
             The syncrhonization scope for the arrive operation. Candidates: 'cta', 'cluster'.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``mbarrier.arrive.expect_tx.shared::cta.b64``
         """
         if sem not in ("relaxed", "release"):
             raise ValueError(
@@ -188,6 +187,12 @@ class BarrierInstructionGroup(InstructionGroup):
             The memory ordering semantics for the wait operation. Candidates: 'acquire', 'relaxed'.
         scope: str
             The synchronization scope for the wait operation. Candidates: 'cta', 'cluster'.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``mbarrier.try_wait.parity.shared::cta.b64``
         """
         if sem not in ("acquire", "relaxed"):
             raise ValueError(
@@ -207,34 +212,33 @@ class BarrierInstructionGroup(InstructionGroup):
         sem: str = "release",
         scope: str = "cluster",
     ) -> None:
-        """
-        Arrive at a barrier with expected asynchronous memory transactions and multicast the arrival to a subset of blocks in the cluster.
+        """Arrive at barriers across multiple CTAs with expected async transactions.
 
-        This instruction arrives the all barriers on each CTA in the current block cluster with the same offset of the given barrier. The arrival count is 1
-        and the expected transaction bytes are specified by `transaction_bytes`.
-
-        The `barrier` parameter specifies the address of the barrier for the current block, and the `multicast_mask` parameter specifies which blocks
-        in the cluster will be involved in this arrival operation. For example, when `multicast_mask` is 0b101, only the barriers on blocks 0 and 2 be signaled by the arrival
-        and expect-tx operation, while other blocks will not be affected.
-
-        This instruction must be executed in a thread group with at least 16 threads. The arrive-and-expect-tx operation will not be performed by each
-        thread. Instead, one thread will be elected to perform the operation for one CTA in the multicast.
+        Signals an arrive-and-expect-tx on the barriers at the same shared memory offset in each
+        CTA specified by ``multicast_mask``. The arrival count is 1 and the tx-count is increased
+        by ``transaction_bytes`` on each signaled barrier. One thread is elected per CTA to perform
+        the operation.
 
         Parameters
         ----------
         barrier: RegisterTensor
-            A register tensor with one uint32 element representing the address of the barrier in the local shared memory for the current block.
+            A single-element uint32 register tensor with the barrier's shared memory address
+            in the current CTA. The same offset is used for peer CTAs.
         transaction_bytes: Expr | int
-            The number of bytes expected to be delivered by asynchronous memory transactions (e.g., TMA copies) to the barriers. The barriers' tx-count
-            will be increased by this value on arrival and decreased as the async transactions complete. It must be evaluated to a non-negative int32.
+            Expected async transfer size in bytes. Must evaluate to a non-negative int32.
         multicast_mask: int
-            A bitmask specifying which blocks in the cluster will be involved in this arrival operation. The least significant bit corresponds to block 0,
-            the second least significant bit corresponds to block 1, and so on. For example, when `multicast_mask` is 0b101, only the barriers on
-            blocks 0 and 2 be signaled by the arrival and expect-tx operation, while other blocks will not be affected.
+            Bitmask of CTAs to signal. Bit *i* corresponds to the CTA with rank *i*.
+            E.g., ``0b101`` signals CTAs 0 and 2.
         sem: str
-            The memory ordering semantics for the arrive operation. Candidates: 'relaxed', 'release'.
+            Memory ordering semantics. Candidates: ``'relaxed'``, ``'release'``.
         scope: str
-            The syncrhonization scope for the arrive operation. Candidates: 'cta', 'cluster'.
+            Synchronization scope. Candidates: ``'cta'``, ``'cluster'``.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a thread group with at least 16 threads.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``mbarrier.arrive.expect_tx.shared::cluster.b64`` with ``mapa.shared::cluster``
         """
         if sem not in ("relaxed", "release"):
             raise ValueError(
@@ -256,29 +260,31 @@ class BarrierInstructionGroup(InstructionGroup):
         sem: str = "release",
         scope: str = "cluster",
     ) -> None:
-        """
-        Arrive at a barrier on a peer thread block in the same cluster with expected asynchronous memory transactions.
+        """Arrive at a peer CTA's barrier with expected async transactions.
 
-        The arrival count would be 1 and the expected transaction bytes are specified by `transaction_bytes`.
-
-        The `barrier` parameter must be on the local shared memory of the current block. The mbarrier on the target block
-        specified by `target_rank` that has the same offset as the given `barrier` will be signaled by this arrival operation
-        and expect the asynchronous transactions.
+        Signals an arrive-and-expect-tx on the barrier in the CTA specified by ``target_rank``.
+        The barrier at the same shared memory offset as the local ``barrier`` in the target CTA
+        is signaled with arrival count 1 and tx-count increased by ``transaction_bytes``.
 
         Parameters
         ----------
         barrier: RegisterTensor
-            A register tensor with one uint32 element representing the address of the barrier in the local shared memory for the current block.
+            A single-element uint32 register tensor with the barrier's shared memory address
+            in the current CTA. The same offset is used for the target CTA.
         transaction_bytes: Expr | int
-            The number of bytes expected to be delivered by asynchronous memory transactions (e.g., TMA copies) to the barrier. The barrier's tx-count
-            will be increased by this value on arrival and decreased as the async transactions complete. It must be evaluated to a non-negative int32.
+            Expected async transfer size in bytes. Must evaluate to a non-negative int32.
         target_rank: int
-            The rank of the target block in the same cluster for this remote arrive operation. It must be in the range of `[0, clusterSize)` where
-            `clusterSize` is the total number of blocks in the cluster.
+            Rank of the target CTA in the cluster. Must be in ``[0, clusterSize)``.
         sem: str
-            The memory ordering semantics for the arrive operation. Candidates: 'relaxed', 'release'.
+            Memory ordering semantics. Candidates: ``'relaxed'``, ``'release'``.
         scope: str
-            The syncrhonization scope for the arrive operation. Candidates: 'cta', 'cluster'.
+            Synchronization scope. Candidates: ``'cta'``, ``'cluster'``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``mbarrier.arrive.expect_tx.shared::cluster.b64`` with ``mapa.shared::cluster``
         """
         if sem not in ("relaxed", "release"):
             raise ValueError(

--- a/python/tilus/lang/instructions/root.py
+++ b/python/tilus/lang/instructions/root.py
@@ -274,6 +274,18 @@ class RootInstructionGroup(InstructionGroup):
 
     @staticmethod
     def static_assert(cond: bool | Expr, msg: str) -> None:
+        """Assert a compile-time condition.
+
+        Raises ``AssertionError`` at compile time if the condition is false. The condition
+        must be a compile-time constant (a ``bool`` or a ``Constant`` expression).
+
+        Parameters
+        ----------
+        cond: bool | Expr
+            The compile-time condition to check. Must be a constant value.
+        msg: str
+            The error message to display if the assertion fails.
+        """
         if not isinstance(cond, Constant) and not isinstance(cond, bool):
             raise ValueError("Static assert condition must be a constant")
         if not cond:
@@ -311,6 +323,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         tensor: RegisterTensor
             The allocated register tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         f_init: Optional[Callable[[Sequence[Var]], Expr]] = None
         if init is not None:
@@ -363,6 +379,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: GlobalTensor
             The allocated global tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.allocate_global(
             dtype=dtype,
@@ -392,6 +412,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: SharedTensor
             The allocated shared tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.allocate_shared(dtype=dtype, shape=shape)
 
@@ -428,6 +452,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: GlobalTensor
             The global tensor view created.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         from tilus.ir.layout import global_row_major, global_strides
 
@@ -482,6 +510,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor containing the loaded data from the global tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if len(offsets) != len(src.shape):
             raise InstructionError(
@@ -521,6 +553,10 @@ class RootInstructionGroup(InstructionGroup):
             The offsets for each dimension of the global tensor where the register tensor will be stored.
         dims: Sequence[int], optional
             The dimensions of the global tensor that are being sliced.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if dims is not None and len(dims) != len(src.shape):
             raise InstructionError(
@@ -548,6 +584,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor containing the loaded data from the shared tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.load_shared(src=src, output=out)
 
@@ -575,6 +615,10 @@ class RootInstructionGroup(InstructionGroup):
             The dimensions of the shared tensor that are being sliced. If not provided, it is assumed that all
             dimensions are being sliced in the same order as the register tensor. The length of this sequence must
             match the number of dimensions of the register tensor being stored.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if dst.dtype != src.dtype:
             raise InstructionError(
@@ -597,6 +641,10 @@ class RootInstructionGroup(InstructionGroup):
         ----------
         tensor: SharedTensor
             The shared tensor to free.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         self._builder.free_shared(tensor)
 
@@ -614,6 +662,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: SharedTensor
             The reshaped shared tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.reshape_shared(tensor=tensor, shape=shape)
 
@@ -626,28 +678,13 @@ class RootInstructionGroup(InstructionGroup):
         evict: Optional[str] = None,
         check_bounds: bool = True,
     ) -> None:
-        """Copy from global to shared tensor asynchronously.
+        """Asynchronously copy a tile from global memory to shared memory.
 
-        This instruction issues an asynchronous  copy of a tile from a global tensor to a shared tensor. The `src` parameter
-        specifies the global tensor to copy from, while the `dst` parameter specifies the shared tensor to copy to.
+        Issues an ``cp.async`` transfer from a region of ``src`` (global) to ``dst`` (shared).
+        Use ``copy_async_commit_group()`` and ``copy_async_wait_group()`` to synchronize.
 
-        The `offsets` parameter specifies the starting offsets for each dimension of the global tensor where the tile
-        will be copied from. The length of this sequence must match the rank of the global tensor.
-
-        The `dims` parameter specifies which dimensions of the global tensor are being sliced. If not provided, it is
-        assumed that all dimensions are being sliced in the same order as the shared tensor. The length of this sequence
-        must match the number of dimensions of the shared tensor being copied to.
-
-        The `evict` parameter can be used to specify the eviction policy. When we use this instruction, the data in
-        the global memory will be cached. We can use the `evict` parameter to specify the eviction policy for the cached
-        data of this instruction.
-
-        It's valid to specify the loading elements out of bounds of the global tensor, in which case, we will perform
-        bound checking and fill the out-of-bounds elements with zero in the shared tensor. The bound checking might
-        introduce some overhead, especially when the user make sure that the accessed global elements are always in
-        bounds but our compiler cannot infer it. In this case, we can set `check_bounds` to `False` to skip the bound
-        checking. It's the user's responsibility to ensure that the accessed global elements are always in bounds when
-        `check_bounds` is set to `False`.
+        Out-of-bounds accesses are zero-filled by default. Set ``check_bounds=False`` to skip
+        bounds checking when you can guarantee all accesses are in-bounds.
 
         Parameters
         ----------
@@ -656,29 +693,26 @@ class RootInstructionGroup(InstructionGroup):
         dst: SharedTensor
             The shared tensor to copy to.
         offsets: Sequence[Expr | int]
-            The offsets for each dimension of the global tensor where the tile will be copied from. The length of this
-            sequence must match the number of dimensions of the global tensor.
+            Starting offsets for each dimension of the global tensor. Length must match the
+            rank of the global tensor.
         dims: Sequence[int], optional
-            The dimensions of the global tensor that are being sliced when the rank of shared tensor is less than the
-            rank of the global tensor. If not provided, it is assumed that all dimensions are being sliced in the
-            same order as the shared tensor. The length of this sequence must match the number of dimensions of the
-            shared tensor being copied to.
+            Which dimensions of the global tensor are being sliced. If not provided, defaults
+            to all dimensions in order.
         evict: str, optional
-            The eviction policy for the cached data of this instruction. If not provided, the default eviction
-            policy `evict_normal` is used, which is to evict the cached data when the shared memory is full. The
-            eviction policy can be one of
+            Cache eviction policy. Candidates:
 
-            The candidates are:
-
-            - 'evict_normal': Evict the cached data when the shared memory is full.
-            - 'evict_first': Evict the cached data of this instruction first when an eviction is needed. This policy is
-              suitable for streaming data where the data is only needed once and will not be reused.
+            - ``'evict_normal'`` (default): normal eviction priority.
+            - ``'evict_first'``: evict this data first; suitable for streaming access patterns.
 
         check_bounds: bool, optional
-            Whether to check the bounds of the accessed global elements. When set to `True`, the accessed global
-            elements will be checked to ensure they are within bounds. If any accessed global element is out of bounds,
-            it will be filled with zero in the shared tensor. When set to `False`, the bound checking will be skipped,
-            and the user must ensure that the accessed global elements are always in bounds. The default value is `True`.
+            If ``True`` (default), out-of-bounds accesses are zero-filled. If ``False``,
+            bounds checking is skipped (caller must guarantee in-bounds access).
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``cp.async``
         """
         if dims is None:
             if len(dst.shape) != len(src.shape):
@@ -701,6 +735,10 @@ class RootInstructionGroup(InstructionGroup):
             self.copy_async_commit_group()
             self.copy_async_wait_group(0)
 
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
         """
         self._builder.copy_async_wait_all()
 
@@ -709,6 +747,11 @@ class RootInstructionGroup(InstructionGroup):
 
         This instruction commits all the pending asynchronous copy operations into a group.
 
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``cp.async.commit_group``
         """
         self._builder.copy_async_commit_group()
 
@@ -725,6 +768,12 @@ class RootInstructionGroup(InstructionGroup):
         n: Union[Expr, int]
             The maximum number of asynchronous copy groups that can be unfinished at the same time. If `n` is 0,
             it will wait until all asynchronous copy groups are finished.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 8.0+ (sm_80).
+        - **PTX**: ``cp.async.wait_group``
         """
         self._builder.copy_async_wait_group(n)
 
@@ -776,6 +825,11 @@ class RootInstructionGroup(InstructionGroup):
         ret: RegisterTensor
             The result of the dot product, which is a register tensor with shape [m, n]. It will be `out` if provided,
             or a new register tensor if not.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70) for tensor core MMA, or any GPU for SIMT fallback.
         """
         if c is None:
             if acc_dtype is None:
@@ -819,6 +873,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor with the specified data type.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.cast(x=x, dtype=dtype)
 
@@ -856,6 +914,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor with the specified layout and/or data type.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.view(x=x, layout=layout, dtype=dtype, local_offset=0)
 
@@ -881,6 +943,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor with the specified dimension squeezed out.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.squeeze(x, dim=dim, out=out)
 
@@ -909,10 +975,18 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The register tensor with the specified dimension(s) unsqueezed.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.unsqueeze(x, dim=dim, out=out)
 
     def flatten(self):
+        """Flatten a register tensor into a 1-D tensor.
+
+        .. note:: This instruction is not yet implemented.
+        """
         self._builder
 
     def transpose(
@@ -933,6 +1007,10 @@ class RootInstructionGroup(InstructionGroup):
         -------
         ret: RegisterTensor
             The transposed register tensor. The shape of the output tensor will be [x.shape[1], x.shape[0]].
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.transpose(x)
 
@@ -942,23 +1020,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the absolute value of a register tensor.
-
-        This instruction computes the absolute value of each element in the register tensor `x`. The result is a new
-        register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise absolute value.
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the absolute value of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the absolute values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.abs(x, out=out)
 
@@ -968,23 +1046,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the exponential of each element.
-
-        This instruction computes the natural exponential of each element in the register tensor `x`. The result is a
-        new register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise natural exponential (e^x).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the exponential of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the exponential values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.exp(x, out=out)
 
@@ -994,23 +1072,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the base-2 exponential of each element.
-
-        This instruction computes the base-2 exponential of each element in the register tensor `x`. The result is a
-        new register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise base-2 exponential (2^x).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the base-2 exponential of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the base-2 exponential values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.exp2(x, out=out)
 
@@ -1020,23 +1098,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the natural logarithm of each element.
-
-        This instruction computes the natural logarithm of each element in the register tensor `x`. The result is a
-        new register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise natural logarithm (ln x).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the natural logarithm of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the natural logarithm values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.log(x, out=out)
 
@@ -1046,24 +1124,26 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Round each element to the nearest integer.
+        """Round each element to the nearest integer (round-to-nearest-even).
 
-        This instruction rounds each element in the register tensor `x` to the nearest integer. The result is a new
-        register tensor with the same dtype, shape, and layout as `x`. We use the "round-to-nearest-even" rounding mode.
-        This means that if the fractional part of a number is exactly 0.5, it will be rounded to the nearest even integer.
+        Uses banker's rounding: if the fractional part is exactly 0.5, rounds to the nearest
+        even integer.
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to round.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the rounded values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.round(x, out=out)
 
@@ -1073,23 +1153,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the square of each element.
-
-        This instruction computes the square of each element in the register tensor `x`. The result is a new
-        register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise square (x^2).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the square of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the squared values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.square(x, out=out)
 
@@ -1099,23 +1179,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the square root of each element.
-
-        This instruction computes the square root of each element in the register tensor `x`. The result is a new
-        register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise square root.
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the square root of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the square root values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.sqrt(x, out=out)
 
@@ -1125,23 +1205,23 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the reciprocal of the square root of each element.
-
-        This instruction computes the reciprocal of the square root of each element in the register tensor `x`. The result is a new
-        register tensor with the same dtype, shape, and layout as `x`.
+        """Compute the element-wise reciprocal square root (1/sqrt(x)).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to compute the reciprocal of the square root of.
+            Input tensor.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the reciprocal of the square root values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.rsqrt(x, out=out)
 
@@ -1153,28 +1233,27 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Clip the values of a register tensor to a specified range.
-
-        This instruction clips the values of the register tensor `x` to the range specified by `min` and `max`. The
-        resulting values will be in the range [min, max]. The result is a new register tensor with the same
-        dtype, shape, and layout as `x`.
+        """Clip element values to the range [min, max].
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to clip.
+            Input tensor.
         min: Expr | int | float
-            The minimum value to clip the elements of `x` to. Any value less than `min` will be set to `min`.
+            Lower bound. Values below this are set to ``min``.
         max: Expr | int | float
-            The maximum value to clip the elements of `x` to. Any value greater than `max` will be set to `max`.
+            Upper bound. Values above this are set to ``max``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the clipped values of the elements in `x`. The shape and dtype of the
-            output tensor will be the same as that of `x`.
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.clip(x=x, min=min, max=max, out=out)
 
@@ -1223,6 +1302,10 @@ class RootInstructionGroup(InstructionGroup):
         See Also
         --------
         :py:meth:`torch.Tensor.repeat`: A similar function in PyTorch.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.repeat(
             x=x,
@@ -1270,6 +1353,10 @@ class RootInstructionGroup(InstructionGroup):
         ret: RegisterTensor
             The register tensor containing the repeated elements of `x`. The shape of the output tensor will be
             determined by the `repeats` parameter, and its dtype will be the same as that of `x`.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.repeat_interleave(
             x=x,
@@ -1310,32 +1397,27 @@ class RootInstructionGroup(InstructionGroup):
         keepdim: bool = False,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Sum the elements along a specified dimension.
-
-        This instruction computes the sum of the elements in the register tensor `x` along the specified dimension `dim`.
-        If `keepdim` is set to `True`, the output tensor will have the same number of dimensions as the input tensor,
-        with the specified dimension reduced to size 1. If `keepdim` is set to `False`, the output tensor will have
-        the specified dimension removed, resulting in a tensor with one less dimension.
+        """Sum elements along the specified dimension(s).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to reduce.
+            Input tensor.
         dim: int | Sequence[int], optional
-            The dimension(s) along which to compute the sum. They should be in range of [0, len(x.shape)). If not provided,
-            all dimensions will be reduced.
-        keepdim: bool, optional
-            Whether to keep the reduced dimension in the output tensor. If `True`, the output tensor will have the
-            same number of dimensions as the input tensor, with the specified dimension reduced to size 1. If `False`,
-            the output tensor will have the specified dimension removed, resulting in a tensor with one less dimension.
-            Default is `False`.
+            Dimension(s) to reduce. If not provided, reduces all dimensions.
+        keepdim: bool
+            If ``True``, retains the reduced dimension with size 1. Default is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the sum of the elements along the specified dimension.
+            The reduced tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._reduce(x, dim=dim, keepdim=keepdim, op="sum", out=out)
 
@@ -1347,27 +1429,27 @@ class RootInstructionGroup(InstructionGroup):
         keepdim: bool = False,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the maximum value along a dimension.
+        """Compute the maximum along the specified dimension(s).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to reduce.
+            Input tensor.
         dim: int | Sequence[int], optional
-            The dimension(s) along which to compute the maximum value. They should be in range of [0, len(x.shape)). If not provided,
-            all dimensions will be reduced.
-        keepdim: bool, optional
-            Whether to keep the reduced dimension in the output tensor. If `True`, the output tensor will have the
-            same number of dimensions as the input tensor, with the specified dimension reduced to size 1. If `False`,
-            the output tensor will have the specified dimension removed, resulting in a tensor with one less dimension.
-            Default is `False`.
+            Dimension(s) to reduce. If not provided, reduces all dimensions.
+        keepdim: bool
+            If ``True``, retains the reduced dimension with size 1. Default is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the maximum value along the specified dimension.
+            The reduced tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._reduce(x, dim=dim, keepdim=keepdim, op="max", out=out)
 
@@ -1379,32 +1461,27 @@ class RootInstructionGroup(InstructionGroup):
         keepdim: bool = False,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute the minimum value along a dimension.
-
-        This instruction computes the minimum value of the elements in the register tensor `x` along the specified
-        dimension `dim`. If `keepdim` is set to `True`, the output tensor will have the same number of dimensions as
-        the input tensor, with the specified dimension reduced to size 1. If `keepdim` is set to `False`, the output
-        tensor will have the specified dimension removed, resulting in a tensor with one less dimension.
+        """Compute the minimum along the specified dimension(s).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to reduce.
+            Input tensor.
         dim: int | Sequence[int], optional
-            The dimension(s) along which to compute the minimum value. They should be in range of [0, len(x.shape)). If not provided,
-            all dimensions will be reduced.
-        keepdim: bool, optional
-            Whether to keep the reduced dimension in the output tensor. If `True`, the output tensor will have the
-            same number of dimensions as the input tensor, with the specified dimension reduced to size 1. If `False`,
-            the output tensor will have the specified dimension removed, resulting in a tensor with one less dimension.
-            Default is `False`.
+            Dimension(s) to reduce. If not provided, reduces all dimensions.
+        keepdim: bool
+            If ``True``, retains the reduced dimension with size 1. Default is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the minimum value along the specified dimension.
+            The reduced tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._reduce(x, dim=dim, keepdim=keepdim, op="min", out=out)
 
@@ -1416,33 +1493,27 @@ class RootInstructionGroup(InstructionGroup):
         keepdim: bool = False,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute whether there is a non-zero element along a dimension.
-
-        This instruction computes whether any element in the register tensor `x` along the specified
-        dimension `dim` is non-zero. If `keepdim` is set to `True`, the output tensor will have the same number of dimensions as the
-        input tensor, with the specified dimension reduced to size 1. If `keepdim` is set to `False`, the output tensor will have the
-        specified dimension removed, resulting in a tensor with one less dimension.
+        """Test whether any element is non-zero along the specified dimension(s).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to reduce. It must be a boolean tensor.
+            Input boolean tensor.
         dim: int | Sequence[int], optional
-            The dimension(s) along which to compute the any value. They should be in range of [0, len(x.shape)). If not provided,
-            all dimensions will be reduced.
-        keepdim: bool, optional
-            Whether to keep the reduced dimension in the output tensor. If `True`, the output tensor will have the
-            same number of dimensions as the input tensor, with the specified dimension reduced to size 1. If `False`,
-            the output tensor will have the specified dimension removed, resulting in a tensor with one less dimension.
-            Default is `False`.
+            Dimension(s) to reduce. If not provided, reduces all dimensions.
+        keepdim: bool
+            If ``True``, retains the reduced dimension with size 1. Default is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the boolean result of whether any element in the register tensor `x` along the specified
-            dimension `dim` is non-zero. The data type of the output tensor will be boolean.
+            Boolean tensor with the reduction result.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if x.dtype != boolean:
             raise InstructionError("The input tensor must be a boolean tensor.")
@@ -1456,89 +1527,75 @@ class RootInstructionGroup(InstructionGroup):
         keepdim: bool = False,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Compute whether all elements are non-zero along a dimension.
-
-        This instruction computes whether all elements in the register tensor `x` along the specified
-        dimension `dim` are non-zero. If `keepdim` is set to `True`, the output tensor will have the same number of dimensions as the
-        input tensor, with the specified dimension reduced to size 1. If `keepdim` is set to `False`, the output tensor will have the
-        specified dimension removed, resulting in a tensor with one less dimension.
+        """Test whether all elements are non-zero along the specified dimension(s).
 
         Parameters
         ----------
         x: RegisterTensor
-            The register tensor to reduce. It must be a boolean tensor.
+            Input boolean tensor.
         dim: int | Sequence[int], optional
-            The dimension along which to compute the all value. This should be a valid dimension index for the tensor. If not provided,
-            all dimensions will be reduced.
-        keepdim: bool, optional
-            Whether to keep the reduced dimension in the output tensor. If `True`, the output tensor will have the same number of dimensions as the
-            input tensor, with the specified dimension reduced to size 1. If `keepdim` is set to `False`, the output tensor will have the
-            specified dimension removed, resulting in a tensor with one less dimension.
-            Default is `False`.
+            Dimension(s) to reduce. If not provided, reduces all dimensions.
+        keepdim: bool
+            If ``True``, retains the reduced dimension with size 1. Default is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the boolean result of whether all elements in the register tensor `x` along the specified
-            dimension `dim` are non-zero. The data type of the output tensor will be boolean.
+            Boolean tensor with the reduction result.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if x.dtype != boolean:
             raise InstructionError("The input tensor must be a boolean tensor.")
         return self._reduce(x, dim=dim, keepdim=keepdim, op="all", out=out)
 
     def add(self, lhs: RegisterTensor, rhs: RegisterTensor, out: Optional[RegisterTensor] = None) -> RegisterTensor:
-        """Add two register tensors element-wise.
-
-        This instruction computes the element-wise addition of two register tensors `lhs` and `rhs`. The result is a new
-        register tensor with the same dtype.
-
-        This instruction supports broadcasting, so if the shapes of `lhs` and `rhs` are not the same, they will be
-        broadcasted to a common shape before performing the addition. The broadcasting rules are similar to those in
-        NumPy and PyTorch, where dimensions of size 1 can be expanded to match the other tensor's shape.
+        """Element-wise addition with broadcasting.
 
         Parameters
         ----------
         lhs: RegisterTensor
-            The left-hand side register tensor to add.
+            Left operand.
         rhs: RegisterTensor
-            The right-hand side register tensor to add.
+            Right operand.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the element-wise sum of `lhs` and `rhs`. The shape of the output
-            tensor will be determined by the broadcasting rules applied to `lhs` and `rhs`.
+            ``lhs + rhs``, broadcast to a common shape.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.add(lhs, rhs, out=out)
 
     def maximum(self, lhs: RegisterTensor, rhs: RegisterTensor, out: Optional[RegisterTensor] = None) -> RegisterTensor:
-        """Compute the element-wise maximum.
-
-        This instruction computes the element-wise maximum of two register tensors `lhs` and `rhs`. The result is a new
-        register tensor with the same dtype.
-
-        This instruction supports broadcasting, so if the shapes of `lhs` and `rhs` are not the same, they will be
-        broadcasted to a common shape before performing the maximum operation. The broadcasting rules are similar to
-        those in NumPy and PyTorch, where dimensions of size 1 can be expanded to match the other tensor's shape.
+        """Element-wise maximum with broadcasting.
 
         Parameters
         ----------
         lhs: RegisterTensor
-            The left-hand side register tensor to compare.
+            Left operand.
         rhs: RegisterTensor
-            The right-hand side register tensor to compare.
+            Right operand.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the element-wise maximum of `lhs` and `rhs`. The shape of the output
-            tensor will be determined by the broadcasting rules applied to `lhs` and `rhs`.
+            ``max(lhs, rhs)`` element-wise, broadcast to a common shape.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         return self._builder.maximum(lhs, rhs, out=out)
 
@@ -1550,37 +1607,30 @@ class RootInstructionGroup(InstructionGroup):
         *,
         out: Optional[RegisterTensor] = None,
     ) -> RegisterTensor:
-        """Select elements from two tensors based on a condition.
+        """Select elements from ``x`` or ``y`` based on a boolean condition.
 
-        This instruction selects elements from two tensors `x` and `y` based on a boolean condition tensor. For each
-        element in the condition tensor, if the condition is `True`, the corresponding element from `x` is selected,
-        otherwise the corresponding element from `y` is selected. The result is a new register tensor with the same
-        dtype as `x` and `y`.
-
-        This instruction supports broadcasting, so if the shapes of `x` and `y` are not the same, they will be
-        broadcasted to a common shape before performing the selection. The broadcasting rules are similar to those in
-        NumPy and PyTorch, where dimensions of size 1 can be expanded to match the other tensor's shape.
+        Returns ``x`` where ``condition`` is ``True``, ``y`` otherwise. Supports broadcasting.
+        Scalar values for ``x`` or ``y`` are automatically promoted to tensors.
 
         Parameters
         ----------
         condition: RegisterTensor
-            The boolean register tensor that determines which elements to select from `x` and `y`. Its shape must match
-            the shape of `x` and `y` after broadcasting.
+            Boolean tensor determining element selection.
         x: RegisterTensor | Expr | int | float
-            The register tensor or expression to select elements from when the condition is `True`. If `x` is not a
-            register tensor, it will be converted to a zero-dimensional register tensor with the same dtype as `y`.
+            Values selected where ``condition`` is ``True``.
         y: RegisterTensor | Expr | int | float
-            The register tensor or expression to select elements from when the condition is `False`. If `y` is not a
-            register tensor, it will be converted to a zero-dimensional register tensor with the same dtype as `x`.
+            Values selected where ``condition`` is ``False``.
         out: RegisterTensor, optional
-            The register tensor to store the result. If not provided, a new register tensor will be allocated.
+            Output tensor. If not provided, a new tensor is allocated.
 
         Returns
         -------
         ret: RegisterTensor
-            The register tensor containing the selected elements based on the condition. The shape of the output tensor
-            will be determined by the broadcasting rules applied to `x` and `y`. The dtype of the output tensor will be
-            the same as that of `x` and `y`.
+            Tensor with the same dtype as ``x`` and ``y``, broadcast to a common shape.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if not isinstance(condition, RegisterTensor):
             cond_expr = as_expr(condition)
@@ -1611,6 +1661,10 @@ class RootInstructionGroup(InstructionGroup):
         value: Expr | int
             The value to lock the semaphore with. This can be an integer or an expression that evaluates to an 32-bit
             signed integer.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a single thread (use ``self.single_thread()``).
         """
         self._builder.lock_semaphore(semaphore, value)
 
@@ -1628,20 +1682,22 @@ class RootInstructionGroup(InstructionGroup):
         value: Expr | int
             The value to release the semaphore with. This can be an integer or an expression that evaluates to an
             32-bit signed integer.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a single thread (use ``self.single_thread()``).
         """
         self._builder.release_semaphore(semaphore, value)
-
-    def cluster_sync(self) -> None:
-        """Perform a cluster-wide synchronization.
-
-        All threads in the entire block cluster will wait at this point until all threads reach this instruction.
-        """
-        self._builder.cluster_sync()
 
     def sync(self) -> None:
         """Perform a synchronization.
 
         The thread block will continue execution only after all previous instructions finished executing.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **PTX**: ``bar.sync``
         """
         self._builder.syncthreads()
 
@@ -1667,6 +1723,10 @@ class RootInstructionGroup(InstructionGroup):
             The tensor to annotate.
         layout: RegisterLayout | SharedLayout
             The layout to annotate the tensor with. The type of layout must match the type of tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         self._builder.annotate_layout(tensor, layout)
 
@@ -1694,6 +1754,10 @@ class RootInstructionGroup(InstructionGroup):
             - float16: "%5.2f"
             - float32: "%6.3f"
             - boolean: "%1d"
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         self._builder.print_tensor(msg=msg, tensor=tensor, fmt=fmt)
 
@@ -1718,6 +1782,10 @@ class RootInstructionGroup(InstructionGroup):
         :c:func:`printf`: The C-style printf function for formatted output. For its documentation, refer to the
         `printf reference <https://cplusplus.com/reference/cstdio/printf/>`_.
 
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         self._builder.printf(fstring, *args)
 
@@ -1732,6 +1800,10 @@ class RootInstructionGroup(InstructionGroup):
             The destination tensor.
         src: RegisterTensor
             The source tensor.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         if dst.dtype != src.dtype:
             raise InstructionError("The dtypes of dst and src must match, got {} and {}".format(dst.dtype, src.dtype))
@@ -1759,6 +1831,10 @@ class RootInstructionGroup(InstructionGroup):
             floor(a / b)
         remainder : Expr
             a % b (computed as a - quotient * b)
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
         """
         from tilus.hidet.ir.primitives.cuda.fast_divmod import fastdiv
 

--- a/python/tilus/lang/instructions/tcgen05.py
+++ b/python/tilus/lang/instructions/tcgen05.py
@@ -23,7 +23,57 @@ from .root import InstructionGroup
 
 
 class Tcgen05InstructionGroup(InstructionGroup):
+    """Tensor Core Generation 05 (tcgen05) instructions for Blackwell GPUs.
+
+    Blackwell introduces **tensor memory (TMEM)**, a high-bandwidth on-chip memory space dedicated
+    to the tensor core. Unlike registers (which are per-thread), TMEM is a shared accumulator space
+    that persists across loop iterations without the cost of register spilling.
+
+    The tcgen05 instruction group manages the full lifecycle of TMEM tensors:
+
+    - **Allocation**: ``alloc()`` / ``dealloc()`` manage TMEM capacity. ``relinquish_alloc_permit()``
+      yields allocation rights to a peer CTA when using ``cta_group=2``.
+    - **Views**: ``slice()`` and ``view()`` create sub-region or reinterpreted views without copying.
+    - **Data movement**: ``load()`` / ``store()`` transfer between TMEM and registers.
+      ``copy()`` transfers from shared memory to TMEM. All are async and require
+      ``wait_load()`` / ``wait_store()`` or ``commit()`` for synchronization.
+    - **Compute**: ``mma()`` performs matrix multiply-accumulate with the accumulator in TMEM,
+      supporting both shared-memory and TMEM operands for the A matrix.
+    - **Synchronization**: ``commit()`` signals an mbarrier when pending async operations complete.
+
+    With ``cta_group=2``, two CTAs in the same cluster collaborate: each CTA provides half the
+    data (split along the M dimension) and holds half the accumulator, enabling larger tile sizes.
+    """
+
     def alloc(self, dtype: DataType, shape: Sequence[int], cta_group: int = 1) -> TMemoryTensor:
+        """Allocate a tensor in tensor memory (TMEM).
+
+        Tensor memory is a high-bandwidth on-chip memory space accessible by the tensor core
+        on Blackwell GPUs. The allocated tensor can be used as an accumulator for MMA operations
+        or for load/store operations.
+
+        Parameters
+        ----------
+        dtype: DataType
+            The data type of the tensor elements (e.g., ``float32``, ``float16``).
+        shape: Sequence[int]
+            The shape of the tensor. Must have at least 2 dimensions. The second-to-last
+            dimension (``shape[-2]``) must be 32, 64, or 128.
+        cta_group: int
+            The CTA group size for the allocation. Must be 1 or 2. When 2, the tensor is
+            shared across two CTAs in the same cluster.
+
+        Returns
+        -------
+        ret: TMemoryTensor
+            The allocated tensor memory tensor.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a thread group with at least 32 threads (one warp).
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.alloc``
+        """
         if cta_group not in [1, 2]:
             raise InstructionError("cta_group must be 1 or 2")
         if len(shape) < 2:
@@ -36,25 +86,134 @@ class Tcgen05InstructionGroup(InstructionGroup):
         return ret
 
     def dealloc(self, tensor: TMemoryTensor) -> None:
+        """Deallocate a tensor memory tensor.
+
+        Releases the tensor memory previously allocated with ``tcgen05.alloc``.
+
+        Parameters
+        ----------
+        tensor: TMemoryTensor
+            The tensor memory tensor to deallocate.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a thread group with at least 32 threads (one warp).
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.dealloc``
+        """
         self._builder.tcgen05_dealloc(tensor)
 
     def slice(
         self, tensor: TMemoryTensor, offsets: Sequence[Expr | int], dims: Sequence[int], shape: Sequence[int]
     ) -> TMemoryTensor:
+        """Create a sliced view of a tensor memory tensor.
+
+        Returns a new ``TMemoryTensor`` that refers to a sub-region of the original tensor.
+        This is a metadata-only operation and does not copy data.
+
+        Parameters
+        ----------
+        tensor: TMemoryTensor
+            The source tensor memory tensor.
+        offsets: Sequence[Expr | int]
+            The starting offsets for each dimension being sliced.
+        dims: Sequence[int]
+            The dimensions along which to slice.
+        shape: Sequence[int]
+            The shape of the resulting sliced tensor.
+
+        Returns
+        -------
+        ret: TMemoryTensor
+            A new tensor memory tensor referencing the sliced sub-region.
+        """
         return self._builder.tcgen05_slice(tensor, offsets, dims, shape)
 
     def view(self, tensor: TMemoryTensor, dtype: DataType, shape: Sequence[int]) -> TMemoryTensor:
+        """Reinterpret a tensor memory tensor with a different dtype and shape.
+
+        Returns a new ``TMemoryTensor`` that views the same underlying tensor memory with
+        a different data type and shape. This is a metadata-only operation.
+
+        Parameters
+        ----------
+        tensor: TMemoryTensor
+            The source tensor memory tensor.
+        dtype: DataType
+            The new data type for the view.
+        shape: Sequence[int]
+            The new shape for the view.
+
+        Returns
+        -------
+        ret: TMemoryTensor
+            A new tensor memory tensor with the specified dtype and shape.
+        """
         return self._builder.tcgen05_view(tensor, dtype, shape)
 
     def relinquish_alloc_permit(self, cta_group: int) -> None:
+        """Relinquish the tensor memory allocation permit.
+
+        After this instruction, the current CTA group can no longer allocate tensor memory
+        until the permit is re-acquired (which happens implicitly after deallocation).
+        This allows the peer CTA group to allocate tensor memory.
+
+        Parameters
+        ----------
+        cta_group: int
+            The CTA group whose allocation permit is being relinquished. Must be 1 or 2.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.relinquish_alloc_permit``
+        """
         self._builder.tcgen05_relinquish_alloc_permit(cta_group)
 
     def load(self, tensor: TMemoryTensor) -> RegisterTensor:
+        """Load data from tensor memory into registers.
+
+        Copies the contents of a 2D tensor memory tensor into a register tensor.
+
+        Parameters
+        ----------
+        tensor: TMemoryTensor
+            The source tensor memory tensor. Must be 2D.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A register tensor containing the loaded data.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp-aligned thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.ld.sync.aligned``
+        """
         if len(tensor.shape) != 2:
             raise InstructionError("load requires a 2D tensor memory tensor, got shape {}".format(tensor.shape))
         return self._builder.tcgen05_load(tensor)
 
     def store(self, tensor: TMemoryTensor, src: RegisterTensor) -> None:
+        """Store data from registers into tensor memory.
+
+        Copies the contents of a register tensor into a 2D tensor memory tensor.
+
+        Parameters
+        ----------
+        tensor: TMemoryTensor
+            The destination tensor memory tensor. Must be 2D.
+        src: RegisterTensor
+            The source register tensor. Must be 2D.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp-aligned thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.st.sync.aligned``
+        """
         if len(tensor.shape) != 2:
             raise InstructionError("store requires a 2D tensor memory tensor, got shape {}".format(tensor.shape))
         if len(src.shape) != 2:
@@ -62,12 +221,50 @@ class Tcgen05InstructionGroup(InstructionGroup):
         return self._builder.tcgen05_store(tensor, src)
 
     def wait_load(self) -> None:
+        """Wait for all pending tensor memory load operations to complete.
+
+        Must be called after ``tcgen05.load`` before using the loaded register data.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.wait::ld``
+        """
         self._builder.tcgen05_wait_load()
 
     def wait_store(self) -> None:
+        """Wait for all pending tensor memory store operations to complete.
+
+        Must be called after ``tcgen05.store`` before reading from the destination tensor memory.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.wait::st``
+        """
         self._builder.tcgen05_wait_store()
 
     def copy(self, src: SharedTensor, dst: TMemoryTensor) -> None:
+        """Copy data from shared memory to tensor memory.
+
+        Asynchronously copies a 2D shared tensor into a 2D tensor memory tensor. Use
+        ``tcgen05.commit`` to signal completion via an mbarrier.
+
+        Parameters
+        ----------
+        src: SharedTensor
+            The source shared tensor. Must be 2D.
+        dst: TMemoryTensor
+            The destination tensor memory tensor. Must be 2D.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp-aligned thread group.
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.cp``
+        """
         if len(src.shape) != 2:
             raise InstructionError("copy requires a 2D shared tensor, got shape {}".format(src.shape))
         if len(dst.shape) != 2:
@@ -75,6 +272,28 @@ class Tcgen05InstructionGroup(InstructionGroup):
         self._builder.tcgen05_copy(src, dst)
 
     def commit(self, mbarrier: Expr | RegisterTensor, cta_group: int = 1, multicast_mask: Optional[int] = None) -> None:
+        """Commit pending tcgen05 async operations and signal an mbarrier.
+
+        Groups all prior uncommitted tcgen05 async operations (e.g., ``copy``, ``mma``) and
+        signals the specified mbarrier upon completion. The mbarrier's tx-count will be
+        decreased when the operations finish.
+
+        Parameters
+        ----------
+        mbarrier: Expr | RegisterTensor
+            The memory barrier to signal upon completion.
+        cta_group: int
+            The CTA group size. Must be 1 or 2.
+        multicast_mask: Optional[int]
+            If provided, signals mbarriers on multiple CTAs in the cluster specified by
+            the bitmask.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a single warp (use ``self.single_warp()``).
+        - **Hardware**: Requires compute capability 10.0+ (sm_100).
+        - **PTX**: ``tcgen05.commit``
+        """
         num_threads = self._builder.tg_stack.current_num_threads
         if num_threads != 32:
             raise InstructionError(
@@ -90,49 +309,38 @@ class Tcgen05InstructionGroup(InstructionGroup):
         enable_input_d: Expr | bool,
         cta_group: int = 1,
     ) -> None:
-        """
-        Perform tensor core matrix multiply-accumulate (MMA) operation.
+        """Perform tensor core matrix multiply-accumulate with TMEM accumulator.
 
-        This instruction performs MMA operation: D = A @ B + D, where A, B, and D are matrices.
-        The matrices A, B, and D must be 2D tensors. A can be either in shared memory or tensor memory,
-        while B must be in shared memory and D must be in tensor memory.
+        Computes ``d = a @ b + d`` (or ``d = a @ b`` when ``enable_input_d=False``).
+        All operands must be 2D: ``a`` is ``[M, K]``, ``b`` is ``[K, N]``, ``d`` is ``[M, N]``.
 
-        The `cta_group` parameter specifies which the CTA(s) that will execute the MMA operation.
-        - If `cta_group` is 1, the instruction will be executed by the current CTA only.
-        - If `cta_group` is 2, the instruction will be executed by the current CTA and its peer CTA in the same cluster.
+        When ``cta_group=2``, two CTAs collaborate on the MMA. Each CTA provides half the
+        operands and holds half the accumulator:
 
-        The shape of A, B, and D are (M, K), (K, N), and (M, N) respectively.
+        - ``A = [a0; a1]`` — A has shape (M, K), each CTA provides (M/2, K)
+        - ``B = [b0, b1]`` — B has shape (K, N), each CTA provides (K, N/2)
+        - ``D = [d0; d1]`` — D has shape (M, N), each CTA holds (M/2, N)
 
-        When `cta_group` is 1, the given tensors `a`, `b`, and `d` match the shape requirements above directly.
-
-        When `cta_group` is 2, the computation of the MMA is performed collaboratively by two CTAs, and each CTA will provide part of
-        the input tensors and hold part of the output tensor. We name the CTA whose CTA rank in the cluster has last bit 0 as CTA0, and the other as CTA1.
-        We use `a0`, `b0`, `d0` to denote the slices of A, B, and D provided by CTA0, and 'a1', `b1`, `d1` for CTA1.
-        We can represent A, B, and D as follows:
-        - A = [a0]
-              [a1]
-            where A has shape (M, K), a0 and a1 each has shape (M/2, K)
-        - B = [b0, b1]
-            where B has shape (K, N), b0 and b1 each has shape (K, N/2)
-        - D = [d0]
-              [d1]
-            where D has shape (M, N), d0 and d1 each has shape (M/2, N)
-
-        The parameter `enable_input_d` is a boolean expression that indicates whether the input D should be used as the initial value of the accumulator in the MMA operation.
-        When `enable_input_d == False`, what this instruction does becomes `D = A @ B`. Otherwise, the instruction performs `D = A @ B + D`.
+        CTA0 is the CTA whose cluster rank has last bit 0, CTA1 is the other.
 
         Parameters
         ----------
-        a: SharedTensor or TMemoryTensor
-            The first input matrix. Must be a 2D tensor. Can be in shared memory or tensor memory.
+        a: SharedTensor | TMemoryTensor
+            Left-hand operand ``[M, K]``. Can be in shared memory or tensor memory.
         b: SharedTensor
-            The second input matrix. Must be a 2D tensor in shared memory.
+            Right-hand operand ``[K, N]``. Must be in shared memory.
         d: TMemoryTensor
-            The output matrix. Must be a 2D tensor in tensor memory. It also serves as the accumulator input.
+            Accumulator ``[M, N]`` in tensor memory. Used as both input and output.
         enable_input_d: Expr | bool
-            A boolean expression indicating whether the input D should be used as the initial value of the accumulator in the MMA operation.
+            If ``True``, computes ``d = a @ b + d``. If ``False``, computes ``d = a @ b``.
         cta_group: int
-            The CTA group that executes the MMA operation. Must be either 1 or 2.
+            CTA group size. 1 for single-CTA, 2 for two-CTA collaborative MMA.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a single warp (use ``self.single_warp()``).
+        - **Hardware**: Requires compute capability 10.0a+ (sm_100a).
+        - **PTX**: ``tcgen05.mma``
         """
         num_threads = self._builder.tg_stack.current_num_threads
         if num_threads != 32:

--- a/python/tilus/lang/instructions/tma.py
+++ b/python/tilus/lang/instructions/tma.py
@@ -21,6 +21,27 @@ from .root import InstructionGroup
 
 
 class TmaInstructionGroup(InstructionGroup):
+    """Tensor Memory Accelerator (TMA) instructions for asynchronous bulk data transfers.
+
+    TMA is a dedicated hardware engine on Hopper+ GPUs that asynchronously copies multi-dimensional
+    tiles between global memory and shared memory, without occupying SM compute resources.
+
+    TMA transfers are **asynchronous**: the issuing thread returns immediately while the TMA engine
+    performs the copy in the background. Completion is tracked through mbarriers:
+
+    1. Issue ``global_to_shared()`` or ``shared_to_global()`` — the mbarrier's tx-count is
+       automatically increased.
+    2. The TMA engine completes the transfer and decrements the mbarrier's tx-count.
+    3. Consumers call ``mbarrier.wait()`` to block until all transfers for a phase are done.
+
+    For legacy (non-mbarrier) async copies, use ``commit_group()`` and ``wait_group()`` to
+    group and synchronize transfers.
+
+    TMA supports **multicast** (``multicast_mask``) to deliver the same global tile to shared
+    memory of multiple CTAs in a cluster, and **CTA groups** (``cta_group=2``) for coordinated
+    two-CTA operations where the mbarrier can reside on a peer CTA.
+    """
+
     def global_to_shared(
         self,
         *,
@@ -33,42 +54,27 @@ class TmaInstructionGroup(InstructionGroup):
         multicast_mask: Optional[Expr | int] = None,
         cache_policy: Optional[Expr] = None,
     ) -> None:
-        """
-        TMA async copy from global to shared tensor asynchronously.
+        """Asynchronously copy a tile from global memory to shared memory via TMA.
 
-        This instruction issues a TMA tensor async copy from global to shared tensor.
+        Issues an asynchronous TMA transfer from a region of ``src`` (global) to ``dst`` (shared).
+        The ``offsets`` specify where in the global tensor the tile starts, and ``dims`` specifies
+        which global dimensions map to the shared tensor dimensions.
 
-        The `src` parameter specifies the global tensor to copy from, while the `dst` parameter specifies the shared
-        tensor to copy to.
+        Completion is tracked via the ``mbarrier``: this instruction automatically increases the
+        barrier's tx-count by the transfer size in bytes. When the TMA engine finishes, it
+        decrements the tx-count by the same amount. Use ``mbarrier.wait()`` to block until done.
 
-        The `offsets` parameter specifies the starting offsets for each dimension of the global tensor where the tile
-        will be copied from. The length of this sequence must match the number of dimensions of the global tensor.
+        **Multicast and CTA groups:**
 
-        The `dims` parameter specifies which dimensions of the global tensor are being sliced. The dimension dim[0] of
-        the global tensor corresponds to the first dimension of the shared tensor, dim[1] to the second, and so on.
-
-        The `mbarrier` parameter specifies the memory barrier to be used for synchronizing the copy operation. It should be an uint32
-        expression or a register tensor with one element of uint32 type specifying the address of the barrier in shared space.
-        This instruction will signal an arrival to the barrier and increase the expect-tx by the number of bytes pending in the copy operation.
-        Upon finishing the underlying TMA operation, the TMA engine will signal to reduce the expect-rx by the same number of bytes.
-
-        The `cta_group` and `multicast_mask` parameters specify whether the loaded data will be multicast to other thread blocks in the same cluster,
-        and how the mbarrier signaling is handled.
-        - When `cta_group == 1` and `multicast_mask == None`, both `dst` and `mbarrier` must be in the current thread block.
-        - When `cta_group == 1` and `multicast_mask != None`, the loaded data will be stored in the thread blocks specified by `multicast_mask`.
-          The same offset of the shared memory as `dst` will be used in those thread blocks.  The `mbarrier` must be in the current thread block.
-        - When `cta_group == 2` and `multicast_mask == None`, The `dst` must be in the current thread block, while the `mbarrier` can be in
-          the current or the peer thread block in the cluster.
-        - When `cta_group == 2` and `multicast_mask != None`, the loaded data will be stored in the thread blocks specified by `multicast_mask`.
-          The same offset of the shared memory as `dst` will be used in those thread blocks. The `mbarrier` can be in the current or the peer
-          thread block. When it is in the current thread block, the mbarrier with the same shared memory offset in thread blocks specified in `multicast_mask`
-          will be signaled. When the `mbarrier` is in the peer thread block, the mbarrier with the same shared memory offset in the peer thread blocks for
-          the thread blocks in `multicast_mask` will be signaled.
-
-        If `multicast_mask` is given, it should be a uint16 variable specifying the multicast mask to be used, where the i-th bit specifying the
-        thread block with rank i.
-
-        The `cache_policy` parameter specifies the cache policy to be used. It should be an uint64 variable encoded with the cache policy.
+        - ``cta_group=1, multicast_mask=None``: single-CTA transfer. Both ``dst`` and ``mbarrier``
+          must be in the current CTA.
+        - ``cta_group=1, multicast_mask != None``: the loaded tile is delivered to shared memory of
+          all CTAs specified by the mask. ``mbarrier`` must be in the current CTA.
+        - ``cta_group=2, multicast_mask=None``: ``dst`` must be in the current CTA, but ``mbarrier``
+          can be in the current or peer CTA.
+        - ``cta_group=2, multicast_mask != None``: the tile is multicast, and ``mbarrier`` can be in
+          the current or peer CTA. Barriers at the same shared memory offset in the target CTAs
+          are signaled.
 
         Parameters
         ----------
@@ -77,18 +83,29 @@ class TmaInstructionGroup(InstructionGroup):
         dst: SharedTensor
             The shared tensor to copy to.
         offsets: Sequence[Expr | int]
-            The offsets for each dimension of the global tensor where the tile will be copied from. The
-            length of this sequence must match the number of dimensions of the global tensor.
-        dims: Sequence[int]
-            The dimensions of the global tensor that are being sliced. The length of this sequence must match the
-            number of dimensions of the shared tensor being copied to.
+            Starting offsets for each dimension of the global tensor. Length must match the rank
+            of the global tensor.
+        dims: Sequence[int], optional
+            Which dimensions of the global tensor are being sliced. ``dims[0]`` maps to the first
+            dimension of the shared tensor, ``dims[1]`` to the second, etc. If not provided,
+            defaults to all dimensions in order.
         mbarrier: Expr | RegisterTensor
-            The memory barrier to be used for synchronizing the copy operation. It should be an uint32 expression specifying the address
-            of the barrier in shared space. It can also be a register tensor with a single element of uint32 type containing the address of the barrier.
-        multicast_mask: Optional[Expr]
-            The multicast mask to be used. It should be a uint16 variable specifying the multicast thread blocks. When not given, no multicast is performed.
+            The barrier for tracking completion. A uint32 expression or single-element register
+            tensor containing the barrier's shared memory address.
+        cta_group: int
+            CTA group size for the transfer. 1 (default) for single-CTA, 2 for two-CTA
+            coordinated operations.
+        multicast_mask: Optional[Expr | int]
+            A uint16 bitmask specifying which CTAs in the cluster receive the data. Bit *i*
+            corresponds to the CTA with rank *i*. When ``None``, no multicast is performed.
         cache_policy: Optional[Expr]
-            The cache policy to be used. It should be an uint64 variable encoded with the cache policy.
+            Cache eviction policy encoded as a uint64 value.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp-aligned thread group (i.e., a multiple of 32 threads).
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``cp.async.bulk.tensor.global.shared::cta.tile.mbarrier::complete_tx::bytes``
         """
         self._builder.copy_async_tensor_global_to_shared(
             src=src,
@@ -109,21 +126,20 @@ class TmaInstructionGroup(InstructionGroup):
         dims: Optional[Sequence[int]] = None,
         cache_policy: Optional[Expr] = None,
     ) -> None:
-        """
-        TMA async copy from shared to global tensor asynchronously.
+        """Asynchronously copy a tile from shared memory to global memory via TMA.
 
-        This instruction issues a TMA tensor async copy from shared to global tensor.
+        Issues an asynchronous TMA transfer from ``src`` (shared) to a region of ``dst`` (global).
+        The ``offsets`` specify where in the global tensor the tile is written to, and ``dims``
+        specifies which global dimensions map to the shared tensor dimensions.
 
-        The `src` parameter specifies the shared tensor to copy from, while the `dst` parameter specifies the global
-        tensor to copy to.
+        Unlike ``global_to_shared()``, this instruction does not use an mbarrier. Use
+        ``commit_group()`` and ``wait_group()`` to synchronize completion.
 
-        The `offsets` parameter specifies the starting offsets for each dimension of the global tensor where the tile
-        will be copied to. The length of this sequence must match the number of dimensions of the global tensor.
+        .. important::
 
-        The `dims` parameter specifies which dimensions of the global tensor are being sliced. The dimension dim[0] of
-        the global tensor corresponds to the first dimension of the shared tensor, dim[1] to the second, and so on.
-
-        The `cache_policy` parameter specifies the cache policy to be used. It should be an uint64 variable encoded with the cache policy.
+            If the shared memory data was written via the **generic proxy** (e.g., ``store_shared()``),
+            a ``fence.proxy_async()`` or ``fence.proxy_async_release()`` must be called before this
+            instruction to ensure the writes are visible to the TMA engine (async proxy).
 
         Parameters
         ----------
@@ -132,43 +148,51 @@ class TmaInstructionGroup(InstructionGroup):
         dst: GlobalTensor
             The global tensor to copy to.
         offsets: Sequence[Expr | int]
-            The offsets for each dimension of the global tensor where the tile will be copied to. The
-            length of this sequence must match the number of dimensions of the global tensor.
-        dims: Sequence[int]
-            The dimensions of the global tensor that are being sliced. The length of this sequence must match the
-            number of dimensions of the shared tensor being copied from.
+            Starting offsets for each dimension of the global tensor. Length must match the rank
+            of the global tensor.
+        dims: Sequence[int], optional
+            Which dimensions of the global tensor are being sliced. If not provided, defaults to
+            all dimensions in order.
         cache_policy: Optional[Expr]
-            The cache policy to be used. It should be an uint64 variable encoded with the cache policy.
+            Cache eviction policy encoded as a uint64 value.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp-aligned thread group (i.e., a multiple of 32 threads).
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``cp.async.bulk.tensor.shared::cta.global.tile``
         """
         self._builder.copy_async_tensor_shared_to_global(
             src=src, dst=dst, offsets=offsets, dims=dims, cache_policy=cache_policy
         )
 
     def commit_group(self):
-        """
-        Commit the previously issued async tensor copy operations.
+        """Commit pending TMA async copy operations into a group.
 
-        This instruction commits the previously issued async tensor copy operations.
+        Groups all prior uncommitted ``shared_to_global()`` operations so they can be
+        collectively waited on with ``wait_group()``.
 
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``cp.async.bulk.commit_group``
         """
         self._builder.copy_async_tensor_commit_group()
 
     def wait_group(self, n: int, read: bool = False) -> None:
-        """
-        Wait for the previously issued async tensor copy operations to complete.
+        """Wait for TMA async copy commit groups to complete.
 
-        This instruction waits for the previously issued async tensor copy operations to complete.
-        The `n` parameter specifies the number of groups to allow to be on-the-fly.
+        Blocks until at most ``n`` commit groups remain pending. Use ``n=0`` to wait for all
+        committed groups.
 
-        When `read` is False (default), waits for all bulk async operations to complete,
-        including writes being made visible to the executing thread.
+        When ``read=False`` (default), waits for all operations to complete, including writes
+        being visible to the executing thread.
 
-        When `read` is True, only waits for reads from source locations to complete. Use
-        this when the source memory (e.g., shared memory) needs to be reused but there is
-        no subsequent instruction that reads the destination (e.g., global memory) written
-        by the TMA. If subsequent instructions need to load the global memory that the TMA
-        writes to, do NOT use `read=True` — use the default `read=False` to ensure writes
-        are visible.
+        When ``read=True``, only waits for reads from source locations to complete. This is
+        useful when the source shared memory needs to be reused, but there is no subsequent
+        instruction that reads the destination global memory. If subsequent instructions need
+        to read the global memory written by TMA, use the default ``read=False``.
 
         Parameters
         ----------
@@ -176,5 +200,11 @@ class TmaInstructionGroup(InstructionGroup):
             The number of groups to allow to be on-the-fly. It should be an integer larger or equal to 0.
         read: bool
             If True, only wait for reads to complete (not writes). Default is False.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 9.0+ (sm_90).
+        - **PTX**: ``cp.async.bulk.wait_group`` or ``cp.async.bulk.wait_group.read``
         """
         self._builder.copy_async_tensor_wait_group(n, read=read)

--- a/python/tilus/lang/instructions/wgmma.py
+++ b/python/tilus/lang/instructions/wgmma.py
@@ -22,16 +22,102 @@ from .root import InstructionGroup
 
 
 class WgmmaInstructionGroup(InstructionGroup):
+    """Warp Group Matrix Multiply-Accumulate (WGMMA) instructions for Hopper GPUs.
+
+    WGMMA performs asynchronous matrix multiply-accumulate operations using a **warp group**
+    (4 consecutive warps, 128 threads). The operands reside in shared memory (``a``, ``b``) or
+    registers (``a``), and the accumulator (``d``) is in registers.
+
+    WGMMA operations are asynchronous and must follow a strict execution protocol:
+
+    1. ``fence()`` — establish memory ordering so prior writes to operands are visible.
+    2. ``mma()`` — issue one or more async MMA operations (can be called multiple times).
+    3. ``commit_group()`` — group all pending MMAs into a commit group.
+    4. ``wait_group(n)`` — wait until at most ``n`` commit groups remain pending.
+
+    Multiple commit groups can be in flight simultaneously for latency hiding in pipelined
+    loops. For example, issue new MMAs while waiting for a previous group to complete.
+
+    All WGMMA instructions must be executed by a full warp group (4 warps). Use
+    ``self.warp_group()`` to create the appropriate thread group context.
+    """
+
     def fence(self) -> None:
+        """Issue a warp group MMA fence.
+
+        This fence must be issued before any ``wgmma.mma`` instruction to ensure that prior
+        register or shared memory writes are visible to the MMA operation. It establishes
+        ordering between generic memory accesses and subsequent wgmma operations.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp group (4 warps).
+        - **Hardware**: Requires compute capability 9.0a+ (sm_90a).
+        - **PTX**: ``wgmma.fence.sync.aligned``
+        """
         self._builder.wgmma_fence()
 
     def commit_group(self) -> None:
+        """Commit the previously issued warp group MMA operations.
+
+        Groups all prior uncommitted ``wgmma.mma`` operations into a commit group
+        that can be waited on with ``wgmma.wait_group``.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp group (4 warps).
+        - **Hardware**: Requires compute capability 9.0a+ (sm_90a).
+        - **PTX**: ``wgmma.commit_group.sync.aligned``
+        """
         self._builder.wgmma_commit_group()
 
     def wait_group(self, n: Union[Expr, int]) -> None:
+        """Wait for warp group MMA commit groups to complete.
+
+        Waits until at most ``n`` commit groups are pending (i.e., all but the most recent
+        ``n`` groups have completed).
+
+        Parameters
+        ----------
+        n: Expr | int
+            The number of commit groups allowed to remain pending. Use 0 to wait for all
+            committed groups to complete.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp group (4 warps).
+        - **Hardware**: Requires compute capability 9.0a+ (sm_90a).
+        - **PTX**: ``wgmma.wait_group.sync.aligned``
+        """
         self._builder.wgmma_wait_group(n)
 
     def mma(self, a: SharedTensor | RegisterTensor, b: SharedTensor, d: RegisterTensor) -> None:
+        """Perform warp group matrix multiply-accumulate (MMA) operation.
+
+        Computes ``d = a @ b + d`` where ``a`` is in shared or register memory, ``b`` is in
+        shared memory, and ``d`` is in register memory (both input accumulator and output).
+
+        All tensors must be 2D with compatible shapes: ``a`` is ``[M, K]``, ``b`` is ``[K, N]``,
+        and ``d`` is ``[M, N]``.
+
+        A ``wgmma.fence()`` must be called before this instruction, and a ``wgmma.commit_group()``
+        followed by ``wgmma.wait_group()`` after.
+
+        Parameters
+        ----------
+        a: SharedTensor | RegisterTensor
+            The left-hand operand of the matrix multiplication. Shape ``[M, K]``.
+        b: SharedTensor
+            The right-hand operand of the matrix multiplication. Shape ``[K, N]``.
+        d: RegisterTensor
+            The accumulator tensor, used as both input and output. Shape ``[M, N]``.
+
+        Notes
+        -----
+        - **Thread group**: Must be executed by a warp group (4 warps).
+        - **Hardware**: Requires compute capability 9.0a+ (sm_90a).
+        - **PTX**: ``wgmma.mma_async.sync.aligned``
+        """
         if any(len(tensor.shape) != 2 for tensor in (a, b, d)):
             raise InstructionError(
                 "mma requires 2D tensors, got shapes {}".format([tensor.shape for tensor in (a, b, d)])

--- a/python/tilus/lang/script.py
+++ b/python/tilus/lang/script.py
@@ -27,10 +27,15 @@ Int: TypeAlias = int | Expr
 
 
 class Attributes:
-    def __init__(self):
-        self.blocks: Optional[Sequence[Int] | Int] = None
-        self.cluster_blocks: Sequence[Int] | Int = (1, 1, 1)
-        self.warps: Optional[int] = None
+    #: The grid dimensions of the kernel launch. Set as a list of up to 3
+    #: integers, e.g., ``self.attrs.blocks = [grid_x, grid_y]``.
+    blocks: Optional[Sequence[Int] | Int] = None
+
+    #: The cluster dimensions. Defaults to ``(1, 1, 1)``.
+    cluster_blocks: Sequence[Int] | Int = (1, 1, 1)
+
+    #: The number of warps per thread block. Must be a compile-time constant.
+    warps: Optional[int] = None
 
 
 class Script(InstructionInterface):


### PR DESCRIPTION
  - Add docstrings to all instruction group classes (mbarrier, fence, tma, wgmma, tcgen05, clc, cluster) with high-level descriptions of the hardware resources they manage and how instructions collaborate
  - Add/revise method-level docstrings across all instruction files with Notes sections (thread group, hardware, PTX requirements)
  - Write full docstrings for undocumented methods: wgmma (4), cluster (5), tcgen05 (11), root.py static_assert and flatten
  - Revise verbose docstrings for conciseness: tma, mbarrier, root.py elementwise/reduction/binary ops
  - Add new instruction group pages: tma, tcgen05, clc, cluster, wgmma
  - Add missing root instructions to tilus-script.rst and instructions.rst
  - Reorganize instructions.rst with category descriptions and all groups
  - Rewrite thread-group.rst programming guide with motivation, shortcuts, and producer-consumer pipeline example
  - Add tilus.target API docs page with predefined targets table
  - Add Script.attrs page with class field documentation
  - Replace self.cluster_sync() with self.cluster.sync() in examples