### PR TITLE
[Tutorial] Add Blackwell matmul V2 tutorial (software pipelining)

### DIFF
--- a/docs/source/tutorials/matmul-blackwell/__init__.rst
+++ b/docs/source/tutorials/matmul-blackwell/__init__.rst
@@ -14,3 +14,4 @@ performance.
 
    v0
    v1
+   v2

--- a/docs/source/tutorials/matmul-blackwell/figures/v2_pipeline.svg
+++ b/docs/source/tutorials/matmul-blackwell/figures/v2_pipeline.svg
@@ -1,0 +1,146 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 410" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13">
+  <!-- V1 (no pipeline): serial load → compute → load → compute -->
+  <text x="380" y="20" text-anchor="middle" font-weight="700" font-size="15" fill="#333">V1: No Pipeline (serial)</text>
+
+  <!-- Timeline axis -->
+  <line x1="80" y1="80" x2="720" y2="80" stroke="#ccc" stroke-width="1"/>
+  <text x="50" y="60" text-anchor="middle" font-size="11" fill="#666">TMA</text>
+  <text x="50" y="85" text-anchor="middle" font-size="11" fill="#666">MMA</text>
+
+  <!-- V1 blocks: load0, mma0, load1, mma1, load2, mma2 -->
+  <rect x="80" y="45" width="100" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="130" y="62" text-anchor="middle" font-size="10" fill="#bf360c">Load k=0</text>
+
+  <rect x="180" y="70" width="80" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="220" y="87" text-anchor="middle" font-size="10" fill="#5e35b1">MMA k=0</text>
+
+  <rect x="260" y="45" width="100" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="310" y="62" text-anchor="middle" font-size="10" fill="#bf360c">Load k=1</text>
+
+  <rect x="360" y="70" width="80" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="400" y="87" text-anchor="middle" font-size="10" fill="#5e35b1">MMA k=1</text>
+
+  <rect x="440" y="45" width="100" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="490" y="62" text-anchor="middle" font-size="10" fill="#bf360c">Load k=2</text>
+
+  <rect x="540" y="70" width="80" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="580" y="87" text-anchor="middle" font-size="10" fill="#5e35b1">MMA k=2</text>
+
+  <text x="660" y="67" font-size="12" fill="#999">...</text>
+
+  <!-- Idle gaps annotation -->
+  <text x="400" y="110" text-anchor="middle" font-size="11" fill="#dc3545" font-weight="600">TMA and MMA never overlap --- wasted time</text>
+
+  <!-- Dividing line -->
+  <line x1="40" y1="135" x2="720" y2="135" stroke="#ccc" stroke-width="1" stroke-dasharray="6,4"/>
+
+  <!-- V2 (3-stage pipeline) -->
+  <text x="380" y="160" text-anchor="middle" font-weight="700" font-size="15" fill="#333">V2: 3-Stage Software Pipeline</text>
+
+  <!-- Stage labels on left -->
+  <text x="50" y="200" text-anchor="middle" font-size="11" fill="#666">TMA</text>
+  <text x="50" y="230" text-anchor="middle" font-size="11" fill="#666">MMA</text>
+
+  <!-- Prefill phase -->
+  <rect x="80" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="115" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=0</text>
+  <rect x="150" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="185" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=1</text>
+
+  <!-- Prefill bracket -->
+  <line x1="80" y1="175" x2="220" y2="175" stroke="#888" stroke-width="1"/>
+  <line x1="80" y1="172" x2="80" y2="178" stroke="#888" stroke-width="1"/>
+  <line x1="220" y1="172" x2="220" y2="178" stroke="#888" stroke-width="1"/>
+  <text x="150" y="170" text-anchor="middle" font-size="9" fill="#888">prefill</text>
+
+  <!-- Main loop: overlapping load and compute -->
+  <!-- Iteration 0: load k=2, mma k=0 -->
+  <rect x="230" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="265" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=2</text>
+  <rect x="230" y="215" width="70" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="265" y="232" text-anchor="middle" font-size="9" fill="#5e35b1">MMA k=0</text>
+
+  <!-- Iteration 1: load k=3, mma k=1 -->
+  <rect x="310" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="345" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=3</text>
+  <rect x="310" y="215" width="70" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="345" y="232" text-anchor="middle" font-size="9" fill="#5e35b1">MMA k=1</text>
+
+  <!-- Iteration 2: load k=4, mma k=2 -->
+  <rect x="390" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="425" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=4</text>
+  <rect x="390" y="215" width="70" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="425" y="232" text-anchor="middle" font-size="9" fill="#5e35b1">MMA k=2</text>
+
+  <!-- Iteration 3: load k=5, mma k=3 -->
+  <rect x="470" y="185" width="70" height="25" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="505" y="202" text-anchor="middle" font-size="9" fill="#bf360c">Load k=5</text>
+  <rect x="470" y="215" width="70" height="25" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="505" y="232" text-anchor="middle" font-size="9" fill="#5e35b1">MMA k=3</text>
+
+  <text x="570" y="205" font-size="12" fill="#999">...</text>
+
+  <!-- Main loop bracket -->
+  <line x1="230" y1="175" x2="540" y2="175" stroke="#888" stroke-width="1"/>
+  <line x1="230" y1="172" x2="230" y2="178" stroke="#888" stroke-width="1"/>
+  <line x1="540" y1="172" x2="540" y2="178" stroke="#888" stroke-width="1"/>
+  <text x="385" y="170" text-anchor="middle" font-size="9" fill="#888">main loop</text>
+
+  <!-- Overlap annotation -->
+  <text x="400" y="260" text-anchor="middle" font-size="11" fill="#28a745" font-weight="600">TMA and MMA overlap --- higher utilization</text>
+
+  <!-- Shared memory stages diagram -->
+  <!-- Stage usage snapshots -->
+  <text x="380" y="290" text-anchor="middle" font-weight="600" font-size="13" fill="#333">Stage Usage (3 stages, showing 3 iterations)</text>
+
+  <!-- Time arrow -->
+  <defs>
+    <marker id="arr-time" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5 Z" fill="#888"/>
+    </marker>
+  </defs>
+  <line x1="50" y1="315" x2="50" y2="395" stroke="#888" stroke-width="1.2" marker-end="url(#arr-time)"/>
+  <text x="50" y="308" text-anchor="middle" font-size="9" fill="#888">time</text>
+
+  <!-- Column headers -->
+  <text x="105" y="310" text-anchor="middle" font-size="10" fill="#666" font-weight="600">Iteration</text>
+  <text x="260" y="310" text-anchor="middle" font-size="10" fill="#155724">Stage 0</text>
+  <text x="400" y="310" text-anchor="middle" font-size="10" fill="#155724">Stage 1</text>
+  <text x="540" y="310" text-anchor="middle" font-size="10" fill="#155724">Stage 2</text>
+
+  <!-- Iter 0: MMA reads stage 0, TMA writes stage 2 -->
+  <text x="105" y="332" text-anchor="middle" font-size="10" fill="#333" font-weight="600">iter 0</text>
+  <rect x="205" y="320" width="110" height="18" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="260" y="333" text-anchor="middle" font-size="9" fill="#5e35b1">MMA reads k=0</text>
+  <rect x="345" y="320" width="110" height="18" rx="3" fill="#f0f0f0" stroke="#ccc" stroke-width="0.8"/>
+  <text x="400" y="333" text-anchor="middle" font-size="9" fill="#999">ready (k=1)</text>
+  <rect x="485" y="320" width="110" height="18" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1"/>
+  <text x="540" y="333" text-anchor="middle" font-size="9" fill="#bf360c">TMA loads k=2</text>
+
+  <!-- Iter 1: MMA reads stage 1, TMA writes stage 0 -->
+  <text x="105" y="352" text-anchor="middle" font-size="10" fill="#333" font-weight="600">iter 1</text>
+  <rect x="205" y="340" width="110" height="18" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1"/>
+  <text x="260" y="353" text-anchor="middle" font-size="9" fill="#bf360c">TMA loads k=3</text>
+  <rect x="345" y="340" width="110" height="18" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="400" y="353" text-anchor="middle" font-size="9" fill="#5e35b1">MMA reads k=1</text>
+  <rect x="485" y="340" width="110" height="18" rx="3" fill="#f0f0f0" stroke="#ccc" stroke-width="0.8"/>
+  <text x="540" y="353" text-anchor="middle" font-size="9" fill="#999">ready (k=2)</text>
+
+  <!-- Iter 2: MMA reads stage 2, TMA writes stage 1 -->
+  <text x="105" y="372" text-anchor="middle" font-size="10" fill="#333" font-weight="600">iter 2</text>
+  <rect x="205" y="360" width="110" height="18" rx="3" fill="#f0f0f0" stroke="#ccc" stroke-width="0.8"/>
+  <text x="260" y="373" text-anchor="middle" font-size="9" fill="#999">ready (k=3)</text>
+  <rect x="345" y="360" width="110" height="18" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1"/>
+  <text x="400" y="373" text-anchor="middle" font-size="9" fill="#bf360c">TMA loads k=4</text>
+  <rect x="485" y="360" width="110" height="18" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="540" y="373" text-anchor="middle" font-size="9" fill="#5e35b1">MMA reads k=2</text>
+
+  <!-- Iter 3: MMA reads stage 0, TMA writes stage 2 (same as iter 0 — cycle repeats) -->
+  <text x="105" y="392" text-anchor="middle" font-size="10" fill="#333" font-weight="600">iter 3</text>
+  <rect x="205" y="380" width="110" height="18" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1"/>
+  <text x="260" y="393" text-anchor="middle" font-size="9" fill="#5e35b1">MMA reads k=3</text>
+  <rect x="345" y="380" width="110" height="18" rx="3" fill="#f0f0f0" stroke="#ccc" stroke-width="0.8"/>
+  <text x="400" y="393" text-anchor="middle" font-size="9" fill="#999">ready (k=4)</text>
+  <rect x="485" y="380" width="110" height="18" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1"/>
+  <text x="540" y="393" text-anchor="middle" font-size="9" fill="#bf360c">TMA loads k=5</text>
+</svg>

--- a/docs/source/tutorials/matmul-blackwell/v0.rst
+++ b/docs/source/tutorials/matmul-blackwell/v0.rst
@@ -351,4 +351,4 @@ Full Source
 -----------
 
 The complete example file is located at
-:download:`examples/blackwell_matmul/matmul_v0.py <../../../../examples/blackwell_matmul/matmul_v0.py>`.
+`examples/blackwell_matmul/matmul_v0.py <https://github.com/NVIDIA/tilus/blob/main/examples/blackwell_matmul/matmul_v0.py>`__.

--- a/docs/source/tutorials/matmul-blackwell/v1.rst
+++ b/docs/source/tutorials/matmul-blackwell/v1.rst
@@ -177,13 +177,14 @@ V1 is still single-stage: the warp waits for TMA to complete before issuing the
 MMA, then waits for MMA before starting the next TMA. Load and compute are
 fully serialized.
 
-In the next version, we introduce **multi-stage software pipelining** --- the
-kernel prefills multiple stages of shared memory before entering the main loop,
-so that the TMA for iteration *i+1* can overlap with the MMA for iteration *i*.
+In :doc:`the next version <v2>`, we introduce **multi-stage software pipelining**
+--- the kernel prefills multiple stages of shared memory before entering the main
+loop, so that the TMA for iteration *i+1* can overlap with the MMA for
+iteration *i*.
 
 
 Full Source
 -----------
 
 The complete example file is located at
-:download:`examples/blackwell_matmul/matmul_v1.py <../../../../examples/blackwell_matmul/matmul_v1.py>`.
+`examples/blackwell_matmul/matmul_v1.py <https://github.com/NVIDIA/tilus/blob/main/examples/blackwell_matmul/matmul_v1.py>`__.

--- a/docs/source/tutorials/matmul-blackwell/v2.rst
+++ b/docs/source/tutorials/matmul-blackwell/v2.rst
@@ -1,0 +1,221 @@
+.. _tutorial_blackwell_matmul_v2:
+
+2. Multi-Stage Software Pipelining
+===================================
+
+In :doc:`V1 <v1>`, each loop iteration first waits for TMA to finish loading data,
+then issues the MMA. Load and compute are fully serialized --- the TMA engine sits
+idle during MMA, and the tensor cores sit idle during TMA.
+
+This version introduces **multi-stage software pipelining**: shared memory is
+divided into multiple stages (a ring buffer), and the kernel prefills several
+stages before entering the main loop. In each iteration of the main loop, the TMA
+loads data for a future iteration while the MMA processes data from a previously
+loaded stage. This overlaps load and compute, significantly improving utilization.
+
+
+The Full Kernel
+---------------
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v2.py
+   :language: python
+   :start-at: @tilus.autotune
+   :end-at: self.tcgen05.dealloc(t_acc)
+   :caption: BlackwellMatmulV2 --- full kernel
+
+
+What Changed from V1
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 40 40
+
+   * -
+     - V1
+     - V2
+   * - **Shared memory**
+     - Single stage: ``[block_m, block_k]``
+     - Multi-stage ring buffer: ``[stages, block_m, block_k]``
+   * - **TMA barriers**
+     - 1 barrier
+     - 1 barrier **per stage**
+   * - **Phase tracking**
+     - Single ``phase`` variable
+     - Per-stage ``tma_phases`` register tensor
+   * - **Loop structure**
+     - Load then compute, serial
+     - Prefill stages, then overlap load and compute
+   * - **New parameter**
+     - ---
+     - ``stages`` (autotuned: 2, 3, or 4)
+
+
+Software Pipelining
+-------------------
+
+.. figure:: figures/v2_pipeline.svg
+   :width: 100%
+   :align: center
+
+   Top: V1 serializes load and compute. Bottom: V2 overlaps them using a
+   multi-stage pipeline.
+
+The idea is simple: if we have ``S`` stages of shared memory, we can have up to
+``S - 1`` TMA loads in flight while one stage is being consumed by MMA. The
+kernel proceeds in two phases:
+
+1. **Prefill** --- Before the main loop, load the first ``S - 1`` stages via TMA.
+   These loads run asynchronously; we do not wait for them yet.
+2. **Main loop** --- Each iteration does three things:
+
+   - **Preload**: issue a TMA load into the next free stage (``preload_stage``).
+   - **Wait**: wait for the current stage's TMA to complete
+     (``tma_barriers[current_stage]``).
+   - **Compute**: run MMA on the current stage's data.
+
+   After each iteration, both ``current_stage`` and ``preload_stage`` advance
+   modulo ``stages``, cycling through the ring buffer.
+
+
+Multi-Stage Shared Memory
+-------------------------
+
+In V1, shared tensors had shape ``[block_m, block_k]`` --- a single buffer that
+was overwritten every iteration. In V2, shared tensors gain a leading stage
+dimension:
+
+.. code-block:: python
+
+   s_a = self.shared_tensor(dtype=float16, shape=[self.stages, self.block_m, self.block_k])
+   s_b = self.shared_tensor(dtype=float16, shape=[self.stages, self.block_n, self.block_k])
+
+Each stage ``s_a[i]`` / ``s_b[i]`` is an independent buffer. TMA writes to one
+stage while MMA reads from another, without conflicts.
+
+
+Per-Stage Barriers and Phases
+-----------------------------
+
+Each stage has its own mbarrier to track TMA completion independently:
+
+.. code-block:: python
+
+   tma_barriers = self.mbarrier.alloc(counts=[1 for _ in range(self.stages)])
+   tma_phases = self.register_tensor(dtype=uint32, shape=[self.stages], init=0)
+
+Since the same stage is reused every ``stages`` iterations, each stage's barrier
+goes through its own phase cycle. The ``tma_phases`` register tensor stores the
+current expected phase for each stage's barrier.
+
+The MMA barrier remains a single barrier (as in V1) since MMA operations are
+still serialized.
+
+.. note::
+
+   :meth:`~tilus.Script.register_tensor` allocates a register tensor with a
+   given shape and initial value. Here ``tma_phases`` is a vector of ``stages``
+   uint32 values, all initialized to 0. Use ``.item()`` to extract a scalar
+   from a single-element slice (e.g., ``tma_phases[current_stage].item()``).
+
+
+Loop Unrolling
+--------------
+
+The main loop uses :meth:`self.range() <tilus.Script.range>` with
+``unroll=self.stages`` instead of Python's ``range()``:
+
+.. code-block:: python
+
+   for offset_k in self.range(0, k_size, self.block_k, unroll=self.stages):
+
+This instructs the compiler to unroll the loop body by the number of stages. Loop
+unrolling is important for pipelined kernels because the stage index
+(``current_stage``, ``preload_stage``) cycles modulo ``stages`` --- with
+unrolling, the compiler can resolve these indices to constants, eliminating
+modular arithmetic and enabling more efficient code generation.
+
+
+Walkthrough
+-----------
+
+Prefill
+~~~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v2.py
+   :language: python
+   :start-at: for i in range(self.stages - 1)
+   :end-before: self.sync()
+   :dedent: 8
+   :caption: Prefill: load the first stages - 1 tiles
+
+Before the main loop, the first ``stages - 1`` TMA loads are issued without
+waiting. Each iteration loads into stage ``i`` and signals ``tma_barriers[i]``.
+After the prefill, ``self.sync()`` ensures all threads have issued their TMA
+requests before entering the main loop.
+
+
+Main Loop
+~~~~~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v2.py
+   :language: python
+   :start-at: current_stage
+   :end-at: self.sync()
+   :dedent: 8
+   :caption: Main loop: overlap preload and compute
+
+In each iteration:
+
+- **Preload** (into ``preload_stage``):
+  :meth:`mbarrier.arrive_and_expect_tx <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.arrive_and_expect_tx>`
+  and :meth:`tma.global_to_shared <tilus.lang.instructions.tma.TmaInstructionGroup.global_to_shared>`
+  issue TMA loads for a future K-tile into the next free stage. This runs
+  asynchronously --- the TMA engine works in the background.
+
+- **Wait** (on ``current_stage``):
+  :meth:`mbarrier.wait <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.wait>`
+  blocks until the current stage's TMA data has arrived. The phase comes from
+  ``tma_phases[current_stage]``.
+
+- **Compute** (from ``current_stage``):
+  :meth:`tcgen05.mma <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.mma>`
+  reads ``s_a[current_stage]`` and ``s_b[current_stage]``, accumulating into the
+  tensor memory accumulator.
+
+After the MMA,
+:meth:`tcgen05.commit <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.commit>`
+and :meth:`mbarrier.wait <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.wait>`
+on the MMA barrier ensure the MMA completes before the next iteration.
+
+Finally, the stage indices advance modulo ``stages``:
+
+.. code-block:: python
+
+   tma_phases[current_stage] ^= 1                     # flip phase for this stage
+   mma_phase ^= 1
+   preload_stage = (preload_stage + 1) % self.stages   # next free stage
+   current_stage = (current_stage + 1) % self.stages   # next stage to consume
+
+
+What's Next
+-----------
+
+V2 overlaps TMA loads with MMA compute across iterations, but there is still a
+limitation: each iteration runs one MMA and must wait for it to complete
+(via ``tcgen05.commit`` + ``mbarrier.wait``) before issuing the next. The MMA
+pipeline depth is effectively 1 --- no in-flight MMAs overlap.
+
+In the next version, we separate the load and compute into **different thread
+groups**: a dedicated TMA warp and a dedicated MMA warp. With separate warps, the
+MMA warp can issue its next MMA immediately after the previous one without
+waiting for the TMA warp, and vice versa. This enables true parallelism between
+TMA and MMA, with the two warps progressing independently and synchronizing only
+through mbarriers.
+
+
+Full Source
+-----------
+
+The complete example file is located at
+`examples/blackwell_matmul/matmul_v2.py <https://github.com/NVIDIA/tilus/blob/main/examples/blackwell_matmul/matmul_v2.py>`__.

--- a/examples/blackwell_matmul/matmul_v2.py
+++ b/examples/blackwell_matmul/matmul_v2.py
@@ -38,6 +38,7 @@ class BlackwellMatmulV2(tilus.Script):
 
         g_a = self.global_view(a_ptr, dtype=float16, shape=[m_size, k_size])
         g_b = self.global_view(b_ptr, dtype=float16, shape=[n_size, k_size])
+        # multi-stage shared memory: leading dimension indexes the pipeline stage
         s_a = self.shared_tensor(
             dtype=float16, shape=[self.stages, self.block_m, self.block_k]
         )
@@ -45,15 +46,16 @@ class BlackwellMatmulV2(tilus.Script):
             dtype=float16, shape=[self.stages, self.block_n, self.block_k]
         )
 
-        # allocate a tensor in tensor memory (tmem)
         t_acc = self.tcgen05.alloc(dtype=float32, shape=[self.block_m, self.block_n])
 
-        # allocate barriers
+        # one TMA barrier per stage; each tracks its own phase independently
         tma_barriers = self.mbarrier.alloc(counts=[1 for _ in range(self.stages)])
         mma_barrier = self.mbarrier.alloc(counts=1)
+        # per-stage phase tracking via register tensor
         tma_phases = self.register_tensor(dtype=uint32, shape=[self.stages], init=0)
         mma_phase: uint32 = 0
 
+        # prefill: issue TMA loads for the first (stages - 1) tiles without waiting
         for i in range(self.stages - 1):
             offset_k = i * self.block_k
             with self.single_warp():
@@ -79,8 +81,10 @@ class BlackwellMatmulV2(tilus.Script):
         current_stage: int32 = 0
         preload_stage: int32 = self.stages - 1
 
+        # unroll by stages so the compiler can resolve stage indices to constants
         for offset_k in self.range(0, k_size, self.block_k, unroll=self.stages):
             with self.single_warp():
+                # preload: issue TMA for a future tile into the next free stage
                 preload_offset_k = offset_k + (self.stages - 1) * self.block_k
                 with self.single_thread():
                     self.mbarrier.arrive_and_expect_tx(
@@ -100,9 +104,11 @@ class BlackwellMatmulV2(tilus.Script):
                     offsets=[offset_n, preload_offset_k],
                     mbarrier=tma_barriers[preload_stage],
                 )
+                # wait for the current stage's TMA data to arrive
                 self.mbarrier.wait(
                     tma_barriers[current_stage], phase=tma_phases[current_stage].item()
                 )
+                # compute on the current stage
                 self.tcgen05.mma(
                     s_a[current_stage],
                     s_b[current_stage].transpose(),
@@ -112,19 +118,18 @@ class BlackwellMatmulV2(tilus.Script):
                 self.tcgen05.commit(mbarrier=mma_barrier)
                 self.mbarrier.wait(mma_barrier, phase=mma_phase)
 
+            # advance stage indices (ring buffer)
             tma_phases[current_stage] ^= 1
             mma_phase ^= 1
             preload_stage = (preload_stage + 1) % self.stages
             current_stage = (current_stage + 1) % self.stages
             self.sync()
 
-        # load the result from tensor memory to register
         r_acc = self.tcgen05.load(t_acc)
 
         g_c = self.global_view(c_ptr, dtype=float16, shape=[m_size, n_size])
         self.store_global(g_c, r_acc.to(float16), offsets=[offset_m, offset_n])
 
-        # all allocated tensor memory must be deallocated
         self.sync()
         self.tcgen05.dealloc(t_acc)
 


### PR DESCRIPTION
- New tutorial covering software pipelining, multi-stage shared memory, per-stage barriers/phases, loop unrolling, prefill + main loop
- SVG diagram comparing V1 serial vs V2 pipelined execution with stage usage table showing ring buffer rotation
- Add comments to matmul_v2.py for new pipeline concepts
- Link Full Source sections to GitHub instead of download for v0-v2
- Add forward reference from V1 to V2