### PR TITLE
[Docs] Improve cache guide, target API docs, and add TMemoryTensor dos

### DIFF
--- a/docs/source/programming-guides/cache.rst
+++ b/docs/source/programming-guides/cache.rst
@@ -1,72 +1,87 @@
 Cache
 =====
 
-Tilus caches the results of compilation to speed up subsequent calls to the same tilus script. By default, tilus stores
-the cache under the **default cache directory**: ``~/.cache/tilus``.
+Tilus caches compiled kernels so that subsequent calls to the same script skip
+compilation. By default, the cache is stored under ``.cache/`` in the root of
+the current Git repository. If Tilus is used outside a Git repository, the
+default falls back to ``~/.cache/tilus``.
 
-You can change the cache directory by calling the :py:func:`tilus.option.cache_dir`
-function.
+You can override the cache directory with :func:`tilus.option.cache_dir`:
 
-Get the generated CUDA kernel
------------------------------
+.. code-block:: python
 
-A convenient way to get the generated CUDA kernel is to change the cache directory of tilus to the current working directory:
+    import tilus
+    tilus.option.cache_dir('./my-cache')
+
+The cache directory can be safely deleted at any time --- Tilus will simply
+recompile on the next run.
+
+
+Viewing the Generated CUDA Kernel
+----------------------------------
+
+To inspect the generated CUDA source for a kernel, set the cache directory and
+run your program:
 
 .. code-block:: python
 
     import tilus
     tilus.option.cache_dir('./cache')
 
-    <your program>
+    # ... your program ...
 
-This will store the generated CUDA kernel in the ``./cache`` directory, and you can find the generated cuda kernels.
+After execution, the generated CUDA source can be found at::
 
-If you are interested in the compilation process, you can also enable the debug mode to dump the
-intermediate representations (IRs) via the :py:func:`tilus.option.debug.dump_ir` function.
+    cache/programs/<program-hash>/module/source.cu
+
+
+Dumping Intermediate Representations
+------------------------------------
+
+To inspect the intermediate representations (IRs) produced during compilation,
+enable :func:`tilus.option.debug.dump_ir`:
 
 .. code-block:: python
 
     import tilus
-
     tilus.option.cache_dir('./cache')
-    tilus.option.debug.dump_ir(True)
+    tilus.option.debug.dump_ir()
 
-    <your program>
+    # ... your program ...
+
+This writes the IR after each compiler pass into the cache directory:
+
+- ``cache/programs/<program-hash>/ir/`` --- Tilus IR after each pass
+- ``cache/programs/<program-hash>/module/ir/`` --- Hidet IR after each pass
+
 
 Cache Structure
 ---------------
 
-The cache directory contains the following structure (only show the important parts):
+::
 
-- **cache/**
+    cache/
+    ├── scripts/                              # one entry per tilus script
+    │   └── <script-name>/                    # class name, in snake_case
+    │       └── <script-hash>/
+    │           ├── programs/
+    │           │   ├── 0 -> ../../programs/…  # symlink to the 1st schedule
+    │           │   ├── 1 -> ../../programs/…  # symlink to the 2nd schedule
+    │           │   └── ...
+    │           └── dispatch_table.txt         # maps dynamic input sizes to programs
+    │
+    └── programs/                             # one entry per compiled program
+        └── <program-hash>/                   # hex256 hash of program.txt + options.txt
+            ├── program.txt                   # human-readable Tilus program
+            ├── options.txt                   # compilation options
+            ├── ir/                           # Tilus IR dumps (when dump_ir is enabled)
+            └── module/
+                ├── ir/                       # Hidet IR dumps (when dump_ir is enabled)
+                ├── source.cu                 # generated CUDA source
+                ├── compile.sh                # nvcc compilation command
+                └── lib.so                    # compiled shared library
 
-  - **scripts/**: compilation results for all tilus scripts
-
-    - **<script-name>/**: name of your tilus script class, converted to snake case
-
-      - **<script-hash>/**
-
-        - **programs/**: programs for each schedule
-
-          - **0** a soft link to a program directory for the **first** schedule
-          - **1** a soft link to a program directory for the **second** schedule
-          - ...
-
-        - **dispatch_table.txt** dispatch table from dynamic input size to program id
-
-  - **programs/** compilation results for all tilus programs, each corresponds to a schedule of a tilus script
-
-    - **<program-hash>/**  hex256 hash of the program.txt and options.txt in the directory
-
-      - **ir/** IRs, when dump_ir is enabled
-      - **module/**
-
-        - **ir/**  IRs, when dump_ir is enabled
-        - **compile.sh**  the bash script to compile the source.cu into lib.so
-        - **source.cu**   the source code of the compiled CUDA kernel
-        - **lib.so**  the shared library with the compiled CUDA kernel
-
-      - **program.txt** the program text, which is a human-readable representation of the tilus program
-      - **options.txt** the options used to compile the program
-
-    - ...
+A **script** is a kernel template with a tuning space. Each **program** is a
+concrete instantiation of a script with a specific schedule (tile sizes,
+pipeline depths, etc.). The ``dispatch_table.txt`` records which program to
+use for each combination of dynamic input sizes.

--- a/docs/source/python-api/tilus-target.rst
+++ b/docs/source/python-api/tilus-target.rst
@@ -1,8 +1,9 @@
 tilus.target
 ============
 
-Tilus automatically detects the GPU at runtime and selects the appropriate compilation target.
-You can query or override the target using the functions below.
+Tilus automatically detects the GPU at runtime and selects the most capable
+compilation target for the installed hardware. You can query or override the
+target using the functions below.
 
 .. autosummary::
     :toctree: generated/
@@ -13,12 +14,13 @@ You can query or override the target using the functions below.
 Predefined Targets
 ------------------
 
-Each target represents a GPU architecture with its compute capability and feature suffix.
-Tilus uses these to determine which instructions and optimizations are available.
+Each target represents a GPU architecture with its compute capability and
+feature suffix. Tilus uses these to determine which instructions and
+optimizations are available.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15 30
+   :widths: 30 10 30
 
    * - Target
      - SM
@@ -38,18 +40,57 @@ Tilus uses these to determine which instructions and optimizations are available
    * - ``nvgpu_sm89``
      - 8.9
      - L4, L40, RTX 4090
-   * - ``nvgpu_sm90`` / ``nvgpu_sm90a``
+   * - ``nvgpu_sm90`` / ``sm90a``
      - 9.0
      - H100, H200
-   * - ``nvgpu_sm100`` / ``nvgpu_sm100a``
+   * - ``nvgpu_sm100`` / ``sm100f`` / ``sm100a``
      - 10.0
      - B200, GB200
+   * - ``nvgpu_sm103`` / ``sm103f`` / ``sm103a``
+     - 10.3
+     - GB300
+   * - ``nvgpu_sm120`` / ``sm120f`` / ``sm120a``
+     - 12.0
+     - RTX 5080, RTX 5090
 
-**Feature suffixes:**
+Feature Suffixes
+----------------
 
-- No suffix: base architecture (instructions available on all chips with that SM version)
-- ``a``: architecture-specific (e.g., ``sm_90a`` for Hopper-only features like WGMMA)
-- ``f``: family variant
+Starting with SM 9.0, NVIDIA targets can carry a **feature suffix** that
+controls which architecture-conditional features are enabled. Understanding
+the suffixes is important when writing kernels that use advanced hardware
+features (e.g., Tensor Memory, tcgen05 MMA, TMA).
+
+**No suffix:**
+The base architecture (e.g., ``sm_100``). Only instructions guaranteed on
+*every* chip with that compute capability are available. Use this when you
+only need baseline capabilities and want maximum hardware compatibility.
+
+**`a` (architecture-specific):**
+The full-featured variant for that exact architecture (e.g., ``sm_100a``).
+Enables all architecture-conditional features, such as Tensor Memory
+allocation modes, tcgen05 Tensor Core operations, and special TMA behaviors.
+Use this when you want every available hardware feature and are targeting a
+specific GPU.
+
+**`f` (family-portable):**
+The family-profile variant (e.g., ``sm_100f``). Enables features that are
+portable across all implementations within the same SM family. A feature
+supported on ``sm_100f`` is guaranteed on any chip in the ``sm_100`` family
+that advertises ``f``-level support. Use this when you want advanced features
+with portability across family variants.
+
+The compatibility relationship is:
+
+- ``sm_100a`` supports everything in ``sm_100f`` and ``sm_100``.
+- ``sm_100f`` supports everything in ``sm_100``, but not ``sm_100a``-only features.
+- ``sm_100`` supports only baseline features.
+
+.. note::
+
+   When Tilus auto-detects the target, it picks the most capable variant
+   available: ``a`` first, then ``f``, then the base. For example, on a B200
+   GPU (SM 10.0), Tilus selects ``nvgpu_sm100a``.
 
 Usage
 -----
@@ -57,11 +98,11 @@ Usage
 .. code-block:: python
 
     import tilus
-    from tilus.target import set_current_target, nvgpu_sm90a
+    from tilus.target import set_current_target, nvgpu_sm100a
 
     # Query the auto-detected target
     target = tilus.get_current_target()
-    print(target)  # e.g., nvgpu/sm90a
+    print(target)  # e.g., nvgpu/sm100a
 
     # Override the target (e.g., for cross-compilation)
-    set_current_target(nvgpu_sm90a)
+    set_current_target(nvgpu_sm100a)

--- a/docs/source/tutorials/matmul-blackwell/v0.rst
+++ b/docs/source/tutorials/matmul-blackwell/v0.rst
@@ -18,6 +18,12 @@ The Full Kernel
 Before diving into the details, here is the complete kernel so you can see the
 big picture. We will explain each part in the sections that follow.
 
+.. hint::
+   :class: margin
+
+   To view the generated CUDA source code, check the cache directory.
+   See :doc:`/programming-guides/cache` for details.
+
 .. literalinclude:: ../../../../examples/blackwell_matmul/matmul_v0.py
    :language: python
    :start-at: @tilus.autotune

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = ["GPU", "Compiler", "CUDA", "hidet", "tensor", "torch"]
 authors = [
-    { name = "Hidet Team" }
+    { name = "Tilus Team" }
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/python/tilus/ir/tensor.py
+++ b/python/tilus/ir/tensor.py
@@ -657,11 +657,46 @@ class SharedTensor(Tensor):
 
 @dataclass(frozen=True, eq=False)
 class TMemoryTensor(Tensor):
+    """A tensor that resides in tensor memory (TMEM).
+
+    Tensor memory is a dedicated on-chip memory available on Blackwell (SM 10.0+) GPUs, private to the SM's tensor
+    cores. It is organized as a 2D structure of lanes (rows) and columns, with each cell being 32 bits. The number
+    of lanes (``shape[-2]``) must be 32, 64, or 128.
+
+    Attributes
+    ----------
+    dtype: DataType
+        The data type of the tensor elements.
+    shape: tuple[int, ...]
+        The shape of the tensor. Must have at least 2 dimensions. The second-to-last dimension (lanes) must be
+        32, 64, or 128.
+    optional_layout: TMemoryLayout, optional
+        The layout of the tensor, which is optional. When not provided, the layout will be automatically inferred
+        with compiler pass.
+    """
+
     shape: tuple[int, ...]
     optional_layout: Optional[TMemoryLayout]
 
     @staticmethod
     def create(dtype: DataType, shape: Sequence[int], optional_layout: Optional[TMemoryLayout] = None) -> TMemoryTensor:
+        """Create a TMemoryTensor with the given dtype, shape, and optional layout.
+
+        Parameters
+        ----------
+        dtype: DataType
+            The data type of the tensor elements.
+        shape: Sequence[int]
+            The shape of the tensor. Must have at least 2 dimensions, with the second-to-last
+            dimension (lanes) being 32, 64, or 128.
+        optional_layout: TMemoryLayout, optional
+            The layout of the tensor. If not provided, the layout will be inferred later.
+
+        Returns
+        -------
+        ret: TMemoryTensor
+            The created TMemoryTensor instance.
+        """
         if len(shape) < 2:
             raise ValueError("TMemoryTensor requires at least 2 dimensions, got {}".format(len(shape)))
         if shape[-2] not in (32, 64, 128):
@@ -674,14 +709,45 @@ class TMemoryTensor(Tensor):
 
     @property
     def layout(self) -> TMemoryLayout:
+        """Get the layout of the TMemoryTensor.
+
+        Returns
+        -------
+        ret: TMemoryLayout
+            The layout of the TMemoryTensor.
+
+        Raises
+        ------
+        ValueError
+            If the TMemoryTensor does not have a layout defined.
+        """
         if self.optional_layout is None:
             raise ValueError("TMemoryTensor does not have a layout defined.")
         return self.optional_layout
 
     def has_layout(self) -> bool:
+        """Check if the TMemoryTensor has a layout defined.
+
+        Returns
+        -------
+        ret: bool
+            True if the TMemoryTensor has a layout defined, False otherwise.
+        """
         return self.optional_layout is not None
 
     def with_layout(self, layout: TMemoryLayout) -> TMemoryTensor:
+        """Create a new TMemoryTensor with the given layout.
+
+        Parameters
+        ----------
+        layout: TMemoryLayout
+            The layout to be used for the new TMemoryTensor.
+
+        Returns
+        -------
+        ret: TMemoryTensor
+            A new TMemoryTensor instance with the specified layout.
+        """
         if not same_list(self.shape, layout.shape):
             raise ValueError(f"Shape mismatch: provided shape {self.shape} does not match layout shape {layout.shape}.")
         return dataclasses.replace(self, optional_layout=layout)


### PR DESCRIPTION
- Rewrite cache.rst: fix default directory, add ASCII tree layout, split into sections for viewing CUDA source and dumping IRs
- Enrich tilus.target docs with feature suffix explanations (a/f/base), compatibility rules, and missing GPU targets (SM 10.3, 12.0)
- Add margin hint in blackwell matmul v0 tutorial pointing to cache guide
- Add class and method docstrings to TMemoryTensor