### PR TITLE
[Instruction] Add Philox-4x32 random number generation instructions

### DIFF
--- a/docs/source/programming-guides/instructions.rst
+++ b/docs/source/programming-guides/instructions.rst
@@ -93,15 +93,33 @@ support NumPy-style broadcasting.
    abs
    add
    clip
+   cos
    exp
    exp2
    log
    maximum
    round
    rsqrt
+   sin
    sqrt
    square
    where
+
+
+Random Number Generation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Generate pseudo-random numbers using the Philox-4x32-10 counter-based PRNG. Given a seed (uint64
+scalar) and an offset tensor (uint32), each element produces independent random values.
+``randint4x`` is the most efficient entry point, returning all four Philox outputs per invocation.
+``rand`` and ``randn`` build on top to provide uniform and normal distributions respectively.
+
+.. autosummary::
+
+   rand
+   randint
+   randint4x
+   randn
 
 
 Reduction

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -67,6 +67,7 @@ Instructions
    assign
    cast
    clip
+   cos
    copy_async
    copy_async_commit_group
    copy_async_wait_all
@@ -88,6 +89,10 @@ Instructions
    min
    print_tensor
    printf
+   rand
+   randint
+   randint4x
+   randn
    register_tensor
    release_semaphore
    repeat
@@ -96,6 +101,7 @@ Instructions
    round
    rsqrt
    shared_tensor
+   sin
    sqrt
    square
    squeeze

--- a/python/tilus/backends/emitters/__init__.py
+++ b/python/tilus/backends/emitters/__init__.py
@@ -23,6 +23,7 @@ from . import (
     elementwise,
     gmem,
     ldst,
+    random,
     reduce,
     regs,
     shared_ldst,

--- a/python/tilus/backends/emitters/random.py
+++ b/python/tilus/backends/emitters/random.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Emitter for Philox-4x32 random number generation instruction."""
+
+from tilus.backends.emitter import BaseInstEmitter, register_emitter
+from tilus.hidet.ir.dtypes import uint32, uint64
+from tilus.hidet.ir.expr import BitwiseAnd
+from tilus.hidet.ir.primitives.cuda.random import philox4x32
+from tilus.ir.instructions import Philox4x32Inst
+from tilus.ir.tensor import RegisterTensor
+
+
+@register_emitter(Philox4x32Inst)
+class Philox4x32InstEmitter(BaseInstEmitter):
+    def emit(self, inst: Philox4x32Inst) -> None:
+        offset_tensor: RegisterTensor = inst.inputs[0].as_register_tensor()
+        output_tensor: RegisterTensor = inst.register_output
+        offset_buf = self.tensor2var[offset_tensor]
+        output_buf = self.get_or_allocate_var(output_tensor)
+
+        seed_expr = inst.seed
+        n = offset_tensor.local_size
+
+        # Split seed (uint64) into two uint32 halves: k0 = low, k1 = high
+        seed_lo = self.declare_var("seed_lo", tp=uint32, init=BitwiseAnd(seed_expr, uint64(0xFFFFFFFF)))
+        seed_hi = self.declare_var("seed_hi", tp=uint32, init=BitwiseAnd(seed_expr >> uint64(32), uint64(0xFFFFFFFF)))
+
+        # Since output layout = local(4, 1, ...) * offset_layout, the local buffer is laid out as:
+        #   output_buf[4 * n]  where  output_buf[j * n + i] <=> component j of offset element i
+        with self.for_range(extent=n) as i:
+            self.append(
+                philox4x32(
+                    seed_lo,
+                    seed_hi,
+                    offset=offset_buf[i],
+                    out0=~output_buf[0 * n + i],
+                    out1=~output_buf[1 * n + i],
+                    out2=~output_buf[2 * n + i],
+                    out3=~output_buf[3 * n + i],
+                )
+            )

--- a/python/tilus/hidet/ir/primitives/cuda/integer_intrinsics.py
+++ b/python/tilus/hidet/ir/primitives/cuda/integer_intrinsics.py
@@ -23,7 +23,7 @@ from tilus.hidet.utils import initialize
 @initialize()
 def register_functions():
     from tilus.hidet.lang import asm, attrs, script  # pylint: disable=import-outside-toplevel
-    from tilus.hidet.lang.types import int32
+    from tilus.hidet.lang.types import int32, uint32
 
     @no_type_check
     @script
@@ -34,10 +34,39 @@ def register_functions():
         asm("popc.b32 %0, %1;", outputs=[ret], inputs=[a])
         return ret
 
-    funcs = [cuda_popc]
+    @no_type_check
+    @script
+    def cuda_umulhi(a: uint32, b: uint32) -> uint32:
+        """Unsigned 32-bit multiply-high: returns the upper 32 bits of a * b."""
+        attrs.func_kind = "cuda_internal"
+
+        ret: uint32 = 0
+        asm("mul.hi.u32 %0, %1, %2;", outputs=[ret], inputs=[a, b])
+        return ret
+
+    funcs = [cuda_popc, cuda_umulhi]
     for func in funcs:
         assert isinstance(func, Function)
         register_primitive_function(name=func.name, func_or_type=func)
+
+
+def umulhi(a: Expr, b: Expr) -> Expr:
+    """
+    Unsigned 32-bit multiply-high: returns the upper 32 bits of a * b.
+
+    Parameters
+    ----------
+    a: Expr
+        The first uint32 operand.
+    b: Expr
+        The second uint32 operand.
+
+    Returns
+    -------
+    ret: Expr
+        The upper 32 bits of the unsigned 64-bit product.
+    """
+    return call_primitive_func("cuda_umulhi", args=[a, b])
 
 
 def popc(a: Expr) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/random.py
+++ b/python/tilus/hidet/ir/primitives/cuda/random.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Philox-4x32-10 PRNG primitive function."""
+
+from typing import no_type_check
+
+from tilus.hidet.ir.expr import Expr
+from tilus.hidet.ir.func import Function
+from tilus.hidet.ir.primitives.cuda.integer_intrinsics import umulhi
+from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
+from tilus.hidet.utils import initialize
+
+
+@initialize()
+def register_functions():
+    from tilus.hidet.lang import attrs, script  # pylint: disable=import-outside-toplevel
+    from tilus.hidet.lang.types import uint32
+
+    p_u32 = ~uint32  # PointerType(uint32)
+
+    # Philox-4x32 constants from Salmon et al., "Parallel Random Numbers: As Easy as 1, 2, 3" (2011).
+    # KEY_A/B are Weyl sequence constants (golden ratio and sqrt(3) based).
+    # ROUND_A/B are multiplier constants selected to pass BigCrush in minimal rounds.
+    PHILOX_KEY_A = 0x9E3779B9
+    PHILOX_KEY_B = 0xBB67AE85
+    PHILOX_ROUND_A = 0xD2511F53
+    PHILOX_ROUND_B = 0xCD9E8D57
+
+    @no_type_check
+    @script
+    def cuda_philox4x32(
+        seed_lo: uint32,
+        seed_hi: uint32,
+        offset: uint32,
+        out0: p_u32,
+        out1: p_u32,
+        out2: p_u32,
+        out3: p_u32,
+    ):
+        """Philox-4x32-10 PRNG: given seed (split into lo/hi) and offset, write 4 random uint32 outputs."""
+        attrs.func_kind = "cuda_internal"
+
+        c0: uint32 = offset
+        c1: uint32 = uint32(0)
+        c2: uint32 = uint32(0)
+        c3: uint32 = uint32(0)
+
+        k0: uint32 = seed_lo
+        k1: uint32 = seed_hi
+
+        round_a: uint32 = uint32(PHILOX_ROUND_A)
+        round_b: uint32 = uint32(PHILOX_ROUND_B)
+
+        # 10 rounds (unrolled at Python level during script compilation)
+        for _round in range(10):
+            old_c0: uint32 = c0
+            old_c2: uint32 = c2
+
+            hi_b_c2: uint32 = umulhi(round_b, old_c2)
+            hi_a_c0: uint32 = umulhi(round_a, old_c0)
+
+            c0 = hi_b_c2 ^ c1 ^ k0
+            c2 = hi_a_c0 ^ c3 ^ k1
+            c1 = round_b * old_c2
+            c3 = round_a * old_c0
+
+            k0 = k0 + uint32(PHILOX_KEY_A)
+            k1 = k1 + uint32(PHILOX_KEY_B)
+
+        out0[0] = c0
+        out1[0] = c1
+        out2[0] = c2
+        out3[0] = c3
+
+    assert isinstance(cuda_philox4x32, Function)
+    register_primitive_function(name=cuda_philox4x32.name, func_or_type=cuda_philox4x32)
+
+
+def philox4x32(seed_lo: Expr, seed_hi: Expr, offset: Expr, out0: Expr, out1: Expr, out2: Expr, out3: Expr) -> Expr:
+    """
+    Philox-4x32-10 PRNG. Given a seed (split into lo/hi uint32 halves) and an offset (uint32),
+    writes 4 random uint32 values to the output pointers.
+
+    Parameters
+    ----------
+    seed_lo: Expr
+        Lower 32 bits of the uint64 seed.
+    seed_hi: Expr
+        Upper 32 bits of the uint64 seed.
+    offset: Expr
+        The uint32 offset (counter value).
+    out0, out1, out2, out3: Expr
+        Pointers to uint32 where the 4 random outputs will be written.
+    """
+    return call_primitive_func("cuda_philox4x32", args=[seed_lo, seed_hi, offset, out0, out1, out2, out3])

--- a/python/tilus/ir/builders/stmt_builder.py
+++ b/python/tilus/ir/builders/stmt_builder.py
@@ -98,6 +98,7 @@ from tilus.ir.instructions.generic import (
     ModInst,
     MulInst,
     PermuteSharedInst,
+    Philox4x32Inst,
     PrintTensorInst,
     ReduceInst,
     RepeatInst,
@@ -980,6 +981,12 @@ class StmtBuilder(StmtBuilderCore):
     def log(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: primitives.log(arg), out=out)
 
+    def sin(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_unary(x, f_compute=lambda arg: primitives.sin(arg), out=out)
+
+    def cos(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
+        return self.elementwise_unary(x, f_compute=lambda arg: primitives.cos(arg), out=out)
+
     def logical_not(self, x: RegisterTensor, *, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         return self.elementwise_unary(x, f_compute=lambda arg: LogicalNot(arg), out=out)
 
@@ -1018,6 +1025,107 @@ class StmtBuilder(StmtBuilderCore):
         )
         self.append(inst)
         return inst.register_output
+
+    # random number generation
+
+    def philox4x32(
+        self,
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        inst = Philox4x32Inst.create(seed=seed, offset=offset, n_rounds=n_rounds)
+        self.append(inst)
+        return inst.register_output
+
+    def randint4x(
+        self,
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> tuple[RegisterTensor, RegisterTensor, RegisterTensor, RegisterTensor]:
+        philox_out = self.philox4x32(seed=seed, offset=offset, n_rounds=n_rounds)
+        # Philox output shape is [4, *offset.shape]. Slice along dim 0 to extract each component.
+        # offsets has one entry per source dim; dims lists which source dims the output maps to.
+        zero_offsets = [as_expr(0)] * len(offset.shape)
+        slice_dims = list(range(1, 1 + len(offset.shape)))
+        r0 = self.slice_register(
+            philox_out, offsets=[as_expr(0)] + zero_offsets, slice_dims=slice_dims, slice_shape=list(offset.shape)
+        )
+        r1 = self.slice_register(
+            philox_out, offsets=[as_expr(1)] + zero_offsets, slice_dims=slice_dims, slice_shape=list(offset.shape)
+        )
+        r2 = self.slice_register(
+            philox_out, offsets=[as_expr(2)] + zero_offsets, slice_dims=slice_dims, slice_shape=list(offset.shape)
+        )
+        r3 = self.slice_register(
+            philox_out, offsets=[as_expr(3)] + zero_offsets, slice_dims=slice_dims, slice_shape=list(offset.shape)
+        )
+        return r0, r1, r2, r3
+
+    def randint(
+        self,
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        r0, _, _, _ = self.randint4x(seed=seed, offset=offset, n_rounds=n_rounds)
+        return r0
+
+    def _uint32_to_uniform_float(self, x: RegisterTensor) -> RegisterTensor:
+        """Convert a uint32 register tensor to uniform float32 in [0, 1)."""
+        from tilus.hidet.ir.dtypes import float32
+
+        x_i32 = self.cast(x, dtype=int32)
+        neg = self.elementwise_binary(
+            x_i32,
+            self.allocate_register(dtype=int32, shape=x.shape, f_init=lambda _: int32.constant(0)),
+            f_compute=lambda a, b: LessThan(a, b),
+        )
+        neg_x = self.neg(x_i32)
+        one = self.allocate_register(dtype=int32, shape=x.shape, f_init=lambda _: int32.constant(1))
+        neg_x_minus_1 = self.sub(neg_x, one)
+        folded = self.where(neg, neg_x_minus_1, x_i32)
+        folded_f32 = self.cast(folded, dtype=float32)
+        scale = self.allocate_register(
+            dtype=float32, shape=x.shape, f_init=lambda _: float32.constant(4.6566127342e-10)
+        )
+        return self.mul(folded_f32, scale)
+
+    def rand(
+        self,
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        raw = self.randint(seed=seed, offset=offset, n_rounds=n_rounds)
+        return self._uint32_to_uniform_float(raw)
+
+    def randn(
+        self,
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        from tilus.hidet.ir.dtypes import float32
+
+        r0, r1, _, _ = self.randint4x(seed=seed, offset=offset, n_rounds=n_rounds)
+        u1 = self._uint32_to_uniform_float(r0)
+        u2 = self._uint32_to_uniform_float(r1)
+        # Clamp u1 to avoid log(0)
+        eps = self.allocate_register(dtype=float32, shape=offset.shape, f_init=lambda _: float32.constant(1.0e-7))
+        u1 = self.maximum(u1, eps)
+        # Box-Muller transform
+        two_pi = self.allocate_register(
+            dtype=float32, shape=offset.shape, f_init=lambda _: float32.constant(6.283185307179586)
+        )
+        neg_two = self.allocate_register(dtype=float32, shape=offset.shape, f_init=lambda _: float32.constant(-2.0))
+        theta = self.mul(two_pi, u2)
+        log_u1 = self.log(u1)
+        scaled = self.mul(neg_two, log_u1)
+        r = self.sqrt(scaled)
+        cos_theta = self.cos(theta)
+        return self.mul(r, cos_theta)
 
     # shared value operations
 

--- a/python/tilus/ir/instructions/__init__.py
+++ b/python/tilus/ir/instructions/__init__.py
@@ -54,6 +54,7 @@ from .generic import (
     ModInst,
     MulInst,
     PermuteSharedInst,
+    Philox4x32Inst,
     PrintTensorInst,
     ReduceInst,
     RepeatInst,

--- a/python/tilus/ir/instructions/generic.py
+++ b/python/tilus/ir/instructions/generic.py
@@ -590,3 +590,28 @@ class NopInst(Instruction):
     @staticmethod
     def create() -> NopInst:
         return NopInst(output=None, inputs=())
+
+
+@dataclass(frozen=True, eq=False)
+class Philox4x32Inst(Instruction):
+    """Philox-4x32 counter-based PRNG instruction.
+
+    Given a seed (uint64 scalar) and an offset register tensor (uint32),
+    produces an output register tensor with shape [4, *offset.shape] of dtype uint32,
+    containing four independent streams of random uint32 values.
+    """
+
+    seed: Expr
+    n_rounds: int
+
+    @staticmethod
+    def create(
+        seed: Expr,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> Philox4x32Inst:
+        from tilus.hidet.ir.dtypes import uint32
+
+        assert offset.dtype == uint32, f"offset must be uint32, got {offset.dtype}"
+        output = RegisterTensor.create(dtype=uint32, shape=(4, *offset.shape))
+        return Philox4x32Inst(output=output, inputs=(offset,), seed=seed, n_rounds=n_rounds)

--- a/python/tilus/ir/layout/inference/inference_rules/__init__.py
+++ b/python/tilus/ir/layout/inference/inference_rules/__init__.py
@@ -23,6 +23,7 @@ from . import (
     load_shared,
     mbarrier,
     mma_dot,
+    philox,
     reduce,
     reshape_shared,
     slice_register,

--- a/python/tilus/ir/layout/inference/inference_rules/philox.py
+++ b/python/tilus/ir/layout/inference/inference_rules/philox.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Layout inference and validation rules for Philox4x32Inst.
+
+The output layout must be ``local(4, 1, ..., 1) * offset_layout`` — i.e., the leading
+dimension of size 4 is purely local (each thread holds all 4 Philox outputs), and the
+remaining dimensions match the offset layout exactly.
+"""
+
+from tilus.ir.instructions import Philox4x32Inst
+from tilus.ir.layout import RegisterLayout, ops
+from tilus.ir.layout.inference.rule import (
+    LayoutInferenceContext,
+    LayoutInferenceRule,
+    LayoutValidationRule,
+    register_rule,
+)
+from tilus.ir.tensor import RegisterTensor
+
+
+def _output_layout_from_offset(offset_layout: RegisterLayout) -> RegisterLayout:
+    """Compute the expected output layout: local(4) composed with offset_layout via unsqueeze."""
+    # Unsqueeze adds a dim-0 of size 1, then compose with local(4) to get size 4 in dim 0
+    unsqueezed = ops.unsqueeze(offset_layout, dims=[0])
+    local_4 = ops.local(4, *([1] * len(offset_layout.shape)))
+    return ops.compose(local_4, unsqueezed)
+
+
+def _offset_layout_from_output(output_layout: RegisterLayout) -> RegisterLayout:
+    """Extract offset layout from output layout by squeezing the leading dim-4."""
+    # Reduce dim 0 (size 4) then squeeze it out
+    reduced = ops.reduce(output_layout, dims=[0], keepdims=False)
+    return reduced
+
+
+@register_rule(Philox4x32Inst)
+class Philox4x32InferenceRule(LayoutInferenceRule):
+    @staticmethod
+    def inference(ctx: LayoutInferenceContext, inst: Philox4x32Inst) -> dict[RegisterTensor, RegisterLayout]:
+        offset = inst.inputs[0].as_register_tensor()
+        output = inst.register_output
+
+        if offset.optional_layout is not None and output.optional_layout is not None:
+            return {}
+        elif offset.optional_layout is not None:
+            return {output: _output_layout_from_offset(offset.layout)}
+        elif output.optional_layout is not None:
+            return {offset: _offset_layout_from_output(output.layout)}
+        else:
+            return {}
+
+
+@register_rule(Philox4x32Inst)
+class Philox4x32ValidationRule(LayoutValidationRule):
+    @staticmethod
+    def validate(inst: Philox4x32Inst) -> bool:
+        offset = inst.inputs[0].as_register_tensor()
+        output = inst.register_output
+
+        if offset.optional_layout is None or output.optional_layout is None:
+            return True
+
+        expected_output = _output_layout_from_offset(offset.layout)
+        return output.layout == expected_output

--- a/python/tilus/ir/layout/inference/order.py
+++ b/python/tilus/ir/layout/inference/order.py
@@ -34,6 +34,7 @@ from .inference_rules.load_shared import (
 from .inference_rules.mapa import MapSharedAddrRule
 from .inference_rules.mbarrier import AllocBarrierRule
 from .inference_rules.mma_dot import MmaDotRule
+from .inference_rules.philox import Philox4x32InferenceRule
 from .inference_rules.reduce import ReduceRule
 from .inference_rules.reshape_shared import ReshapeSharedRule
 from .inference_rules.slice_register import SliceAssignRule, SliceRegisterRule
@@ -58,6 +59,7 @@ inference_order: list[list[Type[LayoutInferenceRule]]] = [
     [WgmmaMmaSSRule],
     [Tcgen05LoadRule, Tcgen05StoreRule],
     [Tcgen05CopyRule],
+    [Philox4x32InferenceRule],
     [BinaryRule, UnaryRule],
     [LoadGlobalRule],
     [ReduceRule],

--- a/python/tilus/lang/instructions/root.py
+++ b/python/tilus/lang/instructions/root.py
@@ -1118,6 +1118,58 @@ class RootInstructionGroup(InstructionGroup):
         """
         return self._builder.log(x, out=out)
 
+    def sin(
+        self,
+        x: RegisterTensor,
+        *,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Compute the element-wise sine.
+
+        Parameters
+        ----------
+        x: RegisterTensor
+            Input tensor (in radians).
+        out: RegisterTensor, optional
+            Output tensor. If not provided, a new tensor is allocated.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        return self._builder.sin(x, out=out)
+
+    def cos(
+        self,
+        x: RegisterTensor,
+        *,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Compute the element-wise cosine.
+
+        Parameters
+        ----------
+        x: RegisterTensor
+            Input tensor (in radians).
+        out: RegisterTensor, optional
+            Output tensor. If not provided, a new tensor is allocated.
+
+        Returns
+        -------
+        ret: RegisterTensor
+            Tensor with the same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        return self._builder.cos(x, out=out)
+
     def round(
         self,
         x: RegisterTensor,
@@ -1846,3 +1898,135 @@ class RootInstructionGroup(InstructionGroup):
             q = fastdiv(a, b)
             r = a - q * b
             return q, r
+
+    # random number generation
+
+    def randint4x(
+        self,
+        seed: Expr | int,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> tuple[RegisterTensor, RegisterTensor, RegisterTensor, RegisterTensor]:
+        """Generate four blocks of random int32 using Philox-4x32 PRNG.
+
+        Given a seed scalar and an offset register tensor, returns four register tensors
+        of random uint32 values. This is the most efficient entry point to Tilus's
+        Philox pseudo-random number generator.
+
+        Parameters
+        ----------
+        seed: Expr | int
+            The seed for generating random numbers (uint64 scalar).
+        offset: RegisterTensor
+            The offsets to generate random numbers for (uint32).
+        n_rounds: int
+            Number of Philox rounds (default 10).
+
+        Returns
+        -------
+        r0, r1, r2, r3: tuple[RegisterTensor, RegisterTensor, RegisterTensor, RegisterTensor]
+            Four register tensors of random uint32 values with the same shape as ``offset``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        seed = as_expr(seed)
+        return self._builder.randint4x(seed=seed, offset=offset, n_rounds=n_rounds)
+
+    def randint(
+        self,
+        seed: Expr | int,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        """Generate a block of random int32 using Philox-4x32 PRNG.
+
+        Given a seed scalar and an offset register tensor, returns a single register tensor
+        of random uint32 values.
+
+        Parameters
+        ----------
+        seed: Expr | int
+            The seed for generating random numbers (uint64 scalar).
+        offset: RegisterTensor
+            The offsets to generate random numbers for (uint32).
+        n_rounds: int
+            Number of Philox rounds (default 10).
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A register tensor of random uint32 values with the same shape as ``offset``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        seed = as_expr(seed)
+        return self._builder.randint(seed=seed, offset=offset, n_rounds=n_rounds)
+
+    def rand(
+        self,
+        seed: Expr | int,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        """Generate a block of random float32 in U(0, 1) using Philox-4x32 PRNG.
+
+        Given a seed scalar and an offset register tensor, returns a register tensor
+        of random float32 values uniformly distributed in [0, 1).
+
+        Parameters
+        ----------
+        seed: Expr | int
+            The seed for generating random numbers (uint64 scalar).
+        offset: RegisterTensor
+            The offsets to generate random numbers for (uint32).
+        n_rounds: int
+            Number of Philox rounds (default 10).
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A register tensor of random float32 values in [0, 1) with the same shape as ``offset``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        seed = as_expr(seed)
+        return self._builder.rand(seed=seed, offset=offset, n_rounds=n_rounds)
+
+    def randn(
+        self,
+        seed: Expr | int,
+        offset: RegisterTensor,
+        n_rounds: int = 10,
+    ) -> RegisterTensor:
+        """Generate a block of random float32 in N(0, 1) using Philox-4x32 PRNG.
+
+        Given a seed scalar and an offset register tensor, returns a register tensor
+        of random float32 values following a standard normal distribution, using the
+        Box-Muller transform.
+
+        Parameters
+        ----------
+        seed: Expr | int
+            The seed for generating random numbers (uint64 scalar).
+        offset: RegisterTensor
+            The offsets to generate random numbers for (uint32).
+        n_rounds: int
+            Number of Philox rounds (default 10).
+
+        Returns
+        -------
+        ret: RegisterTensor
+            A register tensor of random float32 values ~ N(0, 1) with the same shape as ``offset``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        seed = as_expr(seed)
+        return self._builder.randn(seed=seed, offset=offset, n_rounds=n_rounds)

--- a/python/tilus/transforms/dead_code_elimination.py
+++ b/python/tilus/transforms/dead_code_elimination.py
@@ -41,6 +41,7 @@ from tilus.ir.instructions.generic import (
     LoadGlobalInst,
     LoadSharedInst,
     PermuteSharedInst,
+    Philox4x32Inst,
     ReduceInst,
     RepeatInst,
     RepeatInterleaveInst,
@@ -88,6 +89,8 @@ FUNCTIONAL_INST_TYPES: tuple[Type[Instruction], ...] = (
     # TMemory views
     Tcgen05SliceInst,
     Tcgen05ViewInst,
+    # Random number generation
+    Philox4x32Inst,
     # Other pure ops
     DotInst,
     SimtDotInst,

--- a/tests/instructions/test_random.py
+++ b/tests/instructions/test_random.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for random number generation instructions (Philox-4x32 PRNG)."""
+
+import numpy as np
+import pytest
+import tilus
+import torch
+from tilus import float32, int32, uint32, uint64
+from tilus.ir.layout import RegisterLayout
+from tilus.ir.layout.ops import spatial
+from tilus.utils import cdiv
+
+
+# Reference Philox-4x32-10 implementation for validation
+def philox4x32_reference(seed: int, offset: np.ndarray, n_rounds: int = 10) -> tuple:
+    """Reference Philox-4x32-10 in NumPy.
+
+    Constants from Salmon et al., "Parallel Random Numbers: As Easy as 1, 2, 3" (2011).
+    """
+    ROUND_A = np.uint32(0xD2511F53)
+    ROUND_B = np.uint32(0xCD9E8D57)
+    KEY_A = np.uint32(0x9E3779B9)
+    KEY_B = np.uint32(0xBB67AE85)
+
+    offset = offset.astype(np.uint32)
+    c0 = offset.copy()
+    c1 = np.zeros_like(offset, dtype=np.uint32)
+    c2 = np.zeros_like(offset, dtype=np.uint32)
+    c3 = np.zeros_like(offset, dtype=np.uint32)
+
+    k0 = np.uint32(seed & 0xFFFFFFFF)
+    k1 = np.uint32((seed >> 32) & 0xFFFFFFFF)
+
+    def umulhi(a, b):
+        """Unsigned multiply high for uint32."""
+        return np.uint32((np.uint64(a) * np.uint64(b)) >> np.uint64(32))
+
+    for _ in range(n_rounds):
+        old_c0, old_c2 = c0.copy(), c2.copy()
+        c0 = umulhi(ROUND_B, old_c2) ^ c1 ^ k0
+        c2 = umulhi(ROUND_A, old_c0) ^ c3 ^ k1
+        c1 = np.uint32(np.uint64(ROUND_B) * np.uint64(old_c2))
+        c3 = np.uint32(np.uint64(ROUND_A) * np.uint64(old_c0))
+        k0 = np.uint32(np.uint64(k0) + np.uint64(KEY_A))
+        k1 = np.uint32(np.uint64(k1) + np.uint64(KEY_B))
+
+    return c0, c1, c2, c3
+
+
+class RandInt4xKernel(tilus.Script):
+    """Kernel that generates 4 blocks of random uint32 using randint4x."""
+
+    def __init__(self, block_size: int, layout: RegisterLayout, seed: int):
+        super().__init__()
+        self.block_size = block_size
+        self.layout = layout
+        self.num_warps = layout.spatial_size // 32
+        self.seed = seed
+
+    def __call__(
+        self,
+        n: int32,
+        offset_ptr: ~uint32,
+        out0_ptr: ~uint32,
+        out1_ptr: ~uint32,
+        out2_ptr: ~uint32,
+        out3_ptr: ~uint32,
+    ) -> None:
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (cdiv(n, self.block_size),)
+
+        block_offset: int32 = self.blockIdx.x * self.block_size
+
+        g_offset = self.global_view(offset_ptr, dtype=uint32, shape=(n,))
+        g_out0 = self.global_view(out0_ptr, dtype=uint32, shape=(n,))
+        g_out1 = self.global_view(out1_ptr, dtype=uint32, shape=(n,))
+        g_out2 = self.global_view(out2_ptr, dtype=uint32, shape=(n,))
+        g_out3 = self.global_view(out3_ptr, dtype=uint32, shape=(n,))
+
+        r_offset = self.load_global(g_offset, offsets=[block_offset], shape=[self.block_size])
+        self.annotate_layout(r_offset, self.layout)
+
+        seed_expr = uint64(self.seed)
+        r0, r1, r2, r3 = self.randint4x(seed=seed_expr, offset=r_offset)
+
+        self.store_global(g_out0, r0, offsets=[block_offset])
+        self.store_global(g_out1, r1, offsets=[block_offset])
+        self.store_global(g_out2, r2, offsets=[block_offset])
+        self.store_global(g_out3, r3, offsets=[block_offset])
+
+
+class RandKernel(tilus.Script):
+    """Kernel that generates random float32 in [0, 1) using rand."""
+
+    def __init__(self, block_size: int, layout: RegisterLayout, seed: int):
+        super().__init__()
+        self.block_size = block_size
+        self.layout = layout
+        self.num_warps = layout.spatial_size // 32
+        self.seed = seed
+
+    def __call__(
+        self,
+        n: int32,
+        offset_ptr: ~uint32,
+        out_ptr: ~float32,
+    ) -> None:
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (cdiv(n, self.block_size),)
+
+        block_offset: int32 = self.blockIdx.x * self.block_size
+
+        g_offset = self.global_view(offset_ptr, dtype=uint32, shape=(n,))
+        g_out = self.global_view(out_ptr, dtype=float32, shape=(n,))
+
+        r_offset = self.load_global(g_offset, offsets=[block_offset], shape=[self.block_size])
+        self.annotate_layout(r_offset, self.layout)
+
+        seed_expr = uint64(self.seed)
+        r_out = self.rand(seed=seed_expr, offset=r_offset)
+
+        self.store_global(g_out, r_out, offsets=[block_offset])
+
+
+class RandnKernel(tilus.Script):
+    """Kernel that generates random float32 ~ N(0, 1) using randn."""
+
+    def __init__(self, block_size: int, layout: RegisterLayout, seed: int):
+        super().__init__()
+        self.block_size = block_size
+        self.layout = layout
+        self.num_warps = layout.spatial_size // 32
+        self.seed = seed
+
+    def __call__(
+        self,
+        n: int32,
+        offset_ptr: ~uint32,
+        out_ptr: ~float32,
+    ) -> None:
+        self.attrs.warps = self.num_warps
+        self.attrs.blocks = (cdiv(n, self.block_size),)
+
+        block_offset: int32 = self.blockIdx.x * self.block_size
+
+        g_offset = self.global_view(offset_ptr, dtype=uint32, shape=(n,))
+        g_out = self.global_view(out_ptr, dtype=float32, shape=(n,))
+
+        r_offset = self.load_global(g_offset, offsets=[block_offset], shape=[self.block_size])
+        self.annotate_layout(r_offset, self.layout)
+
+        seed_expr = uint64(self.seed)
+        r_out = self.randn(seed=seed_expr, offset=r_offset)
+
+        self.store_global(g_out, r_out, offsets=[block_offset])
+
+
+BLOCK_SIZE = 128
+LAYOUT = spatial(128)
+SEED = 42
+
+
+def _make_uint32_tensor(n: int, device="cuda") -> torch.Tensor:
+    """Create a uint32 tensor by viewing an int32 tensor."""
+    return torch.zeros(n, dtype=torch.int32, device=device).view(torch.uint32)
+
+
+def _arange_uint32(n: int, device="cuda") -> torch.Tensor:
+    """Create arange as uint32 by viewing int32."""
+    return torch.arange(n, dtype=torch.int32, device=device).view(torch.uint32)
+
+
+@pytest.mark.parametrize("n", [128, 1024])
+def test_randint4x_correctness(n: int) -> None:
+    """Test that randint4x matches the reference Philox implementation."""
+    offsets = _arange_uint32(n)
+
+    out0 = _make_uint32_tensor(n)
+    out1 = _make_uint32_tensor(n)
+    out2 = _make_uint32_tensor(n)
+    out3 = _make_uint32_tensor(n)
+
+    kernel = RandInt4xKernel(BLOCK_SIZE, LAYOUT, SEED)
+    kernel(n, offsets, out0, out1, out2, out3)
+
+    # Reference
+    offsets_np = np.arange(n, dtype=np.uint32)
+    ref0, ref1, ref2, ref3 = philox4x32_reference(SEED, offsets_np)
+
+    np.testing.assert_array_equal(out0.cpu().numpy().view(np.uint32), ref0)
+    np.testing.assert_array_equal(out1.cpu().numpy().view(np.uint32), ref1)
+    np.testing.assert_array_equal(out2.cpu().numpy().view(np.uint32), ref2)
+    np.testing.assert_array_equal(out3.cpu().numpy().view(np.uint32), ref3)
+
+
+@pytest.mark.parametrize("n", [4096])
+def test_rand_distribution(n: int) -> None:
+    """Test that rand produces values in [0, 1) with roughly uniform distribution."""
+    offsets = _arange_uint32(n)
+    out = torch.empty(n, dtype=torch.float32, device="cuda")
+
+    kernel = RandKernel(BLOCK_SIZE, LAYOUT, SEED)
+    kernel(n, offsets, out)
+
+    out_cpu = out.cpu().numpy()
+
+    # All values should be in [0, 1)
+    assert np.all(out_cpu >= 0.0), "rand produced values < 0"
+    assert np.all(out_cpu < 1.0), "rand produced values >= 1"
+
+    # Rough uniformity check: mean should be close to 0.5
+    mean = np.mean(out_cpu)
+    assert 0.3 < mean < 0.7, f"rand mean {mean} is too far from 0.5"
+
+
+@pytest.mark.parametrize("n", [4096])
+def test_randn_distribution(n: int) -> None:
+    """Test that randn produces values with roughly normal distribution."""
+    offsets = _arange_uint32(n)
+    out = torch.empty(n, dtype=torch.float32, device="cuda")
+
+    kernel = RandnKernel(BLOCK_SIZE, LAYOUT, SEED)
+    kernel(n, offsets, out)
+
+    out_cpu = out.cpu().numpy()
+
+    # Mean should be close to 0
+    mean = np.mean(out_cpu)
+    assert -0.5 < mean < 0.5, f"randn mean {mean} is too far from 0"
+
+    # Std should be close to 1
+    std = np.std(out_cpu)
+    assert 0.5 < std < 1.5, f"randn std {std} is too far from 1"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add randint4x, randint, rand, and randn instructions matching Triton's RNG API, backed by the Philox-4x32-10 counter-based PRNG algorithm.

- Philox4x32Inst: IR instruction producing [4, *offset.shape] uint32 output
- Hidet primitives: cuda_umulhi (mul.hi.u32) and cuda_philox4x32 in hidet script
- Emitter: calls philox4x32 primitive with direct buffer pointer indexing
- Layout inference: bidirectional (output = local(4,...) * offset_layout)
- Builder: philox4x32, randint4x, randint, rand (uniform), randn (Box-Muller)
- User API: sin, cos, randint4x, randint, rand, randn on Script