### PR TITLE
[Workflow] Append PR number to gh-pages deploy commit

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -118,5 +118,10 @@ jobs:
           # Commit and push
           git add -A
           git diff --cached --quiet && echo "No changes to deploy" && exit 0
-          git commit -m "Deploy docs: $VERSION_DIR ($(date -u +%Y-%m-%d))"
+          MSG="Deploy docs: $VERSION_DIR ($(date -u +%Y-%m-%d))"
+          PR_NUM=$(git log -1 --pretty=%s "$GITHUB_SHA" | grep -oE '#[0-9]+' | head -n 1 || true)
+          if [[ -n "$PR_NUM" ]]; then
+            MSG="$MSG $PR_NUM"
+          fi
+          git commit -m "$MSG"
           git push origin gh-pages


### PR DESCRIPTION
When the triggering commit's subject contains a #<num> marker (e.g. squash-merged PR commits like "[Docs] ... (#141)"), append it to the gh-pages deploy commit message so the deploy history links back to the source PR.