### PR TITLE
[Tutorial] Add Blackwell matmul V3 (warp specialization)

### DIFF
--- a/docs/source/tutorials/matmul-blackwell/__init__.rst
+++ b/docs/source/tutorials/matmul-blackwell/__init__.rst
@@ -15,3 +15,4 @@ performance.
    v0
    v1
    v2
+   v3

--- a/docs/source/tutorials/matmul-blackwell/v2.rst
+++ b/docs/source/tutorials/matmul-blackwell/v2.rst
@@ -206,8 +206,8 @@ limitation: each iteration runs one MMA and must wait for it to complete
 (via ``tcgen05.commit`` + ``mbarrier.wait``) before issuing the next. The MMA
 pipeline depth is effectively 1 --- no in-flight MMAs overlap.
 
-In the next version, we separate the load and compute into **different thread
-groups**: a dedicated TMA warp and a dedicated MMA warp. With separate warps, the
+In :doc:`the next version <v3>`, we separate the load and compute into
+**different thread groups**: a dedicated TMA warp and a dedicated MMA warp. With separate warps, the
 MMA warp can issue its next MMA immediately after the previous one without
 waiting for the TMA warp, and vice versa. This enables true parallelism between
 TMA and MMA, with the two warps progressing independently and synchronizing only

--- a/docs/source/tutorials/matmul-blackwell/v3.rst
+++ b/docs/source/tutorials/matmul-blackwell/v3.rst
@@ -1,0 +1,199 @@
+.. _tutorial_blackwell_matmul_v3:
+
+3. Warp Specialization
+======================
+
+In :doc:`V2 <v2>`, each iteration issues one MMA and waits for it to complete
+(via ``tcgen05.commit`` + ``mbarrier.wait``) before issuing the next. The tensor
+core MMA pipeline sees only one operation at a time --- it goes idle between
+consecutive MMAs while the warp handles TMA and synchronization.
+
+To keep the MMA pipeline busy, we want **multiple MMAs in flight**: issue the
+next MMA as soon as its input data is ready, without waiting for the previous
+MMA to finish writing its results. This is achieved through **warp
+specialization** --- assigning TMA and MMA to **separate warps**, each running
+its own loop. The MMA warp can issue MMA after MMA without interruption, while
+the TMA warp independently keeps shared memory filled. The two warps synchronize
+only through mbarriers, allowing multiple in-flight MMA and TMA operations
+simultaneously.
+
+
+The Full Kernel
+---------------
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v3.py
+   :language: python
+   :start-at: @tilus.autotune
+   :end-at: self.tcgen05.dealloc(t_acc)
+   :caption: BlackwellMatmulV3 --- full kernel
+
+
+What Changed from V2
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 40 40
+
+   * -
+     - V2
+     - V3
+   * - **Warp structure**
+     - Single warp does both TMA and MMA
+     - TMA warp + MMA warp (warp specialization)
+   * - **Barriers**
+     - TMA barriers + 1 MMA barrier
+     - ``full_barriers`` + ``empty_barriers`` (producer-consumer)
+   * - **Parallelism**
+     - TMA and MMA overlap across iterations
+     - TMA and MMA run **truly in parallel** on separate warps
+   * - **In-flight MMA**
+     - 1 (wait after each MMA)
+     - Multiple (MMA warp issues next MMA without waiting for TMA)
+   * - **Prefill**
+     - Explicit prefill loop
+     - Implicit: TMA warp runs ahead of MMA warp
+
+
+Warp Specialization
+-------------------
+
+.. |rarr| unicode:: U+2192
+
+In V2, a single warp handles both TMA and MMA. Each iteration looks like: issue
+TMA |rarr| wait for TMA |rarr| issue MMA |rarr| **wait for MMA** |rarr| repeat.
+The ``tcgen05.commit`` + ``mbarrier.wait`` after each MMA means the tensor core
+pipeline sees at most one MMA at a time. Between consecutive MMAs, the pipeline
+goes idle while the warp handles synchronization, TMA issuing, and TMA waiting.
+
+With warp specialization, we assign TMA and MMA to **separate warps**, each
+running its own loop:
+
+- **TMA warp** (threads 0--31): issues TMA loads back-to-back. Before each load,
+  it only waits on ``empty_barriers`` to ensure the shared memory slot is free.
+- **MMA warp** (threads 32--63): issues MMA operations back-to-back. Before each
+  MMA, it only waits on ``full_barriers`` to ensure the input data has arrived.
+  Crucially, it does **not** wait for the previous MMA to complete --- it issues
+  ``tcgen05.commit(mbarrier=empty_barriers[stage])`` which returns immediately
+  and makes the barrier track the MMA's completion in the background. When the
+  MMA actually finishes, the hardware will signal the barrier, freeing the stage
+  for the TMA warp. Meanwhile, the MMA warp has already moved on to the next
+  iteration. This allows **multiple MMAs to be in flight** in the tensor core
+  pipeline.
+
+The result: as long as TMA delivers data fast enough, the MMA warp keeps the
+tensor core pipeline fully occupied with no idle gaps between operations.
+
+
+Producer-Consumer Barriers
+--------------------------
+
+V2 used TMA barriers and a single MMA barrier. V3 replaces them with a
+**producer-consumer** barrier pair, as described in the
+:doc:`mbarrier guide </python-api/instruction-groups/mbarrier>`:
+
+- ``full_barriers``: signaled when TMA has filled a stage (data ready).
+  The MMA warp waits on these.
+- ``empty_barriers``: signaled when MMA has consumed a stage (slot free).
+  The TMA warp waits on these.
+
+.. code-block:: python
+
+   full_barriers = self.mbarrier.alloc(counts=[1] * self.stages)
+   empty_barriers = self.mbarrier.alloc(counts=[1] * self.stages)
+
+The initial phases reflect the starting state:
+
+- ``empty_phases`` are initialized to ``1``
+  (:attr:`~tilus.lang.instructions.mbarrier.BarrierInstructionGroup.producer_initial_phase`):
+  all stages start empty, so the TMA warp can begin filling immediately.
+- ``full_phases`` are initialized to ``0``
+  (:attr:`~tilus.lang.instructions.mbarrier.BarrierInstructionGroup.consumer_initial_phase`):
+  no stages are full yet, so the MMA warp blocks until the first TMA completes.
+
+
+Flush Barrier
+-------------
+
+After the MMA loop ends, we need to ensure all in-flight MMAs have completed
+before reading the accumulator. This is done with a **flush barrier**:
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v3.py
+   :language: python
+   :start-at: # drain: wait for all in-flight MMA
+   :end-at: self.mbarrier.wait(flush_barrier
+   :dedent: 12
+
+This extra ``tcgen05.commit`` makes the ``flush_barrier`` track all prior
+uncommitted MMA operations. Once the barrier completes, it is safe to read
+from tensor memory.
+
+
+Walkthrough
+-----------
+
+TMA Warp (Producer)
+~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v3.py
+   :language: python
+   :start-at: # TMA warp (producer)
+   :end-before: # MMA warp (consumer)
+   :dedent: 8
+   :caption: TMA warp
+
+The TMA warp runs a loop over all K-tiles:
+
+- :meth:`mbarrier.wait <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.wait>`
+  on ``empty_barriers[stage]`` blocks until the MMA warp has freed this stage.
+- :meth:`mbarrier.arrive_and_expect_tx <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.arrive_and_expect_tx>`
+  on ``full_barriers[stage]`` declares the expected TMA bytes.
+- Two :meth:`tma.global_to_shared <tilus.lang.instructions.tma.TmaInstructionGroup.global_to_shared>`
+  calls load the A and B tiles.
+- The stage index advances modulo ``stages``.
+
+Note there is no explicit prefill loop as in V2: the TMA warp simply starts
+running and naturally gets ahead of the MMA warp (which blocks until the first
+``full_barrier`` is signaled).
+
+
+MMA Warp (Consumer)
+~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v3.py
+   :language: python
+   :start-at: # MMA warp (consumer)
+   :end-before: self.sync()
+   :dedent: 8
+   :caption: MMA warp
+
+The MMA warp runs a matching loop:
+
+- :meth:`mbarrier.wait <tilus.lang.instructions.mbarrier.BarrierInstructionGroup.wait>`
+  on ``full_barriers[stage]`` blocks until TMA data has arrived.
+- :meth:`tcgen05.mma <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.mma>`
+  computes on the loaded tiles.
+- :meth:`tcgen05.commit <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.commit>`
+  on ``empty_barriers[stage]`` signals that this stage is now free for the TMA
+  warp to reuse.
+- After the loop, the flush barrier ensures all MMA writes to tensor memory are
+  complete.
+
+
+What's Next
+-----------
+
+V3 achieves true overlap between TMA and MMA through warp specialization.
+However, the code still manages the pipeline state (stages, barriers, phases)
+inline, which becomes increasingly complex as we add more features.
+
+In the next version, we refactor the pipeline logic into reusable **helper
+classes** (``Pipeline``, ``LoadWorker``, ``MmaWorker``) using ``tilus.Class``,
+and add a TMA-based **epilogue** for writing results back to global memory.
+
+
+Full Source
+-----------
+
+The complete example file is located at
+`examples/blackwell_matmul/matmul_v3.py <https://github.com/NVIDIA/tilus/blob/main/examples/blackwell_matmul/matmul_v3.py>`__.

--- a/examples/blackwell_matmul/matmul_v3.py
+++ b/examples/blackwell_matmul/matmul_v3.py
@@ -45,84 +45,72 @@ class BlackwellMatmulV3(tilus.Script):
             dtype=float16, shape=[self.stages, self.block_n, self.block_k]
         )
 
-        # allocate a tensor in tensor memory (tmem)
         t_acc = self.tcgen05.alloc(dtype=float32, shape=[self.block_m, self.block_n])
 
-        # allocate barriers and the initial phases
-        consumer_barriers = self.mbarrier.alloc(
-            counts=[1 for _ in range(self.stages)]
-        )  # whether the data is ready for consumption
-        producer_barriers = self.mbarrier.alloc(
-            counts=[1 for _ in range(self.stages)]
-        )  # whether the data is ready to be filled
+        # full_barriers: signaled when data is ready (TMA done)
+        full_barriers = self.mbarrier.alloc(counts=[1] * self.stages)
+        # empty_barriers: signaled when slot is free (MMA done)
+        empty_barriers = self.mbarrier.alloc(counts=[1] * self.stages)
 
+        # TMA warp (producer): loads tiles from global to shared memory
         with self.thread_group(thread_begin=0, num_threads=32):
-            # tma warp
             stage: int32 = 0
-            producer_phases = self.register_tensor(
-                dtype=uint32, shape=[self.stages], init=1
-            )  # all stages are ready to be filled at the beginning
+            # init=1: all stages start empty (ready to be filled)
+            empty_phases = self.register_tensor(dtype=uint32, shape=[self.stages], init=1)
             for offset_k in self.range(0, k_size, self.block_k, unroll=self.stages):
-                self.mbarrier.wait(
-                    producer_barriers[stage], phase=producer_phases[stage]
-                )  # wait until the stage is ready to be filled
-                producer_phases[stage] ^= 1
+                # wait for the MMA warp to free this stage
+                self.mbarrier.wait(empty_barriers[stage], phase=empty_phases[stage])
+                empty_phases[stage] ^= 1
                 with self.single_thread():
                     self.mbarrier.arrive_and_expect_tx(
-                        consumer_barriers[stage],
+                        full_barriers[stage],
                         transaction_bytes=s_a[stage].nbytes + s_b[stage].nbytes,
                     )
                 self.tma.global_to_shared(
                     src=g_a,
                     dst=s_a[stage],
                     offsets=[offset_m, offset_k],
-                    mbarrier=consumer_barriers[stage],
+                    mbarrier=full_barriers[stage],
                 )
                 self.tma.global_to_shared(
                     src=g_b,
                     dst=s_b[stage],
                     offsets=[offset_n, offset_k],
-                    mbarrier=consumer_barriers[stage],
+                    mbarrier=full_barriers[stage],
                 )
                 stage = (stage + 1) % self.stages
 
-            # remaining mma stages to wait for completion
-            for _ in self.range(min(self.stages, cdiv(k_size, self.block_k))):
-                self.mbarrier.wait(
-                    producer_barriers[stage], phase=producer_phases[stage]
-                )  # wait until the stage is ready to be filled
-                producer_phases[stage] ^= 1
-                stage = (stage + 1) % self.stages
-
+        # MMA warp (consumer): computes on tiles loaded by the TMA warp
         with self.thread_group(thread_begin=32, num_threads=32):
-            # mma warp
-            consumer_phases = self.register_tensor(
-                dtype=uint32, shape=[self.stages], init=0
-            )  # all stages are not ready for consumption at the beginning
+            # init=0: no stages are full yet (waiting for TMA)
+            full_phases = self.register_tensor(dtype=uint32, shape=[self.stages], init=0)
             stage: int32 = 0
             for offset_k in self.range(0, k_size, self.block_k, unroll=self.stages):
-                self.mbarrier.wait(
-                    consumer_barriers[stage], phase=consumer_phases[stage]
-                )  # wait until the stage is ready for consumption
-                consumer_phases[stage] ^= 1
+                # wait for the TMA warp to fill this stage
+                self.mbarrier.wait(full_barriers[stage], phase=full_phases[stage])
+                full_phases[stage] ^= 1
                 self.tcgen05.mma(
                     s_a[stage],
                     s_b[stage].transpose(),
                     t_acc,
                     enable_input_d=offset_k != 0,
                 )
-                self.tcgen05.commit(mbarrier=producer_barriers[stage])
+                # commit signals empty_barriers: frees this stage for TMA reuse
+                self.tcgen05.commit(mbarrier=empty_barriers[stage])
                 stage = (stage + 1) % self.stages
+
+            # drain: wait for all in-flight MMA to finish
+            flush_barrier = self.mbarrier.alloc(1)
+            self.tcgen05.commit(mbarrier=flush_barrier)
+            self.mbarrier.wait(flush_barrier, phase=0)
 
         self.sync()
 
-        # load the result from tensor memory to register
         r_acc = self.tcgen05.load(t_acc)
 
         g_c = self.global_view(c_ptr, dtype=float16, shape=[m_size, n_size])
         self.store_global(g_c, r_acc.to(float16), offsets=[offset_m, offset_n])
 
-        # all allocated tensor memory must be deallocated
         self.sync()
         self.tcgen05.dealloc(t_acc)
 

--- a/python/tilus/lang/transpiler/transpiler.py
+++ b/python/tilus/lang/transpiler/transpiler.py
@@ -757,6 +757,8 @@ class Transpiler(ScopedProgramBuilder, PythonAstFunctor):
         elif isinstance(lhs, (list, tuple)) and isinstance(rhs, (list, tuple)):
             assert isinstance(expr.op, ast.Add)
             return list(lhs) + list(rhs)
+        elif isinstance(lhs, list) and isinstance(rhs, int) and isinstance(expr.op, ast.Mult):
+            return lhs * rhs
         elif isinstance(lhs, (ir.Expr, float, int)) and isinstance(rhs, (ir.Expr, float, int)):
             if type(expr.op) in op_dict:
                 return op_dict[type(expr.op)](lhs, rhs)


### PR DESCRIPTION
V3 tutorial (warp specialization):
- Explain in-flight MMA motivation and warp specialization
- Cover producer-consumer barriers (full/empty), flush barrier
- Walkthrough of TMA warp and MMA warp with literalinclude

V2 updates:
- Add forward reference from V2 to V3

Example updates:
- Rename matmul_v3.py barriers to full/empty convention
- Add comments for new instructions and optimizations