### PR TITLE
[Refactor] Build Stmt nodes bottom-up; drop Optional body defaults

### DIFF
--- a/python/tilus/backends/emitters/cast.py
+++ b/python/tilus/backends/emitters/cast.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, Tuple
+from typing import Callable, Dict, Tuple
 
 from tilus.backends.emitter import BaseInstEmitter, register_emitter
 from tilus.hidet.ir.dtypes import (
@@ -39,7 +39,7 @@ from tilus.hidet.ir.primitives.cuda.bfloat16 import mul_bf16x2
 from tilus.hidet.ir.primitives.cuda.half import fma_f16x2, mul_f16x2, sub_f16x2
 from tilus.hidet.ir.primitives.cuda.lop3 import lop3
 from tilus.hidet.ir.primitives.cuda.prmt import prmt
-from tilus.hidet.ir.type import BaseType, Callable, DataType, PointerType, TensorPointerType, TensorType
+from tilus.hidet.ir.type import BaseType, DataType, PointerType, TensorPointerType, TensorType
 from tilus.ir.instructions import CastInst
 from tilus.target import amdgpu_any, nvgpu_any
 from tilus.utils import cdiv

--- a/python/tilus/hidet/backend/codegen.py
+++ b/python/tilus/hidet/backend/codegen.py
@@ -39,8 +39,10 @@ from tilus.hidet.ir.expr import (
     convert,
 )
 from tilus.hidet.ir.func import Function
+from tilus.hidet.ir.functors import ExprFunctor, ModuleFunctor, StmtFunctor, TypeFunctor
 from tilus.hidet.ir.module import IRModule
 from tilus.hidet.ir.node import Node
+from tilus.hidet.ir.primitives import is_primitive_function, lookup_primitive_function
 from tilus.hidet.ir.stmt import (
     AsmStmt,
     AssertStmt,
@@ -61,6 +63,7 @@ from tilus.hidet.ir.stmt import (
     WhileStmt,
 )
 from tilus.hidet.ir.target import Target
+from tilus.hidet.ir.tools import TypeInfer
 from tilus.hidet.ir.type import (
     DataType,
     FuncType,
@@ -71,14 +74,6 @@ from tilus.hidet.ir.type import (
     TensorType,
     VoidType,
 )
-
-try:
-    from tilus.hidet.ir.compute import ScalarNode, TensorNode
-except ImportError:
-    TensorNode = ScalarNode = None
-from tilus.hidet.ir.functors import ExprFunctor, ModuleFunctor, StmtFunctor, TypeFunctor
-from tilus.hidet.ir.primitives import is_primitive_function, lookup_primitive_function
-from tilus.hidet.ir.tools import TypeInfer
 from tilus.hidet.ir.utils.call_graph import CallGraph
 from tilus.hidet.utils import prod
 from tilus.hidet.utils.doc import Doc, NewLine, Text, doc_join, doc_strip_parentheses
@@ -499,12 +494,6 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
                     f"functions in current module:\n{list(self.ir_module.functions.keys())}."
                 )
                 raise ValueError(msg)
-            if entry.generic:
-                msg = (
-                    "Please use resolve_generic_primitive_function pass to lower "
-                    "the generic primitive function {}.".format(entry.name)
-                )
-                raise ValueError(msg)
             # system-provided function, do not canonize the func name
             return entry.codegen_name + (Text("(") + doc_join([self(arg) for arg in e.args], Text(", ")) + ")")
         else:
@@ -781,12 +770,6 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
         return doc_join(t.modifiers, " ") + Text((" " if len(t.modifiers) > 0 else "") + f"{t.cpp_name}")
 
     # the following expressions should not remain to codegen
-    def visit_ScalarNode(self, e: ScalarNode):
-        raise ValueError()
-
-    def visit_TensorNode(self, e: TensorNode):
-        raise ValueError()
-
     def visit_PlaceholderExpr(self, e: PlaceholderExpr):
         raise ValueError()
 

--- a/python/tilus/hidet/ir/builders/stmt_builder.py
+++ b/python/tilus/hidet/ir/builders/stmt_builder.py
@@ -12,20 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from typing import Generic, List, Optional, Sequence, TypeVar, Union, cast
+from dataclasses import dataclass
+from typing import Generic, List, Optional, Sequence, Tuple, TypeVar, Union, cast
 
-from tilus.hidet.ir.dtypes import int32
 from tilus.hidet.ir.expr import Expr, Var, convert, var
 from tilus.hidet.ir.stmt import (
     AssertStmt,
@@ -46,87 +35,96 @@ from tilus.hidet.ir.stmt import (
 )
 from tilus.hidet.ir.type import BaseType
 
-ScopedStmt = Union[IfStmt, ForStmt, LetStmt, WhileStmt]
+
+@dataclass
+class _Frame:
+    """An open scope in the builder. Inherit and implement :meth:`build`.
+
+    Subclasses either produce a final Stmt from the accumulated body, or participate
+    in an in-flight if/elif/else ladder handled directly by the StmtBuilder.
+    """
+
+    def build(self, body: Stmt) -> Stmt:
+        raise NotImplementedError
+
+
+@dataclass
+class _ForFrame(_Frame):
+    loop_var: Var
+    extent: Expr
+    attr: ForStmtAttr
+
+    def build(self, body: Stmt) -> ForStmt:
+        return ForStmt(self.loop_var, self.extent, body, attr=self.attr)
+
+
+@dataclass
+class _LetFrame(_Frame):
+    bind_vars: Tuple[Var, ...]
+    bind_values: Tuple[Expr, ...]
+
+    def build(self, body: Stmt) -> LetStmt:
+        return LetStmt(self.bind_vars, self.bind_values, body)
+
+
+@dataclass
+class _WhileFrame(_Frame):
+    cond: Expr
+
+    def build(self, body: Stmt) -> WhileStmt:
+        return WhileStmt(self.cond, body)
+
+
+@dataclass
+class _IfThenFrame(_Frame):
+    cond: Expr
+
+
+@dataclass
+class _ElseIfFrame(_Frame):
+    cond: Expr
+
+
+@dataclass
+class _OtherwiseFrame(_Frame):
+    pass
 
 
 class StmtScope:
-    def __init__(self, sb, stmts: Union[ScopedStmt, Sequence[ScopedStmt]], ret=None):
-        if not isinstance(stmts, Sequence):
-            stmts = [stmts]
+    """Context manager that opens one or more scopes on a :class:`StmtBuilder`."""
 
-        assert all(isinstance(stmt, (IfStmt, ForStmt, LetStmt, WhileStmt)) for stmt in stmts)
-
+    def __init__(self, sb: "StmtBuilder", frames: Sequence[_Frame], ret=None):
         self.sb: StmtBuilder = sb
-        self.stmts: List[ScopedStmt] = list(stmts)
+        self.frames: List[_Frame] = list(frames)
         self.ret = ret
 
     def __enter__(self):
-        for stmt in self.stmts:
-            self.sb.enter_body(stmt)
+        for frame in self.frames:
+            self.sb._enter_scope(frame)
         return self.ret
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        for _ in self.stmts:
-            self.sb.exit_body()
-
-
-class ElseIfScope:
-    def __init__(self, sb, stmt: IfStmt):
-        self.sb: StmtBuilder = sb
-        self.stmt: IfStmt = stmt
-
-    def __enter__(self):
-        if not isinstance(self.sb.scope_stack[-1][-1], IfStmt):
-            raise RuntimeError("else_if() must be called after if_then() or else_if()")
-
-        # put the current one into the scope stack
-        self.sb.scope_stack[-1].append(self.stmt)
-        self.sb.scope_stack.append([])
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # exit the then body of the current if statement
-        self.stmt.then_body = SeqStmt(self.sb.scope_stack.pop())
-        self.sb.scope_stack[-1].pop()
-
-        cur: IfStmt = self.sb.scope_stack[-1][-1]
-        while cur.else_body is not None:
-            if not isinstance(cur.else_body, IfStmt):
-                raise RuntimeError("else_if() must be called after if_then() or else_if()")
-            cur = cur.else_body
-
-        cur.else_body = self.stmt
-
-
-class OtherwiseScope:
-    def __init__(self, sb):
-        self.sb: StmtBuilder = sb
-
-    def __enter__(self):
-        if not isinstance(self.sb.scope_stack[-1][-1], IfStmt):
-            raise RuntimeError("otherwise() must be called after if_then() or else_if()")
-        self.sb.scope_stack.append([])
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        else_body = SeqStmt(self.sb.scope_stack.pop())
-        cur: IfStmt = self.sb.scope_stack[-1][-1]
-        while cur.else_body is not None:
-            if not isinstance(cur.else_body, IfStmt):
-                raise RuntimeError("otherwise() must be called after if_then() or else_if()")
-            cur = cur.else_body
-        cur.else_body = else_body
+        for _ in self.frames:
+            self.sb._exit_scope()
 
 
 class StmtBuilder:
+    """Build statements imperatively, but construct every IR node immutably bottom-up.
+
+    The builder maintains three parallel stacks, one entry per open scope:
+
+    - ``scope_stack[i]`` — completed sibling statements accumulated in scope ``i``.
+    - ``frame_stack[i-1]`` — description of the scope-opening statement (``_Frame``).
+      Has one fewer entry than ``scope_stack`` because the outermost scope has no frame.
+    - ``pending_if_stack[i]`` — in-flight if/elif ladder in scope ``i``. Held as an
+      ``IfStmt`` whose deepest ``else_body`` may still be ``None``; flushed when
+      any non-``else_if``/``otherwise`` stmt arrives or when the enclosing scope ends.
+    """
+
     def __init__(self):
-        # the structure of scope_stack:
-        # [
-        #    [...], # finished statements in outermost scope
-        #    [...], # finished statements in the second outermost scope
-        #    ...
-        #    [...], # finished statements in the innermost scope
-        # ]
-        # when we exit a scope, it will be wrapped into a statement and append to outer scope
-        self.scope_stack = [[]]
+        self.scope_stack: List[List[Stmt]] = [[]]
+        self.frame_stack: List[_Frame] = []
+        self.pending_if_stack: List[Optional[IfStmt]] = [None]
 
     def __iadd__(self, other: Union[Stmt, Expr, Sequence[Stmt]]):
         assert isinstance(other, (Stmt, Expr, list, tuple))
@@ -135,14 +133,13 @@ class StmtBuilder:
 
     @staticmethod
     def _name_index_vars(num_vars: int) -> List[str]:
-        predefined_names = ["i", "j", "k", "p", "q", "r", "s", "u", "v"]
-        if num_vars <= len(predefined_names):
-            iter_names = predefined_names[:num_vars]
-        else:
-            iter_names = [f"i{idx}" for idx in range(num_vars)]
-        return iter_names
+        predefined = ["i", "j", "k", "p", "q", "r", "s", "u", "v"]
+        if num_vars <= len(predefined):
+            return predefined[:num_vars]
+        return [f"i{idx}" for idx in range(num_vars)]
 
-    # singleton statements
+    # ---- singleton statements ----
+
     def declare(self, v: Var, init: Optional[Expr] = None, scope=None):
         self.append(DeclareStmt(v, init, scope=scope))
         return v
@@ -171,60 +168,63 @@ class StmtBuilder:
     def brk(self):
         self.append(BreakStmt())
 
-    # scope statements
+    def ret(self, value: Optional[Expr] = None):
+        self.append(ReturnStmt(value))
+
+    # ---- scope-opening statements ----
+
     def let(self, v: Union[str, Var], value: Union[int, Expr]) -> StmtScope:
         if isinstance(v, str):
             v = var(v)
-        return StmtScope(self, stmts=LetStmt(v, value), ret=v)
+        return StmtScope(self, frames=[_LetFrame((v,), (convert(value),))], ret=v)
 
     def lets(self, bind_vars: Sequence[Union[str, Var]], values: Sequence[Union[int, Expr]]) -> StmtScope:
         assert len(bind_vars) == len(values)
-        bind_vars = [var(v) if isinstance(v, str) else v for v in bind_vars]
-        bind_values = [convert(value) for value in values]
-        return StmtScope(self, stmts=LetStmt(bind_vars, bind_values, body=None), ret=bind_vars)
+        resolved_vars = tuple(var(v) if isinstance(v, str) else v for v in bind_vars)
+        resolved_values = tuple(convert(value) for value in values)
+        return StmtScope(self, frames=[_LetFrame(resolved_vars, resolved_values)], ret=list(resolved_vars))
 
     def for_loop(self, v: Union[str, Var], extent: Union[int, Expr], attr: str = ".") -> StmtScope:
         if isinstance(v, str):
             v = var(v)
-        return StmtScope(self, stmts=ForStmt(v, extent, attr=ForStmtAttr.parse(attr, num_loops=1)[0]), ret=v)
+        parsed_attr = ForStmtAttr.parse(attr, num_loops=1)[0]
+        return StmtScope(self, frames=[_ForFrame(v, convert(extent), parsed_attr)], ret=v)
 
     def if_then(self, cond: Union[bool, Expr]) -> StmtScope:
-        return StmtScope(self, stmts=IfStmt(cond), ret=None)
+        return StmtScope(self, frames=[_IfThenFrame(convert(cond))], ret=None)
 
-    def else_if(self, cond: Union[bool, Expr]) -> ElseIfScope:
-        return ElseIfScope(self, IfStmt(cond))
+    def else_if(self, cond: Union[bool, Expr]) -> StmtScope:
+        return StmtScope(self, frames=[_ElseIfFrame(convert(cond))], ret=None)
 
-    def otherwise(self) -> OtherwiseScope:
-        return OtherwiseScope(self)
+    def otherwise(self) -> StmtScope:
+        return StmtScope(self, frames=[_OtherwiseFrame()], ret=None)
 
     def for_grid(self, shape: Sequence[Union[Expr, int]]) -> StmtScope:
         iter_names = self._name_index_vars(len(shape))
         iter_vars = [var(name) for name in iter_names]
-        # Build nested ForStmt from outermost to innermost
-        stmts = []
-        for iv, extent in zip(iter_vars, shape):
-            stmts.append(ForStmt(iv, extent, attr=ForStmtAttr()))
-        return StmtScope(self, stmts=stmts, ret=iter_vars)
+        frames = [_ForFrame(iv, convert(extent), ForStmtAttr()) for iv, extent in zip(iter_vars, shape)]
+        return StmtScope(self, frames=frames, ret=iter_vars)
 
     def for_range(self, extent: Union[Expr, int], *, attr: Optional[Union[str, ForStmtAttr]] = None) -> StmtScope:
         iter_var = var("i")
         if isinstance(attr, str):
-            attr = ForStmtAttr.parse(attr, num_loops=1)[0]
+            attr_obj = ForStmtAttr.parse(attr, num_loops=1)[0]
+        elif isinstance(attr, ForStmtAttr):
+            attr_obj = attr
         else:
-            attr = ForStmtAttr()
-        return StmtScope(self, stmts=ForStmt(iter_var, extent, attr=attr), ret=iter_var)
+            attr_obj = ForStmtAttr()
+        return StmtScope(self, frames=[_ForFrame(iter_var, convert(extent), attr_obj)], ret=iter_var)
 
     def while_loop(self, cond: Expr) -> StmtScope:
-        return StmtScope(self, stmts=WhileStmt(cond, body=None), ret=None)
+        return StmtScope(self, frames=[_WhileFrame(convert(cond))], ret=None)
 
-    def ret(self, value: Optional[Expr] = None):
-        self.append(ReturnStmt(value))
+    # ---- core ----
 
-    # utils
     def append(self, stmt: Union[Stmt, Expr, Sequence[Stmt], None]) -> None:
         if stmt is None:
             return
         if isinstance(stmt, (Stmt, Expr)):
+            self._flush_pending_if()
             if isinstance(stmt, Expr):
                 stmt = EvaluateStmt(stmt)
             self.scope_stack[-1].append(stmt)
@@ -233,29 +233,52 @@ class StmtBuilder:
             for s in stmt:
                 self.append(s)
 
-    def enter_body(self, stmt: Union[IfStmt, ForStmt, LetStmt, WhileStmt]):
-        self.scope_stack[-1].append(stmt)
-        self.scope_stack.append([])
+    def _flush_pending_if(self) -> None:
+        pending = self.pending_if_stack[-1]
+        if pending is not None:
+            self.scope_stack[-1].append(pending)
+            self.pending_if_stack[-1] = None
 
-    def exit_body(self):
-        body = SeqStmt(self.scope_stack.pop())
-        assert len(self.scope_stack) > 0
-        last_stmt = self.scope_stack[-1][-1]
-        if isinstance(last_stmt, (ForStmt, LetStmt, WhileStmt)):
-            assert last_stmt.body is None
-            last_stmt.body = body
-        elif isinstance(last_stmt, IfStmt):
-            if last_stmt.then_body is None:
-                last_stmt.then_body = body
-            else:
-                assert last_stmt.else_body is None
-                last_stmt.else_body = body
+    def _enter_scope(self, frame: _Frame) -> None:
+        if isinstance(frame, (_ElseIfFrame, _OtherwiseFrame)):
+            if self.pending_if_stack[-1] is None:
+                raise RuntimeError(f"{type(frame).__name__[1:-5]}() must follow if_then() or else_if()")
         else:
-            assert False
+            self._flush_pending_if()
+        self.frame_stack.append(frame)
+        self.scope_stack.append([])
+        self.pending_if_stack.append(None)
 
-    def finish(self):
-        assert len(self.scope_stack) == 1
+    def _exit_scope(self) -> None:
+        self._flush_pending_if()
+        body = SeqStmt(self.scope_stack.pop())
+        self.pending_if_stack.pop()
+        frame = self.frame_stack.pop()
+        if isinstance(frame, _IfThenFrame):
+            self.pending_if_stack[-1] = IfStmt(frame.cond, body, None)
+        elif isinstance(frame, _ElseIfFrame):
+            prev = self.pending_if_stack[-1]
+            assert prev is not None  # enforced at _enter_scope
+            self.pending_if_stack[-1] = _attach_else(prev, IfStmt(frame.cond, body, None))
+        elif isinstance(frame, _OtherwiseFrame):
+            prev = self.pending_if_stack[-1]
+            assert prev is not None  # enforced at _enter_scope
+            self.pending_if_stack[-1] = _attach_else(prev, body)
+        else:
+            self.scope_stack[-1].append(frame.build(body))
+
+    def finish(self) -> SeqStmt:
+        self._flush_pending_if()
+        assert len(self.scope_stack) == 1 and not self.frame_stack, "finish() called with open scopes"
         return SeqStmt(self.scope_stack.pop())
+
+
+def _attach_else(prev_if: IfStmt, new_else: Stmt) -> IfStmt:
+    """Return a new IfStmt tree with ``new_else`` attached to the innermost ``None`` else slot."""
+    if prev_if.else_body is None:
+        return IfStmt(prev_if.cond, prev_if.then_body, new_else)
+    assert isinstance(prev_if.else_body, IfStmt), "otherwise() must be the last entry in an if-chain"
+    return IfStmt(prev_if.cond, prev_if.then_body, _attach_else(prev_if.else_body, new_else))
 
 
 T = TypeVar("T")

--- a/python/tilus/hidet/ir/functors/type_functor.py
+++ b/python/tilus/hidet/ir/functors/type_functor.py
@@ -147,15 +147,12 @@ class TypeRewriter(TypeFunctor, BaseRewriter):
         return t
 
     def visit_FuncType(self, t: FuncType):
-        if t.type_infer_func is not None:
+        ret_type = self.visit(t.ret_type)
+        param_types = [self.visit(param_type) for param_type in t.param_types]
+        if ret_type == t.ret_type and same_list(param_types, t.param_types):
             return t
         else:
-            ret_type = self.visit(t.ret_type)
-            param_types = [self.visit(param_type) for param_type in t.param_types]
-            if ret_type == t.ret_type and same_list(param_types, t.param_types):
-                return t
-            else:
-                return FuncType(param_types, ret_type)
+            return FuncType(param_types, ret_type)
 
     def visit_OpaqueType(self, t: OpaqueType):
         return t

--- a/python/tilus/hidet/ir/primitives/cuda/math/__init__.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/__init__.py
@@ -23,4 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from . import bfloat16, complex64, complex128, float8e4m3, float8e5m2, float16, float32, float64, int32, int64
+# ruff: noqa: I001
+# Import order matters: dtype math sets that delegate to float32 must be imported after float32.
+from . import complex64, complex128, float32, float64, int32, int64
+from . import bfloat16, float8e4m3, float8e5m2, float16

--- a/python/tilus/hidet/ir/primitives/cuda/math/bfloat16.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/bfloat16.py
@@ -52,7 +52,7 @@ class CUDABFloat16MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_bf16_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["bfloat16"] * num_args, ret_type="bfloat16"),
+                func_or_type=FuncType(param_types=[bfloat16] * num_args, ret_type=bfloat16),
             )
 
     def call(self, name: str, *args) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/math/complex128.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/complex128.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import complex128, float64
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -41,8 +42,8 @@ class CUDAComplex128MathFunctionSet(MathFunctionSet):
                     name="cuda_c128_{}".format(name),
                     codegen_name=codegen_name,
                     func_or_type=FuncType(
-                        param_types=["complex128"] * num_args,
-                        ret_type="complex128" if name not in ["abs"] else "float64",
+                        param_types=[complex128] * num_args,
+                        ret_type=complex128 if name not in ["abs"] else float64,
                     ),
                 )
 

--- a/python/tilus/hidet/ir/primitives/cuda/math/complex64.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/complex64.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import complex64, float32
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -41,7 +42,7 @@ class CUDAComplex64MathFunctionSet(MathFunctionSet):
                     name="cuda_c64_{}".format(name),
                     codegen_name=codegen_name,
                     func_or_type=FuncType(
-                        param_types=["complex64"] * num_args, ret_type="complex64" if name not in ["abs"] else "float32"
+                        param_types=[complex64] * num_args, ret_type=complex64 if name not in ["abs"] else float32
                     ),
                 )
 

--- a/python/tilus/hidet/ir/primitives/cuda/math/float16.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/float16.py
@@ -96,7 +96,7 @@ class CUDAFloat16MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_f16_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["float16"] * num_args, ret_type="float16"),
+                func_or_type=FuncType(param_types=[float16] * num_args, ret_type=float16),
             )
 
         self.register_via_delegate("min", float16, float32, min, 2)

--- a/python/tilus/hidet/ir/primitives/cuda/math/float32.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/float32.py
@@ -23,7 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tilus.hidet.ir.dtypes import float32, float32x2, float32x4
+from tilus.hidet.ir.dtypes import boolean, float32, float32x2, float32x4
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -75,8 +75,8 @@ class CUDAFloat32MathFunctionSet(MathFunctionSet):
                     name="cuda_f32_{}".format(name),
                     codegen_name=codegen_name,
                     func_or_type=FuncType(
-                        param_types=["float32"] * num_args,
-                        ret_type="float32" if name not in ["isfinite", "isinf", "isnan"] else "bool",
+                        param_types=[float32] * num_args,
+                        ret_type=float32 if name not in ["isfinite", "isinf", "isnan"] else boolean,
                     ),
                 )
         register_primitive_function(

--- a/python/tilus/hidet/ir/primitives/cuda/math/float64.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/float64.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import boolean, float64
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -73,8 +74,8 @@ class CUDAFloat64MathFunctionSet(MathFunctionSet):
                     name="cuda_f64_{}".format(name),
                     codegen_name=codegen_name,
                     func_or_type=FuncType(
-                        param_types=["float64"] * num_args,
-                        ret_type="float64" if name not in ["isfinite", "isinf", "isnan"] else "bool",
+                        param_types=[float64] * num_args,
+                        ret_type=float64 if name not in ["isfinite", "isinf", "isnan"] else boolean,
                     ),
                 )
 

--- a/python/tilus/hidet/ir/primitives/cuda/math/float8e4m3.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/float8e4m3.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import float8_e4m3
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -61,7 +62,7 @@ class CUDAFloat8e4m3MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_float8e4m3_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["float8_e4m3"] * num_args, ret_type="float8_e4m3"),
+                func_or_type=FuncType(param_types=[float8_e4m3] * num_args, ret_type=float8_e4m3),
             )
 
     def call(self, name: str, *args) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/math/float8e5m2.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/float8e5m2.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import float8_e5m2
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -61,7 +62,7 @@ class CUDAFloat8e5m2MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_float8e5m2_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["float8_e5m2"] * num_args, ret_type="float8_e5m2"),
+                func_or_type=FuncType(param_types=[float8_e5m2] * num_args, ret_type=float8_e5m2),
             )
 
     def call(self, name: str, *args) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/math/int32.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/int32.py
@@ -23,6 +23,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from tilus.hidet.ir.dtypes import int32
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -38,7 +39,7 @@ class CUDAInt32MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_i32_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["int32"] * num_args, ret_type="int32"),
+                func_or_type=FuncType(param_types=[int32] * num_args, ret_type=int32),
             )
 
     def call(self, name: str, *args) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/math/int64.py
+++ b/python/tilus/hidet/ir/primitives/cuda/math/int64.py
@@ -25,6 +25,7 @@
 # limitations under the License.
 from typing import Optional
 
+from tilus.hidet.ir.dtypes import int64
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import primitive_func_pool, register_primitive_function
 from tilus.hidet.ir.primitives.math import MathFunctionSet, register_math_function_set
@@ -40,7 +41,7 @@ class CUDAInt64MathFunctionSet(MathFunctionSet):
             register_primitive_function(
                 name="cuda_i64_{}".format(name),
                 codegen_name=codegen_name,
-                func_or_type=FuncType(param_types=["int64"] * num_args, ret_type="int64"),
+                func_or_type=FuncType(param_types=[int64] * num_args, ret_type=int64),
             )
 
     def call(self, name: str, *args) -> Expr:

--- a/python/tilus/hidet/ir/primitives/cuda/shfl.py
+++ b/python/tilus/hidet/ir/primitives/cuda/shfl.py
@@ -12,54 +12,59 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+from tilus.hidet.ir.dtypes import bfloat16, float16, float32, float64, int32, int64, uint32, uint64
+from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
-from tilus.hidet.ir.type import FuncType
+from tilus.hidet.ir.tools import infer_type
+from tilus.hidet.ir.type import DataType, FuncType
 from tilus.hidet.utils import initialize
 
+# dtypes supported by the shfl intrinsics (signature: T __shfl*_sync(unsigned, T, int, int=warpSize))
+_shfl_dtypes = [int32, uint32, int64, uint64, float16, bfloat16, float32, float64]
 
-def type_infer(arg_types):
-    return arg_types[1]
+
+_shfl_bases = {
+    "shfl_sync": "__shfl_sync",
+    "shfl_up_sync": "__shfl_up_sync",
+    "shfl_down_sync": "__shfl_down_sync",
+    "shfl_xor_sync": "__shfl_xor_sync",
+}
 
 
 @initialize()
 def register_primitive_functions():
-    functions = [
-        ("cuda_activemask", "__activemask", FuncType([], "int32")),
-        # T __shfl_sync(unsigned mask, T var, int srcLane, int width=warpSize)
-        ("cuda_shfl_sync", "__shfl_sync", FuncType(type_infer_func=type_infer)),
-        ("cuda_shfl_up_sync", "__shfl_up_sync", FuncType(type_infer_func=type_infer)),
-        ("cuda_shfl_down_sync", "__shfl_down_sync", FuncType(type_infer_func=type_infer)),
-        ("cuda_shfl_xor_sync", "__shfl_xor_sync", FuncType(type_infer_func=type_infer)),
-    ]
-    for name, codegen_name, func_type in functions:
-        register_primitive_function(name=name, func_or_type=func_type, codegen_name=codegen_name)
+    register_primitive_function(name="cuda_activemask", func_or_type=FuncType([], int32), codegen_name="__activemask")
+    for base, codegen_name in _shfl_bases.items():
+        for dtype in _shfl_dtypes:
+            # T __shfl*_sync(unsigned mask, T var, int srcLane_or_delta_or_laneMask, int width=warpSize)
+            func_type = FuncType(param_types=[uint32, dtype, int32, int32], ret_type=dtype)
+            register_primitive_function(
+                name=f"cuda_{base}_{dtype.name}", codegen_name=codegen_name, func_or_type=func_type
+            )
+
+
+def _shfl_dispatch(base: str, mask: Expr, var: Expr, lane_arg: Expr, width: Expr) -> Expr:
+    var_type = infer_type(var)
+    if not isinstance(var_type, DataType):
+        raise TypeError(f"{base} expects a scalar data-typed value, got {var_type}")
+    name = f"cuda_{base}_{var_type.name}"
+    return call_primitive_func(name, [mask, var, lane_arg, width])
 
 
 def shfl_sync(mask, var, src_lane, width=32):
-    return call_primitive_func("cuda_shfl_sync", [mask, var, src_lane, width])
+    return _shfl_dispatch("shfl_sync", mask, var, src_lane, width)
 
 
 def shfl_up_sync(mask, var, delta, width=32):
-    return call_primitive_func("cuda_shfl_up_sync", [mask, var, delta, width])
+    return _shfl_dispatch("shfl_up_sync", mask, var, delta, width)
 
 
 def shfl_down_sync(mask, var, delta, width=32):
-    return call_primitive_func("cuda_shfl_down_sync", [mask, var, delta, width])
+    return _shfl_dispatch("shfl_down_sync", mask, var, delta, width)
 
 
 def shfl_xor_sync(mask, var, lane_mask, width=32):
-    return call_primitive_func("cuda_shfl_xor_sync", [mask, var, lane_mask, width])
+    return _shfl_dispatch("shfl_xor_sync", mask, var, lane_mask, width)
 
 
 def active_mask():

--- a/python/tilus/hidet/ir/primitives/cuda/shfl.py
+++ b/python/tilus/hidet/ir/primitives/cuda/shfl.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tilus.hidet.ir.dtypes import bfloat16, float16, float32, float64, int32, int64, uint32, uint64
+from tilus.hidet.ir.dtypes import bfloat16, boolean, float16, float32, float64, int32, int64, uint32, uint64
 from tilus.hidet.ir.expr import Expr
 from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
 from tilus.hidet.ir.tools import infer_type
@@ -20,7 +20,8 @@ from tilus.hidet.ir.type import DataType, FuncType
 from tilus.hidet.utils import initialize
 
 # dtypes supported by the shfl intrinsics (signature: T __shfl*_sync(unsigned, T, int, int=warpSize))
-_shfl_dtypes = [int32, uint32, int64, uint64, float16, bfloat16, float32, float64]
+# bool is included because the reduce emitter shuffles boolean any/all values; CUDA promotes bool to int.
+_shfl_dtypes = [boolean, int32, uint32, int64, uint64, float16, bfloat16, float32, float64]
 
 
 _shfl_bases = {

--- a/python/tilus/hidet/ir/primitives/cuda/sync.py
+++ b/python/tilus/hidet/ir/primitives/cuda/sync.py
@@ -25,6 +25,7 @@
 # limitations under the License.
 from typing import Union
 
+from tilus.hidet.ir.dtypes import int32
 from tilus.hidet.ir.expr import Call, Expr
 from tilus.hidet.ir.func import Function
 from tilus.hidet.ir.primitives.func import call_primitive_func, is_primitive_function, register_primitive_function
@@ -36,12 +37,13 @@ from tilus.hidet.utils import initialize
 
 @initialize()
 def register_primitive_functions():
+    void_t = VoidType()
     functions = [
-        ("cuda_syncthreads", "__syncthreads", FuncType([], VoidType())),
-        ("cuda_syncthreads_count", "__syncthreads_count", FuncType(["int32"], "int32")),
-        ("cuda_syncthreads_and", "__syncthreads_and", FuncType(["int32"], "int32")),
-        ("cuda_syncthreads_or", "__syncthreads_or", FuncType(["int32"], "int32")),
-        ("cuda_syncwarp", "__syncwarp", FuncType([], VoidType())),
+        ("cuda_syncthreads", "__syncthreads", FuncType([], void_t)),
+        ("cuda_syncthreads_count", "__syncthreads_count", FuncType([int32], int32)),
+        ("cuda_syncthreads_and", "__syncthreads_and", FuncType([int32], int32)),
+        ("cuda_syncthreads_or", "__syncthreads_or", FuncType([int32], int32)),
+        ("cuda_syncwarp", "__syncwarp", FuncType([], void_t)),
     ]
     for name, codegen_name, func_type in functions:
         register_primitive_function(name=name, func_or_type=func_type, codegen_name=codegen_name)

--- a/python/tilus/hidet/ir/primitives/cuda/time.py
+++ b/python/tilus/hidet/ir/primitives/cuda/time.py
@@ -25,9 +25,10 @@
 # limitations under the License.
 from typing import Union
 
+from tilus.hidet.ir.dtypes import uint32
 from tilus.hidet.ir.expr import Expr, convert
 from tilus.hidet.ir.primitives.func import call_primitive_func, register_primitive_function
-from tilus.hidet.ir.type import FuncType, VoidType, data_type
+from tilus.hidet.ir.type import FuncType, VoidType
 from tilus.hidet.utils import initialize
 
 
@@ -44,7 +45,7 @@ def register_functions():
     # assert isinstance(cuda_nano_sleep, Function)
     # register_primitive_function(cuda_nano_sleep.name, cuda_nano_sleep)
     register_primitive_function(
-        name="cuda_nano_sleep", func_or_type=FuncType([data_type("uint32")], VoidType()), codegen_name="__nanosleep"
+        name="cuda_nano_sleep", func_or_type=FuncType([uint32], VoidType()), codegen_name="__nanosleep"
     )
 
 

--- a/python/tilus/hidet/ir/primitives/func.py
+++ b/python/tilus/hidet/ir/primitives/func.py
@@ -37,21 +37,19 @@ class PrimitiveFunctionRegistry:
         codegen_name: str,
         func_type: FuncType,
         function: Optional[Function] = None,
-        generic: bool = False,
     ):
         self.var = Var(name=name, type=func_type)
         self.name: str = name
         self.codegen_name: str = codegen_name
         self.func_type: FuncType = func_type
         self.function: Optional[Function] = function
-        self.generic: bool = generic
 
 
 class PrimitiveFunctionPool:
     def __init__(self):
         self.name2func: Dict[str, PrimitiveFunctionRegistry] = {}
 
-    def register(self, name: str, func_or_type: Union[Function, FuncType], codegen_name: Optional[str], generic: bool):
+    def register(self, name: str, func_or_type: Union[Function, FuncType], codegen_name: Optional[str]):
         if isinstance(func_or_type, Function):
             if func_or_type.name != name:
                 raise ValueError("The function name must be consistent, got {} and {}.".format(name, func_or_type.name))
@@ -64,13 +62,12 @@ class PrimitiveFunctionPool:
                 codegen_name=codegen_name,
                 func_type=FuncType.from_func(func_or_type),
                 function=func_or_type,
-                generic=generic,
             )
         elif isinstance(func_or_type, FuncType):
             if codegen_name is None:
                 codegen_name = name
             registry = PrimitiveFunctionRegistry(
-                name=name, codegen_name=codegen_name, func_type=func_or_type, function=None, generic=generic
+                name=name, codegen_name=codegen_name, func_type=func_or_type, function=None
             )
         else:
             raise TypeError(
@@ -124,7 +121,7 @@ def registered_primitive_functions() -> List[str]:
 
 
 def register_primitive_function(
-    name: str, func_or_type: Union[Function, FuncType], codegen_name: Optional[str] = None, generic=False
+    name: str, func_or_type: Union[Function, FuncType], codegen_name: Optional[str] = None
 ) -> PrimitiveFunctionRegistry:
     """
     Register a primitive function.
@@ -141,24 +138,19 @@ def register_primitive_function(
     codegen_name: Optional[str]
         The name used in code generation. When None is given, the 'name' parameter will be used.
 
-    generic: bool
-        Whether this function is a generic function. A generic function will be lowered to a concrete primitive
-        function according to the calling arguments' type.
-
     Returns
     -------
     ret: PrimitiveFunctionRegistry
         The entry of registered primitive function.
     """
-    return primitive_func_pool.register(name, func_or_type, codegen_name, generic)
+    return primitive_func_pool.register(name, func_or_type, codegen_name)
 
 
 def call_primitive_func(func_name, args: List[Expr]) -> Call:
     entry = primitive_func_pool.lookup_by_name(func_name)
-    if entry.func_type.param_types is not None:
-        if len(entry.func_type.param_types) != len(args):
-            raise ValueError(
-                "The number of arguments does not match the number of parameters of function {}, "
-                "got {} and expect {}.".format(func_name, len(args), len(entry.func_type.param_types))
-            )
+    if len(entry.func_type.param_types) != len(args):
+        raise ValueError(
+            "The number of arguments does not match the number of parameters of function {}, "
+            "got {} and expect {}.".format(func_name, len(args), len(entry.func_type.param_types))
+        )
     return call(entry.var, args)

--- a/python/tilus/hidet/ir/primitives/math.py
+++ b/python/tilus/hidet/ir/primitives/math.py
@@ -12,23 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from tilus.hidet.ir.expr import Expr
-from tilus.hidet.ir.primitives.func import lookup_primitive_function, register_primitive_function
-from tilus.hidet.ir.type import DataType, FuncType, data_type
-from tilus.hidet.ir.utils.type_utils import numeric_promotion
+from tilus.hidet.ir.tools import infer_type
+from tilus.hidet.ir.type import DataType
+from tilus.hidet.ir.utils.type_utils import numeric_promotion_for_all
 
 
 class MathFunctionSet:
@@ -201,340 +190,202 @@ def register_math_function_set(device: str, dtype: str, math_function_set: MathF
     registered_math_function_sets[(device, dtype)] = math_function_set
 
 
-def type_infer_func(arg_types: List[DataType]) -> DataType:
-    dtype = arg_types[0]
-    for arg_type in arg_types[1:]:
-        dtype = numeric_promotion(dtype, arg_type)
-    return dtype
+def _arg_dtype(a: Expr) -> DataType:
+    t = infer_type(a)
+    if not isinstance(t, DataType):
+        raise TypeError(f"math function expects a scalar data-typed argument, got {t}")
+    return t
 
 
-def tif_make_vector(arg_types: List[DataType]) -> DataType:
-    from tilus.hidet.ir.dtypes import vectorize
-
-    if len(arg_types) == 0:
-        raise ValueError("At least one argument is required")
-    if not all(arg_types[0] == arg_type for arg_type in arg_types[1:]):
-        raise ValueError("All arguments must have the same type")
-    return vectorize(arg_types[0], len(arg_types))
-
-
-class MathFunctionSetGeneric(MathFunctionSet):
-    @staticmethod
-    def register():
-        unary_names = [
-            "sin",
-            "cos",
-            "tan",
-            "sinh",
-            "cosh",
-            "tanh",
-            "asin",
-            "acos",
-            "atan",
-            "asinh",
-            "acosh",
-            "atanh",
-            "exp",
-            "exp2",
-            "expm1",
-            "erf",
-            "sqrt",
-            "rsqrt",
-            "log",
-            "log2",
-            "log10",
-            "log1p",
-            "round",
-            "abs",
-            "ceil",
-            "floor",
-            "trunc",
-            "isfinite",
-            "isinf",
-            "isnan",
-            "make_vector",
-        ]
-        binary_names = ["min", "max", "pow", "mod", "atan2"]
-        ternary_names = ["fma"]
-        for name in unary_names + binary_names + ternary_names:
-            if name in ["isfinite", "isinf", "isnan"]:
-                func_type = FuncType(type_infer_func=lambda _: data_type("bool"))
-            elif name == "make_vector":
-                func_type = FuncType(type_infer_func=tif_make_vector)
-            else:
-                func_type = FuncType(type_infer_func=type_infer_func)
-            register_primitive_function(name=f"generic_{name}", codegen_name=None, func_or_type=func_type, generic=True)
-
-    @staticmethod
-    def call(name, *args) -> Expr:
-        entry = lookup_primitive_function(f"generic_{name}")
-        return entry.var(*args)
-
-    # unary names
-
-    def sin(self, a: Expr) -> Expr:
-        return self.call("sin", a)
-
-    def cos(self, a: Expr) -> Expr:
-        return self.call("cos", a)
-
-    def tan(self, a: Expr) -> Expr:
-        return self.call("tan", a)
-
-    def sinh(self, a: Expr) -> Expr:
-        return self.call("sinh", a)
-
-    def cosh(self, a: Expr) -> Expr:
-        return self.call("cosh", a)
-
-    def tanh(self, a: Expr) -> Expr:
-        return self.call("tanh", a)
-
-    def asin(self, a: Expr) -> Expr:
-        return self.call("asin", a)
-
-    def acos(self, a: Expr) -> Expr:
-        return self.call("acos", a)
-
-    def atan(self, a: Expr) -> Expr:
-        return self.call("atan", a)
-
-    def asinh(self, a: Expr) -> Expr:
-        return self.call("asinh", a)
-
-    def acosh(self, a: Expr) -> Expr:
-        return self.call("acosh", a)
-
-    def atanh(self, a: Expr) -> Expr:
-        return self.call("atanh", a)
-
-    def exp(self, a: Expr) -> Expr:
-        return self.call("exp", a)
-
-    def exp2(self, a: Expr) -> Expr:
-        return self.call("exp2", a)
-
-    def expm1(self, a: Expr) -> Expr:
-        return self.call("expm1", a)
-
-    def erf(self, a: Expr) -> Expr:
-        return self.call("erf", a)
-
-    def sqrt(self, a: Expr) -> Expr:
-        return self.call("sqrt", a)
-
-    def rsqrt(self, a: Expr) -> Expr:
-        return self.call("rsqrt", a)
-
-    def log(self, a: Expr) -> Expr:
-        return self.call("log", a)
-
-    def log2(self, a: Expr) -> Expr:
-        return self.call("log2", a)
-
-    def log10(self, a: Expr) -> Expr:
-        return self.call("log10", a)
-
-    def log1p(self, a: Expr) -> Expr:
-        return self.call("log1p", a)
-
-    def round(self, a: Expr) -> Expr:
-        return self.call("round", a)
-
-    def abs(self, a: Expr) -> Expr:
-        return self.call("abs", a)
-
-    def ceil(self, a: Expr) -> Expr:
-        return self.call("ceil", a)
-
-    def floor(self, a: Expr) -> Expr:
-        return self.call("floor", a)
-
-    def trunc(self, a: Expr) -> Expr:
-        return self.call("trunc", a)
-
-    def isfinite(self, a: Expr) -> Expr:
-        return self.call("isfinite", a)
-
-    def isinf(self, a: Expr) -> Expr:
-        return self.call("isinf", a)
-
-    def isnan(self, a: Expr) -> Expr:
-        return self.call("isnan", a)
-
-    # binary names
-
-    def atan2(self, a: Expr, b: Expr) -> Expr:
-        return self.call("atan2", a, b)
-
-    def min(self, a: Expr, b: Expr) -> Expr:
-        return self.call("min", a, b)
-
-    def max(self, a: Expr, b: Expr) -> Expr:
-        return self.call("max", a, b)
-
-    def mod(self, a: Expr, b: Expr) -> Expr:
-        return self.call("mod", a, b)
-
-    def pow(self, a: Expr, b: Expr) -> Expr:
-        return self.call("pow", a, b)
-
-    # ternary names
-
-    def fma(self, a: Expr, b: Expr, c: Expr) -> Expr:
-        return self.call("fma", a, b, c)
-
-    def make_vector(self, *args) -> Expr:
-        return self.call("make_vector", *args)
+def _lookup_set(dtype: DataType) -> MathFunctionSet:
+    key = ("cuda", dtype.name)
+    if key not in registered_math_function_sets:
+        raise NotImplementedError(
+            "No math function set registered for device 'cuda' and dtype '{}'. Registered: {}".format(
+                dtype.name, list(registered_math_function_sets.keys())
+            )
+        )
+    return registered_math_function_sets[key]
 
 
-generic_math_function_set = MathFunctionSetGeneric()
-generic_math_function_set.register()
+def _promote(*args: Expr) -> Tuple[DataType, Tuple[Expr, ...]]:
+    from tilus.hidet.ir.expr import cast
+
+    dtypes = tuple(_arg_dtype(a) for a in args)
+    target = numeric_promotion_for_all(*dtypes)
+    casted = tuple(a if d.name == target.name else cast(a, target) for a, d in zip(args, dtypes))
+    return target, casted
+
+
+def _unary(method_name: str, a: Expr) -> Expr:
+    target, (a_c,) = _promote(a)
+    return getattr(_lookup_set(target), method_name)(a_c)
+
+
+def _binary(method_name: str, a: Expr, b: Expr) -> Expr:
+    target, (a_c, b_c) = _promote(a, b)
+    return getattr(_lookup_set(target), method_name)(a_c, b_c)
+
+
+def _ternary(method_name: str, a: Expr, b: Expr, c: Expr) -> Expr:
+    target, (a_c, b_c, c_c) = _promote(a, b, c)
+    return getattr(_lookup_set(target), method_name)(a_c, b_c, c_c)
+
+
+def _predicate(method_name: str, a: Expr) -> Expr:
+    # isfinite/isinf/isnan: arg dtype preserved, return type is bool
+    dtype = _arg_dtype(a)
+    return getattr(_lookup_set(dtype), method_name)(a)
 
 
 def sin(a: Expr) -> Expr:
-    return generic_math_function_set.sin(a)
+    return _unary("sin", a)
 
 
 def cos(a: Expr) -> Expr:
-    return generic_math_function_set.cos(a)
+    return _unary("cos", a)
 
 
 def tan(a: Expr) -> Expr:
-    return generic_math_function_set.tan(a)
+    return _unary("tan", a)
 
 
 def sinh(a: Expr) -> Expr:
-    return generic_math_function_set.sinh(a)
+    return _unary("sinh", a)
 
 
 def cosh(a: Expr) -> Expr:
-    return generic_math_function_set.cosh(a)
+    return _unary("cosh", a)
 
 
 def tanh(a: Expr) -> Expr:
-    return generic_math_function_set.tanh(a)
+    return _unary("tanh", a)
 
 
 def asin(a: Expr) -> Expr:
-    return generic_math_function_set.asin(a)
+    return _unary("asin", a)
 
 
 def acos(a: Expr) -> Expr:
-    return generic_math_function_set.acos(a)
+    return _unary("acos", a)
 
 
 def atan(a: Expr) -> Expr:
-    return generic_math_function_set.atan(a)
+    return _unary("atan", a)
 
 
 def atan2(a: Expr, b: Expr) -> Expr:
-    return generic_math_function_set.atan2(a, b)
+    return _binary("atan2", a, b)
 
 
 def asinh(a: Expr) -> Expr:
-    return generic_math_function_set.asinh(a)
+    return _unary("asinh", a)
 
 
 def acosh(a: Expr) -> Expr:
-    return generic_math_function_set.acosh(a)
+    return _unary("acosh", a)
 
 
 def atanh(a: Expr) -> Expr:
-    return generic_math_function_set.atanh(a)
+    return _unary("atanh", a)
 
 
 def exp(a: Expr) -> Expr:
-    return generic_math_function_set.exp(a)
+    return _unary("exp", a)
 
 
 def exp2(a: Expr) -> Expr:
-    return generic_math_function_set.exp2(a)
+    return _unary("exp2", a)
 
 
 def expm1(a: Expr) -> Expr:
-    return generic_math_function_set.expm1(a)
+    return _unary("expm1", a)
 
 
 def erf(a: Expr) -> Expr:
-    return generic_math_function_set.erf(a)
+    return _unary("erf", a)
 
 
 def sqrt(a: Expr) -> Expr:
-    return generic_math_function_set.sqrt(a)
+    return _unary("sqrt", a)
 
 
 def rsqrt(a: Expr) -> Expr:
-    return generic_math_function_set.rsqrt(a)
+    return _unary("rsqrt", a)
 
 
 def log(a: Expr) -> Expr:
-    return generic_math_function_set.log(a)
+    return _unary("log", a)
 
 
 def log2(a: Expr) -> Expr:
-    return generic_math_function_set.log2(a)
+    return _unary("log2", a)
 
 
 def log10(a: Expr) -> Expr:
-    return generic_math_function_set.log10(a)
+    return _unary("log10", a)
 
 
 def log1p(a: Expr) -> Expr:
-    return generic_math_function_set.log1p(a)
+    return _unary("log1p", a)
 
 
 def round(a: Expr) -> Expr:
-    return generic_math_function_set.round(a)
+    return _unary("round", a)
 
 
 def abs(a: Expr) -> Expr:
-    return generic_math_function_set.abs(a)
+    return _unary("abs", a)
 
 
 def ceil(a: Expr) -> Expr:
-    return generic_math_function_set.ceil(a)
+    return _unary("ceil", a)
 
 
 def floor(a: Expr) -> Expr:
-    return generic_math_function_set.floor(a)
+    return _unary("floor", a)
 
 
 def trunc(a: Expr) -> Expr:
-    return generic_math_function_set.trunc(a)
+    return _unary("trunc", a)
 
 
 def min(a: Expr, b: Expr) -> Expr:
-    return generic_math_function_set.min(a, b)
+    return _binary("min", a, b)
 
 
 def max(a: Expr, b: Expr) -> Expr:
-    return generic_math_function_set.max(a, b)
+    return _binary("max", a, b)
 
 
 def mod(a: Expr, b: Expr) -> Expr:
-    return generic_math_function_set.mod(a, b)
+    return _binary("mod", a, b)
 
 
 def pow(a: Expr, b: Expr) -> Expr:
-    return generic_math_function_set.pow(a, b)
+    return _binary("pow", a, b)
 
 
 def fma(a: Expr, b: Expr, c: Expr) -> Expr:
-    return generic_math_function_set.fma(a, b, c)
+    return _ternary("fma", a, b, c)
 
 
 def isfinite(a: Expr) -> Expr:
-    return generic_math_function_set.isfinite(a)
+    return _predicate("isfinite", a)
 
 
 def isinf(a: Expr) -> Expr:
-    return generic_math_function_set.isinf(a)
+    return _predicate("isinf", a)
 
 
 def isnan(a: Expr) -> Expr:
-    return generic_math_function_set.isnan(a)
+    return _predicate("isnan", a)
 
 
-def make_vector(*args) -> Expr:
-    return generic_math_function_set.make_vector(*args)
+def make_vector(*args: Expr) -> Expr:
+    if len(args) == 0:
+        raise ValueError("make_vector requires at least one argument")
+    dtypes = [_arg_dtype(a) for a in args]
+    if not all(d.name == dtypes[0].name for d in dtypes[1:]):
+        raise ValueError("make_vector requires all arguments to have the same dtype, got {}".format(dtypes))
+    return _lookup_set(dtypes[0]).make_vector(*args)

--- a/python/tilus/hidet/ir/stmt.py
+++ b/python/tilus/hidet/ir/stmt.py
@@ -245,34 +245,36 @@ class ReturnStmt(Stmt):
 
 
 class LetStmt(Stmt):
-    def __init__(self, bind_vars, bind_values, body=None):
+    def __init__(self, bind_vars, bind_values, body: Stmt):
         if not isinstance(bind_vars, (list, tuple)):
-            bind_vars = [bind_vars]
+            bind_vars = (bind_vars,)
         if not isinstance(bind_values, (list, tuple)):
-            bind_values = [bind_values]
+            bind_values = (bind_values,)
         assert len(bind_vars) == len(bind_values)
         assert len(bind_vars) > 0
-        bind_values = [convert(bind_value) for bind_value in bind_values]
-        self.bind_vars: List[Var] = bind_vars
-        self.bind_values: List[Expr] = bind_values
-        self.body: Optional[Stmt] = body
+        assert body is not None
+        self.bind_vars: Tuple[Var, ...] = tuple(bind_vars)
+        self.bind_values: Tuple[Expr, ...] = tuple(convert(v) for v in bind_values)
+        self.body: Stmt = body
 
 
 class ForStmt(Stmt):
     DEFAULT_UNROLL_LIMIT = 32
 
-    def __init__(self, loop_var, extent, body=None, *, attr: Optional[ForStmtAttr] = None):
+    def __init__(self, loop_var, extent, body: Stmt, *, attr: Optional[ForStmtAttr] = None):
         from tilus.hidet.ir.tools import simplify  # pylint: disable=import-outside-toplevel
 
         super().__init__()
+        assert body is not None
         self.loop_var: Var = loop_var
         self.extent: Expr = simplify(convert(extent))
-        self.body: Optional[Stmt] = body
+        self.body: Stmt = body
         self.attr: ForStmtAttr = attr if attr else ForStmtAttr.from_extent(extent)
 
 
 class WhileStmt(Stmt):
     def __init__(self, cond: Expr, body: Stmt):
+        assert body is not None
         self.cond: Expr = cond
         self.body: Stmt = body
 
@@ -286,10 +288,11 @@ class ContinueStmt(Stmt):
 
 
 class IfStmt(Stmt):
-    def __init__(self, cond: Expr, then_body=None, else_body=None):
+    def __init__(self, cond: Expr, then_body: Stmt, else_body: Optional[Stmt] = None):
         super().__init__()
+        assert then_body is not None
         self.cond: Expr = convert(cond)
-        self.then_body: Optional[Stmt] = then_body
+        self.then_body: Stmt = then_body
         self.else_body: Optional[Stmt] = else_body
 
 
@@ -309,13 +312,13 @@ class AsmStmt(Stmt):
         is_volatile=False,
         memory_fence=False,
     ):
-        self.template_string = template_string
-        self.output_labels = [pr[0] for pr in outputs]
-        self.output_exprs = [pr[1] for pr in outputs]
-        self.input_labels = [pr[0] for pr in inputs]
-        self.input_exprs = [pr[1] for pr in inputs]
-        self.is_volatile = is_volatile
-        self.memory_fence = memory_fence
+        self.template_string: str = template_string
+        self.output_labels: Tuple[str, ...] = tuple(pr[0] for pr in outputs)
+        self.output_exprs: Tuple[Expr, ...] = tuple(pr[1] for pr in outputs)
+        self.input_labels: Tuple[str, ...] = tuple(pr[0] for pr in inputs)
+        self.input_exprs: Tuple[Expr, ...] = tuple(pr[1] for pr in inputs)
+        self.is_volatile: bool = is_volatile
+        self.memory_fence: bool = memory_fence
 
 
 class BlackBoxStmt(Stmt):

--- a/python/tilus/hidet/ir/tools/printer.py
+++ b/python/tilus/hidet/ir/tools/printer.py
@@ -556,10 +556,7 @@ class IRPrinter(IRFunctor):
         return Text("VoidType")
 
     def visit_FuncType(self, t: FuncType):
-        if t.type_infer_func is not None:
-            return Text("FuncType[type_infer_func]")
-        else:
-            return Text("FuncType(params={}, ret={})".format(self(t.param_types), self(t.ret_type)))
+        return Text("FuncType(params={}, ret={})".format(self(t.param_types), self(t.ret_type)))
 
     def visit_OpaqueType(self, t: OpaqueType):
         return Text(f"OpaqueType({t.cpp_name})")

--- a/python/tilus/hidet/ir/tools/type_infer.py
+++ b/python/tilus/hidet/ir/tools/type_infer.py
@@ -321,8 +321,9 @@ class TypeInfer(IRFunctor):
                     func_var, func_type
                 )
             )
-        args_type = [self(arg) for arg in e.args]
-        return func_type.ret_type_on(args_type)
+        for arg in e.args:
+            self(arg)
+        return func_type.ret_type
 
     def visit_Cast(self, e: Cast):
         return e.target_type

--- a/python/tilus/hidet/ir/type.py
+++ b/python/tilus/hidet/ir/type.py
@@ -26,7 +26,7 @@
 # pylint: disable=import-outside-toplevel
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 from tilus.hidet.ir.node import Node
 
@@ -290,37 +290,12 @@ class TensorPointerType(BaseType):
         return TensorPointerType(tp)
 
 
-TypeLike = Union[str, BaseType]
-
-
 class FuncType(BaseType):
-    def __init__(
-        self,
-        param_types: Optional[List[TypeLike]] = None,
-        ret_type: Optional[TypeLike] = None,
-        type_infer_func: Optional[Callable] = None,  # Callable[[a number of BaseType], BaseType]
-    ):
-        self.param_types: Optional[List[BaseType]] = (
-            [self._convert_type(tp) for tp in param_types] if param_types is not None else None
-        )
-        self.ret_type: Optional[BaseType] = self._convert_type(ret_type) if ret_type is not None else None
-        self.type_infer_func: Optional[Callable[[List[BaseType]], BaseType]] = type_infer_func
-        msg = "Please provide either a static type or a type infer func"
-        assert not all(v is None for v in [ret_type, type_infer_func]), msg
-
-    def ret_type_on(self, arg_types: List[BaseType]) -> BaseType:
-        if self.ret_type is not None:
-            # todo: add type checking
-            assert isinstance(self.ret_type, BaseType)
-            return self.ret_type
-        else:
-            return self.type_infer_func(arg_types)
-
-    def _convert_type(self, tp: Union[str, BaseType]):
-        if isinstance(tp, str):
-            return data_type(tp)
-        else:
-            return tp
+    def __init__(self, param_types: List[BaseType], ret_type: BaseType):
+        assert isinstance(param_types, list) and all(isinstance(tp, BaseType) for tp in param_types)
+        assert isinstance(ret_type, BaseType)
+        self.param_types: List[BaseType] = param_types
+        self.ret_type: BaseType = ret_type
 
     @staticmethod
     def from_func(func):
@@ -440,8 +415,6 @@ def type_equal(lhs: BaseType, rhs: BaseType) -> bool:
         # do not check layout
         return True
     elif isinstance(lhs, FuncType) and isinstance(rhs, FuncType):
-        assert lhs.param_types is not None and lhs.ret_type is not None
-        assert rhs.param_types is not None and rhs.ret_type is not None
         if len(lhs.param_types) != len(rhs.param_types):
             return False
         if not type_equal(lhs.ret_type, rhs.ret_type):

--- a/python/tilus/hidet/transforms/expand_let_expr.py
+++ b/python/tilus/hidet/transforms/expand_let_expr.py
@@ -46,15 +46,12 @@ def wrapper(stmt_visitor):
         # do not cache exprs between different statements, so the let expr will always generate let stmt.
         self.memo.clear()
         updated_stmt = stmt_visitor(self, stmt)
-        let_stmts = self.stmt_stack.pop()
-        if len(let_stmts) == 0:
+        pending = self.stmt_stack.pop()
+        if not pending:
             return updated_stmt
-        else:
-            bind_vars, bind_values = [], []
-            for let in let_stmts:
-                bind_vars.extend(let.bind_vars)
-                bind_values.extend(let.bind_values)
-            return LetStmt(bind_vars, bind_values, updated_stmt)
+        bind_vars = [var for var, _ in pending]
+        bind_values = [value for _, value in pending]
+        return LetStmt(bind_vars, bind_values, updated_stmt)
 
     return wrapped_visitor
 
@@ -67,7 +64,7 @@ class LetExprExpander(IRRewriter):
     def visit_Let(self, e: Let):
         var = self(e.var)
         value = self(e.value)
-        self.stmt_stack[-1].append(LetStmt(var, value))
+        self.stmt_stack[-1].append((var, value))
         return self(e.body)
 
     @wrapper

--- a/python/tilus/hidet/transforms/resolve_generic_primitive_function.py
+++ b/python/tilus/hidet/transforms/resolve_generic_primitive_function.py
@@ -12,89 +12,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from typing import List, Optional, Tuple
+"""
+Insert implicit casts into binary expressions whose operands have different dtypes.
 
-from tilus.hidet.ir.expr import BinaryExpr, Call, Expr, cast
+Historically this pass also lowered `generic_*` primitive function calls to device/dtype-specific
+variants. Now that primitives are registered with concrete types and dispatched at call-site,
+only the binary implicit-cast rewriting remains.
+"""
+
+from typing import List
+
+from tilus.hidet.ir.expr import BinaryExpr, Expr, cast
 from tilus.hidet.ir.func import Function
 from tilus.hidet.ir.functors import IRRewriter
-from tilus.hidet.ir.primitives import is_primitive_function, lookup_primitive_function
-from tilus.hidet.ir.primitives.math import registered_math_function_sets
-from tilus.hidet.ir.tools import TypeInfer, infer_type
+from tilus.hidet.ir.tools import TypeInfer
 from tilus.hidet.ir.type import DataType
+from tilus.hidet.ir.utils.type_utils import numeric_promotion_for_all
 from tilus.hidet.transforms.base import FunctionPass
-from tilus.hidet.utils.py import green
 
 
-def resolve_dtype(arg_dtypes: List[DataType]) -> DataType:
-    import tilus.hidet.ir.primitives.math
-
-    return tilus.hidet.ir.primitives.math.type_infer_func(arg_dtypes)
+def _cast_args(args: List[Expr], arg_dtypes: List[DataType], target_dtype: DataType) -> List[Expr]:
+    return [a if d.name == target_dtype.name else cast(a, target_dtype) for a, d in zip(args, arg_dtypes)]
 
 
-def cast_args(args: List[Expr], arg_dtypes: List[DataType], target_dtype: DataType) -> List[Expr]:
-    casted_args = []
-    for arg, arg_dtype in zip(args, arg_dtypes):
-        if arg_dtype.name != target_dtype.name:
-            casted_args.append(cast(arg, target_dtype))
-        else:
-            casted_args.append(arg)
-    return casted_args
-
-
-class ResolveGenericPrimitiveFuncRewriter(IRRewriter):
-    def __init__(self, device: str):
+class InsertImplicitBinaryCastRewriter(IRRewriter):
+    def __init__(self):
         super().__init__()
         self.type_infer = TypeInfer()
-        self.device: str = device
-
-    def visit_Call(self, e: Call):
-        if is_primitive_function(e.func_var.name):
-            entry = lookup_primitive_function(e.func_var.name)
-            if entry.generic:
-                args = [self(arg) for arg in e.args]
-                arg_types = [infer_type(arg) for arg in args]
-                if any(not isinstance(arg_type, DataType) for arg_type in arg_types):
-                    raise ValueError(
-                        'Cannot resolve generic primitive function "{}" for arguments:'.format(e.func_var.name)
-                        + " args: {}  types: {}".format(args, arg_types)
-                    )
-                resolved_dtype: DataType = resolve_dtype(arg_types)
-                names = entry.name.split("_")  # such as 'generic_exp'
-                generic = names[0]
-                func_name = "_".join(names[1:])
-                assert generic == "generic"
-                dtype: str = resolved_dtype.name
-                key: Tuple[str, str] = (self.device, dtype)
-                if key not in registered_math_function_sets:
-                    msg = "Can not dispatch generic primitive function {} to device {} and dtype {}.\n".format(
-                        green(entry.name), green(self.device), green(dtype)
-                    )
-                    msg += "Registered math function sets: {}".format(list(registered_math_function_sets.keys())) + "\n"
-                    raise NotImplementedError(msg)
-                else:
-                    func_set = registered_math_function_sets[key]
-                    assert hasattr(func_set, func_name)
-                    func = getattr(func_set, func_name)
-                    try:
-                        return func(*args)
-                    except NotImplementedError as err:
-                        msg = "Math function {} for {} data has not been implemented for device {}".format(
-                            green(e.func_var.name.replace("generic_", "")), green(dtype), green(self.device)
-                        )
-                        raise NotImplementedError(msg) from err
-
-        return IRRewriter.visit_Call(self, e)
 
     def visit_Binary(self, e: BinaryExpr):
         lhs = self.visit(e.a)
@@ -102,8 +46,8 @@ class ResolveGenericPrimitiveFuncRewriter(IRRewriter):
         lhs_dtype = self.type_infer(lhs)
         rhs_dtype = self.type_infer(rhs)
         if isinstance(lhs_dtype, DataType) and isinstance(rhs_dtype, DataType) and lhs_dtype.name != rhs_dtype.name:
-            dtype = resolve_dtype([lhs_dtype, rhs_dtype])
-            lhs, rhs = cast_args([lhs, rhs], [lhs_dtype, rhs_dtype], dtype)
+            target = numeric_promotion_for_all(lhs_dtype, rhs_dtype)
+            lhs, rhs = _cast_args([lhs, rhs], [lhs_dtype, rhs_dtype], target)
             if lhs is e.a and rhs is e.b:
                 return e
             else:
@@ -113,22 +57,8 @@ class ResolveGenericPrimitiveFuncRewriter(IRRewriter):
 
 
 class ResolveGenericPrimitiveFuncPass(FunctionPass):
-    def __init__(self):
-        super().__init__()
-        self.device: Optional[str] = None
-
     def process_func(self, func: Function) -> Function:
-        func_kind_to_device = {
-            "cuda_kernel": "cuda",
-            "cuda_internal": "cuda",
-            "hip_kernel": "hip",
-            "hip_internal": "hip",
-            "cpu_kernel": "cpu",
-            "cpu_internal": "cpu",
-            "public": "cpu",
-        }
-        self.device = func_kind_to_device[func.kind]
-        rewriter = ResolveGenericPrimitiveFuncRewriter(self.device)
+        rewriter = InsertImplicitBinaryCastRewriter()
         return rewriter.visit(func)
 
 


### PR DESCRIPTION
Prep work for the upcoming py_class migration: every Stmt IR node is now
constructed immutably, with no post-construction field assignment.

- StmtBuilder rewritten around _Frame dataclasses (for/let/while/if/elif/else).
  enter_body pushes a frame and opens a child scope; exit_body pops the child
  body and calls frame.build(body) to produce the final Stmt. The if/elif/else
  ladder is threaded via a per-scope pending_if slot that gets chained into a
  nested IfStmt tree without mutating already-built nodes. enter_body/exit_body
  no longer take pre-built skeleton stmts; StmtScope now carries a list of frames.
- Stmt classes tightened: LetStmt / ForStmt / WhileStmt / IfStmt drop the
  `body=None` / `then_body=None` defaults (body is now mandatory). IfStmt keeps
  `else_body: Optional[Stmt] = None` since the `else` branch is genuinely optional.
- Tuple-ize mutable list fields: LetStmt.bind_vars / LetStmt.bind_values and
  AsmStmt.(output|input)_(labels|exprs) are now `Tuple[..., ...]`.
- expand_let_expr stashes `(var, value)` pairs instead of placeholder
  `LetStmt(var, value)` skeletons; rebuilds one LetStmt per enclosing statement.