### PR TITLE
[Tutorial] Add Blackwell matmul V4 tutorial (tile rasterization)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ uv.lock
 # claude tasks
 /TASK*.md
 /REPORT*.md
+/knowledge

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "python.analysis.supportDocstringTemplate": true,
     "autoDocstring.docstringFormat": "numpy",
     "files.watcherExclude": {
-        "**/cache/**": true
+        "**/cache/**": true,
+        "**/.cache/**": true,
     },
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,4 +52,5 @@ Additional features include automatic tuning, caching, and a Pythonic interface 
    python-api/tilus-option
    python-api/tilus-target
    python-api/tilus-script
+   python-api/tilus-class
    python-api/tilus-ir/__index__

--- a/docs/source/python-api/tilus-class.rst
+++ b/docs/source/python-api/tilus-class.rst
@@ -1,0 +1,7 @@
+tilus.Class
+===========
+
+.. currentmodule:: tilus
+
+.. autoclass:: Class
+   :exclude-members: __init__, __new__

--- a/docs/source/tutorials/matmul-blackwell/__init__.rst
+++ b/docs/source/tutorials/matmul-blackwell/__init__.rst
@@ -16,3 +16,4 @@ performance.
    v1
    v2
    v3
+   v4

--- a/docs/source/tutorials/matmul-blackwell/figures/v4_pipeline_class.svg
+++ b/docs/source/tutorials/matmul-blackwell/figures/v4_pipeline_class.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 0 740 415" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arr-p" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5 Z" fill="#555"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="380" y="18" text-anchor="middle" font-weight="700" font-size="14" fill="#333">Async Pipeline (stages = 5)</text>
+
+  <!-- ===== Producer (left) ===== -->
+  <rect x="20" y="40" width="190" height="175" rx="8" fill="#fff3e0" stroke="#e65100" stroke-width="1.5"/>
+  <text x="115" y="62" text-anchor="middle" font-weight="700" font-size="13" fill="#e65100">Producer</text>
+
+  <rect x="32" y="75" width="166" height="18" rx="3" fill="#fff9f0" stroke="#e65100" stroke-width="0.8"/>
+  <text x="115" y="88" text-anchor="middle" font-size="9" fill="#bf360c" font-weight="600">producer_acquire()</text>
+  <text x="115" y="104" text-anchor="middle" font-size="8" fill="#888">wait for empty slot</text>
+
+  <rect x="32" y="113" width="166" height="18" rx="3" fill="#fff9f0" stroke="#e65100" stroke-width="0.8"/>
+  <text x="115" y="126" text-anchor="middle" font-size="9" fill="#bf360c" font-weight="600">producer_barrier()</text>
+  <text x="115" y="142" text-anchor="middle" font-size="8" fill="#888">get full_barrier to signal when done</text>
+
+  <rect x="32" y="151" width="166" height="18" rx="3" fill="#fff9f0" stroke="#e65100" stroke-width="0.8"/>
+  <text x="115" y="164" text-anchor="middle" font-size="9" fill="#bf360c" font-weight="600">producer_advance()</text>
+  <text x="115" y="180" text-anchor="middle" font-size="8" fill="#888">move to next slot</text>
+
+  <!-- Producer stage pointer -->
+  <text x="115" y="204" text-anchor="middle" font-size="9" fill="#e65100" font-weight="600">producer_stage → slot 3</text>
+
+  <!-- ===== Consumer (right) ===== -->
+  <rect x="550" y="40" width="190" height="175" rx="8" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.5"/>
+  <text x="645" y="62" text-anchor="middle" font-weight="700" font-size="13" fill="#7e57c2">Consumer</text>
+
+  <rect x="562" y="75" width="166" height="18" rx="3" fill="#f5f0ff" stroke="#7e57c2" stroke-width="0.8"/>
+  <text x="645" y="88" text-anchor="middle" font-size="9" fill="#5e35b1" font-weight="600">consumer_acquire()</text>
+  <text x="645" y="104" text-anchor="middle" font-size="8" fill="#888">wait for filled slot</text>
+
+  <rect x="562" y="113" width="166" height="18" rx="3" fill="#f5f0ff" stroke="#7e57c2" stroke-width="0.8"/>
+  <text x="645" y="126" text-anchor="middle" font-size="9" fill="#5e35b1" font-weight="600">consumer_barrier()</text>
+  <text x="645" y="142" text-anchor="middle" font-size="8" fill="#888">get empty_barrier to signal when done</text>
+
+  <rect x="562" y="151" width="166" height="18" rx="3" fill="#f5f0ff" stroke="#7e57c2" stroke-width="0.8"/>
+  <text x="645" y="164" text-anchor="middle" font-size="9" fill="#5e35b1" font-weight="600">consumer_advance()</text>
+  <text x="645" y="180" text-anchor="middle" font-size="8" fill="#888">move to next slot</text>
+
+  <!-- Consumer stage pointer -->
+  <text x="645" y="204" text-anchor="middle" font-size="9" fill="#7e57c2" font-weight="600">consumer_stage → slot 1</text>
+
+  <!-- ===== Ring Buffer (center) ===== -->
+  <rect x="240" y="35" width="280" height="230" rx="8" fill="#f8f8f8" stroke="#999" stroke-width="1.2"/>
+  <text x="380" y="55" text-anchor="middle" font-weight="700" font-size="12" fill="#333">Ring Buffer</text>
+
+  <!-- Column headers -->
+  <text x="290" y="73" text-anchor="middle" font-size="8" fill="#666" font-weight="600">slot</text>
+  <text x="350" y="73" text-anchor="middle" font-size="8" fill="#666" font-weight="600">full</text>
+  <text x="420" y="73" text-anchor="middle" font-size="8" fill="#666" font-weight="600">empty</text>
+  <text x="496" y="73" text-anchor="end" font-size="8" fill="#666" font-weight="600">state</text>
+
+  <!-- Slot 0: consumed (full=✗, empty=✓) -->
+  <rect x="260" y="80" width="240" height="24" rx="3" fill="#f5f5f5" stroke="#ddd" stroke-width="0.8"/>
+  <text x="290" y="96" text-anchor="middle" font-size="10" fill="#666">0</text>
+  <text x="350" y="96" text-anchor="middle" font-size="11" fill="#dc3545">✗</text>
+  <text x="420" y="96" text-anchor="middle" font-size="11" fill="#28a745">✓</text>
+  <text x="496" y="96" text-anchor="end" font-size="9" fill="#888">empty</text>
+
+  <!-- Slot 1: filled, being consumed (full=✓, empty=✗) — consumer points here -->
+  <rect x="260" y="106" width="240" height="24" rx="3" fill="#ede7f6" stroke="#7e57c2" stroke-width="1.2"/>
+  <text x="290" y="122" text-anchor="middle" font-size="10" fill="#5e35b1" font-weight="600">1</text>
+  <text x="350" y="122" text-anchor="middle" font-size="11" fill="#28a745">✓</text>
+  <text x="420" y="122" text-anchor="middle" font-size="11" fill="#dc3545">✗</text>
+  <text x="496" y="122" text-anchor="end" font-size="9" fill="#5e35b1" font-weight="600">consuming</text>
+
+  <!-- Slot 2: filled, waiting (full=✓, empty=✗) -->
+  <rect x="260" y="132" width="240" height="24" rx="3" fill="#d4edda" stroke="#28a745" stroke-width="0.8"/>
+  <text x="290" y="148" text-anchor="middle" font-size="10" fill="#155724">2</text>
+  <text x="350" y="148" text-anchor="middle" font-size="11" fill="#28a745">✓</text>
+  <text x="420" y="148" text-anchor="middle" font-size="11" fill="#dc3545">✗</text>
+  <text x="496" y="148" text-anchor="end" font-size="9" fill="#155724">full</text>
+
+  <!-- Slot 3: being produced (full=✗, empty=✓) — producer points here -->
+  <rect x="260" y="158" width="240" height="24" rx="3" fill="#fff3e0" stroke="#e65100" stroke-width="1.2"/>
+  <text x="290" y="174" text-anchor="middle" font-size="10" fill="#e65100" font-weight="600">3</text>
+  <text x="350" y="174" text-anchor="middle" font-size="11" fill="#dc3545">✗</text>
+  <text x="420" y="174" text-anchor="middle" font-size="11" fill="#28a745">✓</text>
+  <text x="496" y="174" text-anchor="end" font-size="9" fill="#e65100" font-weight="600">producing</text>
+
+  <!-- Slot 4: empty (full=✗, empty=✓) -->
+  <rect x="260" y="184" width="240" height="24" rx="3" fill="#f5f5f5" stroke="#ddd" stroke-width="0.8"/>
+  <text x="290" y="200" text-anchor="middle" font-size="10" fill="#666">4</text>
+  <text x="350" y="200" text-anchor="middle" font-size="11" fill="#dc3545">✗</text>
+  <text x="420" y="200" text-anchor="middle" font-size="11" fill="#28a745">✓</text>
+  <text x="496" y="200" text-anchor="end" font-size="9" fill="#888">empty</text>
+
+  <!-- Pointer arrows -->
+  <!-- Producer → slot 3 -->
+  <line x1="212" y1="200" x2="258" y2="170" stroke="#e65100" stroke-width="1.5" marker-end="url(#arr-p)"/>
+  <!-- Consumer → slot 1 -->
+  <line x1="548" y1="200" x2="502" y2="118" stroke="#7e57c2" stroke-width="1.5" marker-end="url(#arr-p)"/>
+
+  <!-- Wrap-around annotation -->
+  <text x="380" y="225" text-anchor="middle" font-size="9" fill="#888">slots cycle: 0 → 1 → 2 → 3 → 4 → 0 → ...</text>
+  <text x="380" y="238" text-anchor="middle" font-size="9" fill="#888">phase flips each time a pointer wraps around</text>
+
+  <!-- ===== Legend ===== -->
+  <line x1="30" y1="275" x2="730" y2="275" stroke="#ccc" stroke-width="1" stroke-dasharray="6,4"/>
+
+  <text x="380" y="295" text-anchor="middle" font-size="10" fill="#333">Initial state: all slots are empty. Each slot is in one of four states: <tspan font-weight="600">producing</tspan>, <tspan font-weight="600">full</tspan>, <tspan font-weight="600">consuming</tspan>, or <tspan font-weight="600">empty</tspan>.</text>
+
+  <text x="80" y="318" font-size="10" fill="#333" font-weight="600">full ✓</text>
+  <text x="125" y="318" font-size="10" fill="#333">= producer has filled this slot</text>
+
+  <text x="80" y="338" font-size="10" fill="#333" font-weight="600">empty ✓</text>
+  <text x="131" y="338" font-size="10" fill="#333">= consumer has consumed this slot</text>
+
+  <text x="420" y="318" font-size="10" fill="#333" font-weight="600">full ✗</text>
+  <text x="465" y="318" font-size="10" fill="#333">= not yet filled by producer</text>
+
+  <text x="420" y="338" font-size="10" fill="#333" font-weight="600">empty ✗</text>
+  <text x="471" y="338" font-size="10" fill="#333">= not yet consumed by consumer</text>
+
+  <!-- Summary -->
+  <text x="380" y="370" text-anchor="middle" font-size="10" fill="#333">
+    Producer waits on <tspan fill="#dc3545" font-weight="600">empty</tspan> barrier (slot free?), signals <tspan fill="#28a745" font-weight="600">full</tspan> barrier (data ready).
+  </text>
+  <text x="380" y="386" text-anchor="middle" font-size="10" fill="#333">
+    Consumer waits on <tspan fill="#28a745" font-weight="600">full</tspan> barrier (data ready?), signals <tspan fill="#dc3545" font-weight="600">empty</tspan> barrier (slot freed).
+  </text>
+  <text x="380" y="406" text-anchor="middle" font-size="10" fill="#888">
+    Both advance their stage pointer independently, cycling through the ring buffer.
+  </text>
+</svg>

--- a/docs/source/tutorials/matmul-blackwell/figures/v4_tile_rasterization.svg
+++ b/docs/source/tutorials/matmul-blackwell/figures/v4_tile_rasterization.svg
@@ -1,0 +1,190 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 380" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13">
+
+  <!-- ===== Left: Column-major, wave=16, 8x8 grid ===== -->
+  <text x="175" y="16" text-anchor="middle" font-weight="700" font-size="13" fill="#333">Column-major (wave = 16 blocks)</text>
+
+  <!-- Active column indicators (top) - cols 0,1 active -->
+  <rect x="52" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="80" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="108" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="136" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="164" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="192" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="220" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="248" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+
+  <!-- Active row indicators (left) - all 8 rows active -->
+  <rect x="42" y="36" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="60" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="84" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="108" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="132" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="156" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="180" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="42" y="204" width="8" height="24" rx="2" fill="#e65100"/>
+
+  <!-- 8x8 grid, cell=28x24 -->
+  <!-- Col 0: active tiles 0-7 -->
+  <rect x="52" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">0</text>
+  <rect x="52" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">1</text>
+  <rect x="52" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">2</text>
+  <rect x="52" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">3</text>
+  <rect x="52" y="132" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="148" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">4</text>
+  <rect x="52" y="156" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="172" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">5</text>
+  <rect x="52" y="180" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="196" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">6</text>
+  <rect x="52" y="204" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="66" y="220" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">7</text>
+  <!-- Col 1: active tiles 8-15 -->
+  <rect x="80" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">8</text>
+  <rect x="80" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">9</text>
+  <rect x="80" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">10</text>
+  <rect x="80" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">11</text>
+  <rect x="80" y="132" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="148" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">12</text>
+  <rect x="80" y="156" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="172" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">13</text>
+  <rect x="80" y="180" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="196" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">14</text>
+  <rect x="80" y="204" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="94" y="220" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">15</text>
+  <!-- Cols 2-7: inactive -->
+  <rect x="108" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <rect x="136" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <rect x="164" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <rect x="192" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <rect x="220" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <rect x="248" y="36" width="28" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <!-- Grid lines for inactive -->
+  <line x1="108" y1="60" x2="276" y2="60" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="84" x2="276" y2="84" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="108" x2="276" y2="108" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="132" x2="276" y2="132" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="156" x2="276" y2="156" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="180" x2="276" y2="180" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="108" y1="204" x2="276" y2="204" stroke="#e0e0e0" stroke-width="0.5"/>
+
+  <!-- Summary -->
+  <text x="175" y="246" text-anchor="middle" font-size="11" fill="#333">Active: <tspan fill="#e65100" font-weight="600">8 A rows</tspan> + <tspan fill="#4a86c8" font-weight="600">2 B cols</tspan> = <tspan font-weight="700">10 tiles</tspan></text>
+
+
+  <!-- ===== Right: Swizzled S=4, wave=16, 8x8 grid ===== -->
+  <text x="565" y="16" text-anchor="middle" font-weight="700" font-size="13" fill="#333">Swizzled, S=4 (wave = 16 blocks)</text>
+
+  <!-- Active column indicators (top) - cols 0-3 active -->
+  <rect x="442" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="470" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="498" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="526" y="24" width="28" height="8" rx="2" fill="#4a86c8"/>
+  <rect x="554" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="582" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="610" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+  <rect x="638" y="24" width="28" height="8" rx="2" fill="#e0e0e0"/>
+
+  <!-- Active row indicators (left) - rows 0-3 active -->
+  <rect x="432" y="36" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="432" y="60" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="432" y="84" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="432" y="108" width="8" height="24" rx="2" fill="#e65100"/>
+  <rect x="432" y="132" width="8" height="24" rx="2" fill="#e0e0e0"/>
+  <rect x="432" y="156" width="8" height="24" rx="2" fill="#e0e0e0"/>
+  <rect x="432" y="180" width="8" height="24" rx="2" fill="#e0e0e0"/>
+  <rect x="432" y="204" width="8" height="24" rx="2" fill="#e0e0e0"/>
+
+  <!-- Active tiles: rows 0-3, cols 0-3 (16 tiles) -->
+  <!-- Row 0 -->
+  <rect x="442" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="456" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">0</text>
+  <rect x="470" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="484" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">1</text>
+  <rect x="498" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="512" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">2</text>
+  <rect x="526" y="36" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="540" y="52" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">3</text>
+  <!-- Row 1 -->
+  <rect x="442" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="456" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">4</text>
+  <rect x="470" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="484" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">5</text>
+  <rect x="498" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="512" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">6</text>
+  <rect x="526" y="60" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="540" y="76" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">7</text>
+  <!-- Row 2 -->
+  <rect x="442" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="456" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">8</text>
+  <rect x="470" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="484" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">9</text>
+  <rect x="498" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="512" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">10</text>
+  <rect x="526" y="84" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="540" y="100" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">11</text>
+  <!-- Row 3 -->
+  <rect x="442" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="456" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">12</text>
+  <rect x="470" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="484" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">13</text>
+  <rect x="498" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="512" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">14</text>
+  <rect x="526" y="108" width="28" height="24" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="540" y="124" text-anchor="middle" font-size="9" fill="#1565c0" font-weight="600">15</text>
+
+  <!-- Inactive rows 4-7, cols 0-3 -->
+  <rect x="442" y="132" width="112" height="96" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="442" y1="156" x2="554" y2="156" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="442" y1="180" x2="554" y2="180" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="442" y1="204" x2="554" y2="204" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="470" y1="132" x2="470" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="498" y1="132" x2="498" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="526" y1="132" x2="526" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+
+  <!-- Inactive cols 4-7 (all rows) -->
+  <rect x="554" y="36" width="112" height="192" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="60" x2="666" y2="60" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="84" x2="666" y2="84" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="108" x2="666" y2="108" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="132" x2="666" y2="132" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="156" x2="666" y2="156" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="180" x2="666" y2="180" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="554" y1="204" x2="666" y2="204" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="582" y1="36" x2="582" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="610" y1="36" x2="610" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+  <line x1="638" y1="36" x2="638" y2="228" stroke="#e0e0e0" stroke-width="0.5"/>
+
+  <!-- Summary -->
+  <text x="555" y="246" text-anchor="middle" font-size="11" fill="#333">Active: <tspan fill="#e65100" font-weight="600">4 A rows</tspan> + <tspan fill="#4a86c8" font-weight="600">4 B cols</tspan> = <tspan font-weight="700">8 tiles</tspan></text>
+
+  <!-- ===== Legend ===== -->
+  <line x1="25" y1="270" x2="735" y2="270" stroke="#ccc" stroke-width="1" stroke-dasharray="6,4"/>
+
+  <text x="380" y="292" text-anchor="middle" font-weight="600" font-size="12" fill="#333">Legend</text>
+
+  <rect x="80" y="302" width="20" height="16" fill="#bbdefb" stroke="#64b5f6" stroke-width="1"/>
+  <text x="108" y="314" font-size="10" fill="#333">= active tile (one thread block)</text>
+
+  <rect x="80" y="324" width="20" height="16" fill="#f5f5f5" stroke="#e0e0e0" stroke-width="0.5"/>
+  <text x="108" y="336" font-size="10" fill="#333">= inactive tile</text>
+
+  <rect x="430" y="302" width="16" height="10" rx="2" fill="#e65100"/>
+  <text x="454" y="312" font-size="10" fill="#333">= active A row (needs A tile in L2)</text>
+
+  <rect x="430" y="322" width="16" height="10" rx="2" fill="#4a86c8"/>
+  <text x="454" y="332" font-size="10" fill="#333">= active B col (needs B tile in L2)</text>
+
+  <!-- Key insight -->
+  <text x="380" y="362" text-anchor="middle" font-size="11" fill="#333">
+    Same 16 active blocks, but swizzle reduces L2 working set from
+    <tspan font-weight="700" fill="#dc3545">10</tspan> to
+    <tspan font-weight="700" fill="#28a745">8</tspan> unique A+B tiles
+  </text>
+</svg>

--- a/docs/source/tutorials/matmul-blackwell/figures/v4_tma_epilogue.svg
+++ b/docs/source/tutorials/matmul-blackwell/figures/v4_tma_epilogue.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 155" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13">
+  <defs>
+    <marker id="arr-e" markerWidth="7" markerHeight="5" refX="6" refY="2.5" orient="auto">
+      <path d="M0,0 L7,2.5 L0,5 Z" fill="#555"/>
+    </marker>
+  </defs>
+
+  <!-- TMEM: full accumulator -->
+  <rect x="20" y="25" width="120" height="90" rx="4" fill="#fff3cd" stroke="#ffc107" stroke-width="1.5"/>
+  <text x="80" y="65" text-anchor="middle" font-size="10" fill="#856404">t_acc</text>
+  <!-- Highlight slice -->
+  <rect x="22" y="27" width="38" height="86" rx="2" fill="#ffe082" stroke="#ffa000" stroke-width="1.5"/>
+  <!-- e_block_n bracket at top -->
+  <line x1="22" y1="18" x2="60" y2="18" stroke="#e65100" stroke-width="1"/>
+  <line x1="22" y1="15" x2="22" y2="21" stroke="#e65100" stroke-width="1"/>
+  <line x1="60" y1="15" x2="60" y2="21" stroke="#e65100" stroke-width="1"/>
+  <text x="41" y="12" text-anchor="middle" font-size="8" fill="#e65100">e_block_n</text>
+  <!-- Size label below -->
+  <text x="80" y="130" text-anchor="middle" font-size="9" fill="#888">block_m × block_n</text>
+
+  <!-- Arrow: slice+load+cast -->
+  <line x1="142" y1="70" x2="228" y2="70" stroke="#555" stroke-width="1.2" marker-end="url(#arr-e)"/>
+  <text x="185" y="62" text-anchor="middle" font-size="8" fill="#666">slice + load + cast</text>
+
+  <!-- Registers: narrow slice-sized -->
+  <rect x="230" y="27" width="38" height="86" rx="4" fill="#f8d7da" stroke="#dc3545" stroke-width="1.5"/>
+  <text x="249" y="68" text-anchor="middle" font-size="9" fill="#721c24">r_acc</text>
+  <text x="249" y="80" text-anchor="middle" font-size="7" fill="#888">(fp16)</text>
+  <!-- Size label below -->
+  <text x="249" y="130" text-anchor="middle" font-size="8" fill="#888">block_m ×</text>
+  <text x="249" y="141" text-anchor="middle" font-size="8" fill="#888">e_block_n</text>
+
+  <!-- Arrow: store_shared -->
+  <line x1="270" y1="70" x2="358" y2="70" stroke="#555" stroke-width="1.2" marker-end="url(#arr-e)"/>
+  <text x="314" y="62" text-anchor="middle" font-size="8" fill="#666">store_shared</text>
+
+  <!-- Shared memory: narrow slice-sized -->
+  <rect x="360" y="27" width="38" height="86" rx="4" fill="#d4edda" stroke="#28a745" stroke-width="1.5"/>
+  <text x="379" y="68" text-anchor="middle" font-size="9" fill="#155724">s_c</text>
+  <text x="379" y="80" text-anchor="middle" font-size="7" fill="#888">(fp16)</text>
+  <!-- Size label below -->
+  <text x="379" y="130" text-anchor="middle" font-size="8" fill="#888">block_m ×</text>
+  <text x="379" y="141" text-anchor="middle" font-size="8" fill="#888">e_block_n</text>
+
+  <!-- Arrow: fence + TMA -->
+  <line x1="400" y1="70" x2="498" y2="70" stroke="#555" stroke-width="1.2" marker-end="url(#arr-e)"/>
+  <text x="449" y="62" text-anchor="middle" font-size="8" fill="#666">fence + TMA</text>
+
+  <!-- Global memory -->
+  <rect x="500" y="25" width="120" height="90" rx="4" fill="#e8f0fe" stroke="#4a86c8" stroke-width="1.5"/>
+  <text x="560" y="65" text-anchor="middle" font-size="10" fill="#2a5fa5">g_c</text>
+  <!-- Highlight written slice -->
+  <rect x="502" y="27" width="38" height="86" rx="2" fill="#bbdefb" stroke="#64b5f6" stroke-width="1.5"/>
+  <!-- Size label below -->
+  <text x="560" y="130" text-anchor="middle" font-size="9" fill="#888">M × N</text>
+</svg>

--- a/docs/source/tutorials/matmul-blackwell/v3.rst
+++ b/docs/source/tutorials/matmul-blackwell/v3.rst
@@ -187,9 +187,10 @@ V3 achieves true overlap between TMA and MMA through warp specialization.
 However, the code still manages the pipeline state (stages, barriers, phases)
 inline, which becomes increasingly complex as we add more features.
 
-In the next version, we refactor the pipeline logic into reusable **helper
-classes** (``Pipeline``, ``LoadWorker``, ``MmaWorker``) using ``tilus.Class``,
-and add a TMA-based **epilogue** for writing results back to global memory.
+In :doc:`the next version <v4>`, we refactor the pipeline logic into a reusable
+``Pipeline`` class using ``tilus.Class``, add **tile rasterization** for better
+L2 cache locality, and replace the direct ``store_global`` epilogue with a
+**TMA-based epilogue**.
 
 
 Full Source

--- a/docs/source/tutorials/matmul-blackwell/v4.rst
+++ b/docs/source/tutorials/matmul-blackwell/v4.rst
@@ -7,7 +7,7 @@
 This version adds three improvements:
 
 1. **Tile rasterization** --- reorder tile assignments so that consecutive thread
-   blocks process tiles that share B columns, improving L2 cache reuse.  
+   blocks process tiles that share B columns, improving L2 cache reuse.
 2. **Pipeline abstraction** --- encapsulate the producer-consumer barrier logic
    from V3 into a reusable ``Pipeline`` class using ``tilus.Class``, making it
    easy to add more pipelines as the kernel grows (e.g., separate TMA and MMA

--- a/docs/source/tutorials/matmul-blackwell/v4.rst
+++ b/docs/source/tutorials/matmul-blackwell/v4.rst
@@ -1,0 +1,344 @@
+.. _tutorial_blackwell_matmul_v4:
+
+4. Tile Rasterization, Pipeline Abstraction, and TMA Epilogue
+=============================================================
+
+:doc:`V3 <v3>` introduced warp specialization with separate TMA and MMA warps.
+This version adds three improvements:
+
+1. **Tile rasterization** --- reorder tile assignments so that consecutive thread
+   blocks process tiles that share B columns, improving L2 cache reuse.  
+2. **Pipeline abstraction** --- encapsulate the producer-consumer barrier logic
+   from V3 into a reusable ``Pipeline`` class using ``tilus.Class``, making it
+   easy to add more pipelines as the kernel grows (e.g., separate TMA and MMA
+   pipelines in later versions).
+3. **TMA epilogue** --- store results back to global memory via shared memory and
+   TMA, instead of the direct ``store_global`` used in previous versions.
+
+The Full Kernel
+---------------
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: class Pipeline
+   :end-at: self.tcgen05.dealloc(t_acc)
+   :caption: BlackwellMatmulV4 --- full kernel (including Pipeline class)
+
+
+Tile Rasterization
+------------------
+
+In matmul, each output tile (m, n) needs a row-strip of A (row ``m``) and a
+column-strip of B (column ``n``). A rows are unique per tile, but B columns are
+**shared across all tiles in the same N-column**. This means B data loaded by
+one tile can be reused by other tiles that share the same N-column --- if the
+data is still in L2 cache.
+
+The question is: **how do we order the tiles so that the GPU's L2 cache is used
+effectively?** The key idea is to minimize the **working set** --- the number
+of distinct A rows and B columns that must be in L2 simultaneously for the
+currently active thread blocks.
+
+.. figure:: figures/v4_tile_rasterization.svg
+   :width: 100%
+   :align: center
+
+   An 8 × 8 tile grid with a wave of 16 active blocks (blue cells).
+   Orange bars on the left mark active A rows; blue bars on top mark active B
+   columns. Swizzle achieves a smaller L2 working set (8 vs 10 tiles) for the
+   same number of active blocks.
+
+
+**A concrete example.** Consider an 8 × 8 grid of tiles with
+``block_m = block_n = 128`` and K = 8192. Each A row-strip and each B
+column-strip is 128 × 8192 in fp16 = **2 MB**.
+
+Suppose the GPU can run 16 thread blocks concurrently (one *wave*). With
+**column-major** ordering (the naive 2D grid from V3), ``blockIdx.x`` walks
+down M first, so the 16 active blocks fill columns 0 and 1 completely (8 rows
+each). As shown in the figure:
+
+- **Active A rows**: 8 (all rows touched). Working set: **8 × 2 MB = 16 MB**.
+- **Active B columns**: 2 (cols 0--1). Working set: **2 × 2 MB = 4 MB**.
+- **Total L2 working set: 20 MB** (10 unique tiles).
+
+With **swizzled** ordering (``swizzle_size = 4``), the same 16 blocks are
+mapped to rows 0--3 of columns 0--3 --- a compact 4 × 4 square in the
+top-left of the grid:
+
+- **Active A rows**: 4 (rows 0--3 only). Working set: **4 × 2 MB = 8 MB**.
+- **Active B columns**: 4 (cols 0--3). Working set: **4 × 2 MB = 8 MB**.
+- **Total L2 working set: 16 MB** (8 unique tiles) --- **20% smaller**.
+
+The reduction comes from balancing A and B: column-major packs all 8 rows into
+2 columns (8 + 2 = 10 tiles), while swizzle distributes the same 16 blocks
+across 4 rows and 4 columns (4 + 4 = 8 tiles). Fewer unique tiles in L2 means
+higher hit rates and less off-chip memory traffic.
+
+
+Formulation
+~~~~~~~~~~~
+
+Given a grid of ``num_m_blocks`` × ``num_n_blocks`` tiles and a
+``swizzle_size``, the swizzled mapping works as follows:
+
+1. Divide the N-columns into groups of ``swizzle_size``:
+   group ``group_idx`` covers columns
+   ``[group_idx * swizzle_size, group_idx * swizzle_size + swizzle_size)``.
+2. Within each group, the tile shape is ``[num_m_blocks, swizzle_size]``, and
+   tiles are assigned in **row-major** order:
+   ``(m_block=0, n_block=0), (m_block=0, n_block=1), ...,
+   (m_block=1, n_block=0), ...``
+
+This makes consecutive thread blocks touch nearby rows and columns, producing a
+more compact active region in the grid. The ``swizzle_size`` controls the
+trade-off between A and B working sets: a larger value keeps more B columns
+active (increasing B working set) but fewer A rows active (decreasing A working
+set). The optimal value depends on the problem size and L2 cache capacity, so
+it is autotuned.
+
+
+Implementation
+~~~~~~~~~~~~~~
+
+The grid is launched as 1D, and ``compute_block_coord`` remaps each
+``blockIdx.x`` to the swizzled (m, n) coordinates:
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: num_m_blocks = cdiv
+   :end-at: offset_n
+   :dedent: 8
+   :caption: 1D grid launch with swizzled tile coordinates
+
+The mapping logic:
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: def compute_block_coord
+   :end-at: return m_block, n_block
+   :dedent: 4
+   :caption: Tile rasterization with swizzle grouping
+
+When ``num_n_blocks`` is not divisible by ``swizzle_size``, the last group has
+fewer than ``swizzle_size`` columns. The code handles this by computing
+``last_group_width`` (the remainder) and using it as the divisor for tiles in
+the last group, ensuring correct (m_block, n_block) mapping.
+
+.. hint::
+
+   Integer division and modulo are expensive on GPUs. When the divisor is a
+   compile-time constant (like ``swizzle_size``), the compiler converts division
+   into a mul + shift automatically, so normal ``//`` and ``%`` are fine. For
+   non-constant divisors, the NVIDIA compiler falls back to floating-point
+   arithmetic with int-to-float and float-to-int conversions, which is slow.
+   For **grid-constant** divisors (like ``tiles_per_group``, which is the same
+   for all thread blocks but not known at compile time),
+   :meth:`~tilus.Script.fast_divmod` implements the fast divmod algorithm using
+   integer mul + shift, precomputing the magic number once per grid launch.
+
+
+Pipeline Abstraction
+--------------------
+
+On Blackwell, mbarriers are the fundamental mechanism for tracking completion of
+asynchronous work, and shared memory (or tensor memory) serves as the buffer for
+data in transit. When the producer and consumer operate at different speeds ---
+which is always the case in practice --- we need a **pipeline** to decouple them.
+
+A pipeline has three components:
+
+1. **Producer** --- generates data and writes it into a buffer slot when one is
+   available.
+2. **Consumer** --- reads data from a buffer slot when one is filled.
+3. **Ring buffer** --- a fixed number of slots (``stages``) that the producer and
+   consumer cycle through independently.
+
+Each slot has two mbarriers:
+
+- **full_barrier** --- signaled when the producer has filled the slot. The
+  consumer waits on this.
+- **empty_barrier** --- signaled when the consumer has consumed the slot. The
+  producer waits on this.
+
+The producer and consumer each maintain a **stage pointer** (which slot they are
+currently working on) and a **phase variable** (for the mbarrier of their current
+slot). Both advance through the ring buffer independently, synchronized only by
+the mbarrier signals.
+
+.. figure:: figures/v4_pipeline_class.svg
+   :width: 100%
+   :align: center
+
+   The Pipeline with 5 stages. The producer is filling slot 3; the consumer is
+   consuming slot 1. Slots 2 is full (waiting to be consumed); slots 0 and 4
+   are empty (waiting to be filled). The ✓/✗ marks indicate whether each
+   slot's full/empty mbarrier has completed.
+
+In V3, we managed all this state manually (barriers, phases, stage indices). The
+``Pipeline`` class below encapsulates the bookkeeping into a clean API. Note that
+this is not a built-in part of tilus --- it is constructed from existing
+instructions (``mbarrier.alloc``, ``mbarrier.wait``, etc.) as a user-level
+helper. You can always manage the mbarriers manually as in V3 if you prefer.
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: class Pipeline
+   :end-before: @tilus.autotune
+   :caption: Pipeline class
+
+The ``Pipeline`` class inherits from ``tilus.Class``, which works like
+:class:`~tilus.Script` but for helper objects that are not kernels themselves.
+It can allocate barriers, shared tensors, and use all tilus instructions.
+
+The usage in the kernel becomes straightforward:
+
+.. code-block:: python
+
+   tma_pipe = Pipeline(stages)
+
+   # TMA warp (producer)
+   tma_pipe.producer_acquire()          # wait for empty slot
+   # ... issue TMA loads with tma_pipe.producer_barrier() ...
+   tma_pipe.producer_advance()          # move to next stage
+
+   # MMA warp (consumer)
+   tma_pipe.consumer_acquire()          # wait for filled slot
+   # ... issue MMA ...
+   self.tcgen05.commit(mbarrier=tma_pipe.consumer_barrier())  # signal slot consumed
+   tma_pipe.consumer_advance()          # move to next stage
+
+This pattern is reusable: later versions add a second pipeline (``mma_pipe``)
+between the MMA and epilogue stages, using the same ``Pipeline`` class.
+
+
+TMA Epilogue
+------------
+
+In V0--V3, the epilogue used :meth:`~tilus.Script.store_global` to write
+results directly from registers to global memory. This is simple but not
+optimal: each thread stores a small piece, generating many small memory
+transactions.
+
+V4 uses a **TMA epilogue** that routes data through shared memory for a bulk
+TMA store. However, the full accumulator (``block_m × block_n``, e.g.,
+128 × 256 in fp32) is too large to load into registers or shared memory all at
+once --- it would consume too many registers and too much shared memory. Instead,
+we **slice** the accumulator into narrow column strips of width ``e_block_n``
+(e.g., 16, where the ``e_`` prefix stands for "epilogue") and process one strip
+at a time:
+
+.. figure:: figures/v4_tma_epilogue.svg
+   :width: 100%
+   :align: center
+
+   Dataflow for one epilogue slice: tensor memory → registers (with cast to
+   fp16) → shared memory → global memory (via TMA). Only a ``block_m ×
+   e_block_n`` slice passes through registers and shared memory at a time.
+
+For each strip, the instruction sequence is:
+
+1. :meth:`tcgen05.slice <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.slice>`
+   extracts an ``e_block_n``-wide slice of the accumulator in tensor memory.
+2. :meth:`tcgen05.load <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.load>`
+   moves the slice to registers, and
+   :meth:`tcgen05.wait_load <tilus.lang.instructions.tcgen05.Tcgen05InstructionGroup.wait_load>`
+   waits for the load to complete.
+3. :meth:`~tilus.Script.store_shared` writes the cast result to a shared memory
+   buffer.
+4. :meth:`fence.proxy_async <tilus.lang.instructions.fence.FenceInstructionGroup.proxy_async>` ensures the shared memory writes are
+   visible to the TMA engine.
+5. :meth:`tma.shared_to_global <tilus.lang.instructions.tma.TmaInstructionGroup.shared_to_global>`
+   issues a bulk TMA transfer from shared to global memory.
+6. :meth:`tma.commit_group <tilus.lang.instructions.tma.TmaInstructionGroup.commit_group>`
+   commits the pending TMA operations into a group, and
+   :meth:`tma.wait_group(n=0, read=True) <tilus.lang.instructions.tma.TmaInstructionGroup.wait_group>`
+   waits for the group to complete. The ``read=True`` flag means we only wait
+   for the TMA engine to finish **reading from shared memory** (so shared memory
+   can be reused for the next slice), without waiting for the writes to global
+   memory to be fully visible --- since no subsequent instruction reads the
+   global output.
+
+The epilogue loops over N-dimension slices of width ``e_block_n``:
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: # TMA epilogue
+   :end-before: self.tcgen05.dealloc
+   :dedent: 8
+   :caption: TMA epilogue
+
+.. note::
+
+   **TMA completion mechanisms differ by direction.** Global-to-shared TMA
+   (used in V1--V4 for loading) tracks completion via **mbarrier tx-count**.
+   Shared-to-global TMA (used here in the epilogue) uses a different mechanism:
+   **commit_group + wait_group**, similar to the legacy ``cp.async`` pattern.
+   See `async copy completion mechanisms <https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-asynchronous-copy-completion-mechanisms>`__
+   and `cp.async.bulk <https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk>`__
+   in the PTX documentation.
+
+   The ``fence.proxy_async(space="shared")`` before the TMA store is required
+   because ``store_shared`` writes via the **generic proxy**, while
+   ``tma.shared_to_global`` reads via the **async proxy**. The fence ensures
+   the generic proxy writes are visible to the async proxy. See
+   :doc:`/python-api/instruction-groups/fence` for details.
+
+
+Walkthrough
+-----------
+
+The kernel structure is the same as V3 (TMA warp + MMA warp), but now using
+the ``Pipeline`` class and the new epilogue.
+
+Setup
+~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: num_m_blocks = cdiv
+   :end-at: flush_barrier = self.mbarrier
+   :dedent: 8
+   :caption: Kernel setup
+
+Key differences from V3:
+
+- The grid is 1D: ``blocks = num_m_blocks * num_n_blocks``.
+- ``compute_block_coord`` maps the linear index to swizzled (m, n) coordinates.
+- ``Pipeline(stages)`` replaces manual barrier/phase/stage management.
+- ``e_block_n`` controls the epilogue slice width (autotuned).
+
+
+TMA and MMA Warps
+~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v4.py
+   :language: python
+   :start-at: with self.thread_group(thread_begin=0
+   :end-at: self.mbarrier.wait(flush_barrier
+   :dedent: 8
+   :caption: TMA warp and MMA warp
+
+The logic is identical to V3, but expressed through the Pipeline API:
+``producer_acquire`` / ``producer_barrier`` / ``producer_advance`` for the TMA
+warp, and ``consumer_acquire`` / ``consumer_barrier`` / ``consumer_advance``
+for the MMA warp.
+
+
+What's Next
+-----------
+
+V4 is a well-optimized single-CTA kernel. To push performance further, we need
+to look beyond the single thread block.
+
+In the next version, we introduce **CLC** (Cluster Launch Control) for persistent
+kernels --- each CTA processes multiple output tiles dynamically via hardware
+scheduling, avoiding kernel launch overhead. We also add a **pipelined
+epilogue** and expand to **4 warp roles** (TMA, MMA, scheduler, epilogue).
+
+
+Full Source
+-----------
+
+The complete example file is located at
+`examples/blackwell_matmul/matmul_v4.py <https://github.com/NVIDIA/tilus/blob/main/examples/blackwell_matmul/matmul_v4.py>`__.

--- a/examples/blackwell_matmul/matmul_v4.py
+++ b/examples/blackwell_matmul/matmul_v4.py
@@ -13,12 +13,6 @@ tilus.option.cache_dir("./cache")
 
 
 class Pipeline(tilus.Class):
-    """Manages a multi-stage producer-consumer pipeline using mbarriers.
-
-    - empty_barriers: signaled by consumer ("slot consumed"), producer waits on these
-    - full_barriers: signaled by producer ("slot filled"), consumer waits on these
-    """
-
     def __init__(
         self,
         num_stages: int,
@@ -38,6 +32,7 @@ class Pipeline(tilus.Class):
         self.consumer_phase: uint32 = self.mbarrier.consumer_initial_phase
 
     def producer_acquire(self):
+        # wait until the current stage is free (consumer has finished with it)
         self.mbarrier.wait(
             barrier=self.empty_barriers[self.producer_stage],
             phase=self.producer_phase,
@@ -46,13 +41,16 @@ class Pipeline(tilus.Class):
         )
 
     def producer_barrier(self) -> RegisterTensor:
+        # return the barrier to signal when the producer has filled this stage
         return self.full_barriers[self.producer_stage]
 
     def producer_advance(self):
+        # advance to the next stage; flip phase when wrapping around
         self.producer_stage = (self.producer_stage + 1) % self.num_stages
         self.producer_phase = self.producer_phase ^ (self.producer_stage == 0)
 
     def consumer_acquire(self):
+        # wait until the current stage is filled (producer has loaded data)
         self.mbarrier.wait(
             barrier=self.full_barriers[self.consumer_stage],
             phase=self.consumer_phase,
@@ -61,9 +59,11 @@ class Pipeline(tilus.Class):
         )
 
     def consumer_barrier(self) -> RegisterTensor:
+        # return the barrier to signal when the consumer has consumed this stage
         return self.empty_barriers[self.consumer_stage]
 
     def consumer_advance(self):
+        # advance to the next stage; flip phase when wrapping around
         self.consumer_stage = (self.consumer_stage + 1) % self.num_stages
         self.consumer_phase = self.consumer_phase ^ (self.consumer_stage == 0)
 
@@ -73,14 +73,6 @@ class Pipeline(tilus.Class):
 @tilus.autotune("stages", [2, 3, 4])
 @tilus.autotune("swizzle_size", [4, 8])
 class BlackwellMatmulV4(tilus.Script):
-    """Blackwell matmul with Pipeline abstraction, TMA epilogue, and L2 swizzle.
-
-    New optimizations over V3:
-    - Pipeline class for clean producer-consumer barrier management
-    - TMA epilogue: store results via shared memory + TMA (instead of direct store_global)
-    - L2 swizzle: reorder tile assignments for better L2 cache locality
-    """
-
     def __init__(
         self,
         block_m: int,
@@ -144,10 +136,11 @@ class BlackwellMatmulV4(tilus.Script):
 
         num_m_blocks = cdiv(m_size, block_m)
         num_n_blocks = cdiv(n_size, block_n)
-        self.attrs.blocks = [num_m_blocks * num_n_blocks, 1]
+        # 1D grid: tile rasterization maps linear index to 2D coordinates
+        self.attrs.blocks = num_m_blocks * num_n_blocks
         self.attrs.warps = 4
 
-        # L2 swizzle: map 1D block index to 2D tile coordinates
+        # tile rasterization: swizzle for better L2 cache reuse of B columns
         m_block, n_block = self.compute_block_coord(
             self.blockIdx.x, num_m_blocks, num_n_blocks
         )
@@ -161,10 +154,10 @@ class BlackwellMatmulV4(tilus.Script):
         s_b = self.shared_tensor(dtype=float16, shape=[stages, block_n, block_k])
         t_acc = self.tcgen05.alloc(dtype=float32, shape=[block_m, block_n])
 
+        # Pipeline class encapsulates barrier/phase/stage management from V3
         tma_pipe = Pipeline(stages)
         flush_barrier = self.mbarrier.alloc(1)
 
-        # TMA warp: load tiles from global to shared memory
         with self.thread_group(thread_begin=0, num_threads=32):
             for offset_k in self.range(0, k_size, block_k, unroll=stages):
                 tma_pipe.producer_acquire()
@@ -188,7 +181,6 @@ class BlackwellMatmulV4(tilus.Script):
                 )
                 tma_pipe.producer_advance()
 
-        # MMA warp: compute matrix multiply-accumulate
         with self.thread_group(thread_begin=32, num_threads=32):
             for offset_k in self.range(0, k_size, block_k, unroll=stages):
                 tma_pipe.consumer_acquire()
@@ -206,9 +198,10 @@ class BlackwellMatmulV4(tilus.Script):
 
         self.sync()
 
-        # Epilogue: store result via TMA (tmem -> register -> shared -> global)
+        # TMA epilogue: tmem -> register -> shared -> global (via TMA)
         s_c = self.shared_tensor(dtype=float16, shape=[block_m, e_block_n])
         for e_offset_n in range(0, block_n, e_block_n):
+            # slice a e_block_n-wide column from the accumulator
             t_acc_slice = self.tcgen05.slice(
                 t_acc,
                 offsets=[0, e_offset_n],
@@ -218,9 +211,11 @@ class BlackwellMatmulV4(tilus.Script):
             r_acc = self.tcgen05.load(t_acc_slice)
             self.tcgen05.wait_load()
             self.store_shared(s_c, r_acc.to(float16))
+            # fence: make generic-proxy writes visible to async-proxy (TMA)
             self.fence.proxy_async(space="shared")
             self.sync()
             with self.single_warp():
+                # TMA bulk store from shared to global
                 self.tma.shared_to_global(
                     s_c,
                     g_c,
@@ -231,7 +226,6 @@ class BlackwellMatmulV4(tilus.Script):
                 self.tma.wait_group(n=0, read=True)
             self.sync()
 
-        # all allocated tensor memory must be deallocated
         self.sync()
         self.tcgen05.dealloc(t_acc)
 

--- a/python/tilus/lang/constructs/state.py
+++ b/python/tilus/lang/constructs/state.py
@@ -16,4 +16,31 @@ from tilus.lang.instructions import InstructionInterface
 
 
 class Class(InstructionInterface):
+    """A helper class for organizing kernel logic into reusable components.
+
+    ``tilus.Class`` works like :class:`tilus.Script` but for helper objects that
+    are not kernels themselves. It can allocate mbarriers, shared tensors, tensor
+    memory, and use all tilus instructions.
+
+    Subclass ``tilus.Class`` and define an ``__init__`` method to create reusable
+    abstractions. The ``__init__`` is transpiled alongside the kernel that uses it.
+
+    Example::
+
+        class Pipeline(tilus.Class):
+            def __init__(self, num_stages: int):
+                self.barriers = self.mbarrier.alloc(counts=[1] * num_stages)
+                self.stage: int32 = 0
+
+            def advance(self):
+                self.stage = (self.stage + 1) % self.num_stages
+
+    Use it inside a :class:`tilus.Script`::
+
+        class MyKernel(tilus.Script):
+            def __call__(self, ...):
+                pipe = Pipeline(num_stages=4)
+                pipe.advance()
+    """
+
     pass


### PR DESCRIPTION
- Tile rasterization: educational explanation with concrete working set example (8x8 grid, wave=16), SVG diagram, formulation, fast_divmod hint
- Pipeline abstraction: async pipeline mindset with producer/consumer/ring buffer, SVG diagram showing 5-stage pipeline state, Pipeline class API
- TMA epilogue: motivation (register/smem pressure), dataflow SVG, step-by-step instruction sequence with completion mechanism note
- Add tilus.Class API page with docstring
- Add comments to matmul_v4.py for new instructions/optimizations
- Forward reference from V3 to V4