### PR TITLE
[Refactor] Make IRModule immutable; drop unused tensor-constant support

### DIFF
--- a/python/tilus/hidet/backend/codegen.py
+++ b/python/tilus/hidet/backend/codegen.py
@@ -3,8 +3,6 @@
 import os
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
-import numpy as np
-
 from tilus.hidet.ir import dtypes
 from tilus.hidet.ir.dialects.pattern import PlaceholderExpr
 from tilus.hidet.ir.dtypes import uint32x1, uint32x2, uint32x4
@@ -518,10 +516,6 @@ class Codegen(ModuleFunctor, StmtFunctor, ExprFunctor, TypeFunctor):
             return Text('"{}"'.format(e.value))
         elif e.is_scalar():
             return self.scalar_literal(e.value, e.type)
-        elif e.is_tensor():
-            dtype = e.type.dtype
-            items = [self.scalar_literal(v, dtype) for v in np.array(e.value).flatten()]
-            return "{" + doc_join(items, ", ") + "}"
         elif isinstance(e.type, PointerType):
             return "(" + self(e.type) + ")" + str(int(e.value))
         else:

--- a/python/tilus/hidet/ir/expr.py
+++ b/python/tilus/hidet/ir/expr.py
@@ -31,8 +31,6 @@ import operator
 import string
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
-import numpy as np
-
 from tilus.hidet.ir.dtypes import IntegerType, boolean, int32, int64, promote_type, uint64
 
 from .dtypes import default_float_dtype, default_int_dtype
@@ -447,17 +445,14 @@ class Constant(Expr):
 
     def __init__(
         self,
-        value: Union[np.ndarray, float, int, complex, str],
-        const_type: Union[DataType, StringType, TensorType, PointerType],
+        value: Union[float, int, complex, str],
+        const_type: Union[DataType, StringType, PointerType],
     ):
-        self.value: Union[np.ndarray, float, int, complex, str] = value
-        self.type: Union[DataType, StringType, TensorType, PointerType] = const_type
+        self.value: Union[float, int, complex, str] = value
+        self.type: Union[DataType, StringType, PointerType] = const_type
 
     def is_scalar(self) -> bool:
         return isinstance(self.type, DataType)
-
-    def is_tensor(self) -> bool:
-        return isinstance(self.type, TensorType)
 
     def is_string(self) -> bool:
         return isinstance(self.type, StringType)
@@ -473,9 +468,6 @@ class Constant(Expr):
 
     def __complex__(self):
         return complex(self.value)
-
-    def array(self) -> np.ndarray:
-        return self.value
 
     # This speciallisation of Expr._binary is done for speedup purposes only
     # and fully equvivalent to Expr._binary by functionality
@@ -827,12 +819,6 @@ def call(func: Var, args: Sequence[Union[Expr, PyScalar]]) -> Call:
     return Call(func, args)
 
 
-def const_tensor(value: np.ndarray) -> Constant:
-    from tilus.hidet.ir.utils.type_utils import from_numpy_dtype
-
-    return constant(value=value, const_type=tensor_type(dtype=from_numpy_dtype(value.dtype), shape=list(value.shape)))
-
-
 def tensor_pointer_var(hint: str, shape, dtype: Union[str, DataType] = "float32"):
     return Var(hint, tensor_pointer_type(dtype=dtype, shape=shape))
 
@@ -880,8 +866,6 @@ def constant(value, const_type: Union[str, BaseType]) -> Constant:
             value = tuple(value)
         else:
             raise ValueError(f"Invalid data const_type {const_type}")
-    elif isinstance(const_type, TensorType):
-        value = np.array(value)
     elif isinstance(const_type, PointerType):
         value = int(value)
     elif isinstance(const_type, StringType):

--- a/python/tilus/hidet/ir/functors/module_functor.py
+++ b/python/tilus/hidet/ir/functors/module_functor.py
@@ -65,8 +65,7 @@ class ModuleRewriter(ModuleFunctor, BaseRewriter):
         functions = self.visit(module.functions)
         if same_list(global_vars, module.global_vars) and functions is module.functions:
             return module
-        else:
-            return module.copy().reset_funcs(functions, global_vars)
+        return module.with_functions(functions, global_vars)
 
     def visit_Function(self, func: Function):
         params = self.visit(func.params)

--- a/python/tilus/hidet/ir/module.py
+++ b/python/tilus/hidet/ir/module.py
@@ -12,20 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 from __future__ import annotations
 
-from typing import Dict, List, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence
 
 from tilus.hidet.ir.expr import Var
 from tilus.hidet.ir.func import Function
@@ -34,72 +23,59 @@ from tilus.hidet.ir.type import FuncType
 
 
 class IRModule(Node):
-    """
-    The intermediate representation of tensor programs.
+    """The intermediate representation of tensor programs.
 
-    An IRModule contains one or more functions. It is the basic compilation unit of hidet.
+    Immutable by convention: all update operations return a new ``IRModule``. Consumers
+    must never mutate ``functions`` / ``global_vars`` / ``extern_functions`` / the list
+    fields in-place — use :meth:`with_functions`, :meth:`with_removed_functions`,
+    :meth:`merge`, or construct a new ``IRModule``.
     """
 
     def __init__(
         self,
-        functions=None,
-        global_vars=None,
-        namespace="",
-        extern_functions: Dict[str, Var] = None,
-        include_headers: List[str] = None,
-        include_dirs: List[str] = None,
-        linking_dirs: List[str] = None,
-        linking_libs: List[str] = None,
-        object_files: List[str] = None,
+        functions: Optional[Dict[str, Function]] = None,
+        global_vars: Optional[Dict[str, Var]] = None,
+        namespace: str = "",
+        extern_functions: Optional[Dict[str, Var]] = None,
+        include_headers: Optional[List[str]] = None,
+        include_dirs: Optional[List[str]] = None,
+        linking_dirs: Optional[List[str]] = None,
+        linking_libs: Optional[List[str]] = None,
+        object_files: Optional[List[str]] = None,
     ):
-        # the functions defined in this module
-        self.functions: Dict[str, Function] = functions if functions else {}
-        # the global variables defined in this module
-        self.global_vars: Dict[str, Var] = global_vars if global_vars else {}
-        # the namespace of the module, all the functions and the global variables will be defined in this namespace
+        self.functions: Dict[str, Function] = dict(functions) if functions else {}
+        self.global_vars: Dict[str, Var] = dict(global_vars) if global_vars else {}
+        # Ensure every defined function has a corresponding global_var entry.
+        for name, func in self.functions.items():
+            if name not in self.global_vars:
+                self.global_vars[name] = Var(name=name, type=FuncType.from_func(func))
         self.namespace: str = namespace
-        # the external functions that are used in this module, the Var must have a function type
-        self.extern_functions: Dict[str, Var] = {} if extern_functions is None else extern_functions
-        # '#include ...' preprocessor directives
-        self.include_headers: List[str] = include_headers if include_headers else []
-        # flags that will be passed to the underlying compiler, can be used to add 3rd-party libraries
-        self.include_dirs: List[str] = include_dirs if include_dirs else []  # -L flags
-        self.linking_dirs: List[str] = linking_dirs if linking_dirs else []  # -I flags
-        self.linking_libs: List[str] = linking_libs if linking_libs else []  # -l flags
-        self.object_files: List[str] = object_files if object_files else []  # .o files
+        self.extern_functions: Dict[str, Var] = dict(extern_functions) if extern_functions else {}
+        self.include_headers: List[str] = list(include_headers) if include_headers else []
+        self.include_dirs: List[str] = list(include_dirs) if include_dirs else []
+        self.linking_dirs: List[str] = list(linking_dirs) if linking_dirs else []
+        self.linking_libs: List[str] = list(linking_libs) if linking_libs else []
+        self.object_files: List[str] = list(object_files) if object_files else []
 
         assert all(isinstance(func, Function) for func in self.functions.values()) and all(
             isinstance(var, Var) for var in self.global_vars.values()
         )
 
-    def lookup_var(self, name):
-        assert name in self.functions, (name, self.functions.keys())
-        if name not in self.global_vars:
-            func = self.functions[name]
-            if isinstance(func, Function):
-                self.global_vars[name] = Var(name=name, type=FuncType.from_func(func))
-            else:
-                raise ValueError()
-
+    def lookup_var(self, name: str) -> Var:
+        assert name in self.global_vars, (name, list(self.global_vars.keys()))
         return self.global_vars[name]
 
-    def add_function(self, name, func: Function):
-        if name in self.functions:
-            raise ValueError("Function {} has already existed in module.".format(name))
-        else:
-            self.functions[name] = func
-
-    def copy(self):
+    def copy(self) -> IRModule:
         return IRModule(
-            functions=self.functions.copy(),
-            global_vars=self.global_vars.copy(),
+            functions=self.functions,
+            global_vars=self.global_vars,
             namespace=self.namespace,
-            extern_functions=self.extern_functions.copy(),
-            include_headers=self.include_headers.copy(),
-            include_dirs=self.include_dirs.copy(),
-            linking_dirs=self.linking_dirs.copy(),
-            linking_libs=self.linking_libs.copy(),
-            object_files=self.object_files.copy(),
+            extern_functions=self.extern_functions,
+            include_headers=self.include_headers,
+            include_dirs=self.include_dirs,
+            linking_dirs=self.linking_dirs,
+            linking_libs=self.linking_libs,
+            object_files=self.object_files,
         )
 
     def build(self):
@@ -118,42 +94,94 @@ class IRModule(Node):
         build_ir_module(self, output_dir)
         return CompiledModule(os.path.join(output_dir, "lib.so"))
 
-    def reset_funcs(self, functions: Dict[str, Function] = None, global_vars: Dict[str, Var] = None):
-        self.functions = functions if functions else {}
-        self.global_vars = global_vars if global_vars else {}
-        return self
+    # ---- functional updates ----
+
+    def with_functions(
+        self,
+        functions: Optional[Dict[str, Function]] = None,
+        global_vars: Optional[Dict[str, Var]] = None,
+    ) -> IRModule:
+        """Return a new IRModule with replaced ``functions`` and (optionally) ``global_vars``.
+
+        When ``global_vars`` is omitted, only the entries matching retained function names
+        are kept and fresh entries are synthesized for newly added functions.
+        """
+        new_functions = dict(functions) if functions is not None else dict(self.functions)
+        if global_vars is not None:
+            new_global_vars = dict(global_vars)
+        else:
+            new_global_vars = {name: var for name, var in self.global_vars.items() if name in new_functions}
+        return IRModule(
+            functions=new_functions,
+            global_vars=new_global_vars,
+            namespace=self.namespace,
+            extern_functions=self.extern_functions,
+            include_headers=self.include_headers,
+            include_dirs=self.include_dirs,
+            linking_dirs=self.linking_dirs,
+            linking_libs=self.linking_libs,
+            object_files=self.object_files,
+        )
+
+    def with_added_functions(self, functions: Dict[str, Function]) -> IRModule:
+        """Return a new IRModule with the given functions added (duplicates raise)."""
+        new_functions = dict(self.functions)
+        for name, func in functions.items():
+            if name in new_functions:
+                raise ValueError(f"Function {name} has already existed in module.")
+            new_functions[name] = func
+        return self.with_functions(functions=new_functions, global_vars=None)
+
+    def with_removed_functions(self, names: Iterable[str]) -> IRModule:
+        """Return a new IRModule with the given function names (and their global_vars) removed."""
+        remove = set(names)
+        new_functions = {name: func for name, func in self.functions.items() if name not in remove}
+        new_global_vars = {name: var for name, var in self.global_vars.items() if name not in remove}
+        return self.with_functions(functions=new_functions, global_vars=new_global_vars)
 
 
 def merge_ir_modules(modules: Sequence[IRModule]) -> IRModule:
     if len(modules) == 0:
         return IRModule()
-    merged = modules[0].copy()
+    base = modules[0]
+    namespace = base.namespace
+    functions: Dict[str, Function] = dict(base.functions)
+    global_vars: Dict[str, Var] = dict(base.global_vars)
+    extern_functions: Dict[str, Var] = dict(base.extern_functions)
+    include_headers: List[str] = list(base.include_headers)
+    include_dirs: List[str] = list(base.include_dirs)
+    linking_dirs: List[str] = list(base.linking_dirs)
+    linking_libs: List[str] = list(base.linking_libs)
+    object_files: List[str] = list(base.object_files)
+
     for module in modules[1:]:
-        if module.namespace != merged.namespace:
+        if module.namespace != namespace:
             raise ValueError("Cannot merge IRModules with different namespaces")
-        # merge global vars
         for name, var in module.global_vars.items():
-            if name in merged.global_vars:
-                raise ValueError("Global variable {} has already existed in module.".format(name))
-            merged.global_vars[name] = var
-        # merge functions
+            if name in global_vars:
+                raise ValueError(f"Global variable {name} has already existed in module.")
+            global_vars[name] = var
         for name, func in module.functions.items():
-            if name in merged.functions:
-                raise ValueError("Function {} has already existed in module.".format(name))
-            merged.functions[name] = func
-        # merge extern functions
+            if name in functions:
+                raise ValueError(f"Function {name} has already existed in module.")
+            functions[name] = func
         for name, var in module.extern_functions.items():
-            if name in merged.extern_functions:
-                continue
-            merged.extern_functions[name] = var
+            if name not in extern_functions:
+                extern_functions[name] = var
+        include_headers.extend(h for h in module.include_headers if h not in include_headers)
+        include_dirs.extend(d for d in module.include_dirs if d not in include_dirs)
+        linking_dirs.extend(d for d in module.linking_dirs if d not in linking_dirs)
+        linking_libs.extend(lib for lib in module.linking_libs if lib not in linking_libs)
+        object_files.extend(f for f in module.object_files if f not in object_files)
 
-        # merge include headers, include_dirs, linking_dirs, linking_libs, object_files
-        merged.include_headers.extend(
-            [header for header in module.include_headers if header not in merged.include_dirs]
-        )
-        merged.include_dirs.extend([dir for dir in module.include_dirs if dir not in merged.include_dirs])
-        merged.linking_dirs.extend([dir for dir in module.linking_dirs if dir not in merged.linking_dirs])
-        merged.linking_libs.extend([lib for lib in module.linking_libs if lib not in merged.linking_libs])
-        merged.object_files.extend([file for file in module.object_files if file not in merged.object_files])
-
-    return merged
+    return IRModule(
+        functions=functions,
+        global_vars=global_vars,
+        namespace=namespace,
+        extern_functions=extern_functions,
+        include_headers=include_headers,
+        include_dirs=include_dirs,
+        linking_dirs=linking_dirs,
+        linking_libs=linking_libs,
+        object_files=object_files,
+    )

--- a/python/tilus/hidet/ir/tools/printer.py
+++ b/python/tilus/hidet/ir/tools/printer.py
@@ -371,9 +371,7 @@ class IRPrinter(IRFunctor):
     def visit_Constant(self, e: Constant):
         if e.value is None:
             return self("Constant(None, type=") + self(e.type) + ")"
-        if e.is_tensor():
-            return "ConstTensor({}, {})".format(e.value.shape, e.type)
-        elif e.is_string():
+        if e.is_string():
             return Text('"{}"'.format(str(e.value)))
         elif e.is_scalar():
             dtype = e.type.name

--- a/python/tilus/hidet/ir/tools/renamer.py
+++ b/python/tilus/hidet/ir/tools/renamer.py
@@ -75,5 +75,4 @@ def rename_funcs(ir_module: IRModule, rmap: Dict[str, str]) -> IRModule:
         else:
             global_vars[name] = var
 
-    ir_module.reset_funcs(functions=new_functions, global_vars=global_vars)
-    return ir_module
+    return ir_module.with_functions(functions=new_functions, global_vars=global_vars)

--- a/python/tilus/hidet/transforms/base.py
+++ b/python/tilus/hidet/transforms/base.py
@@ -95,8 +95,7 @@ class Pass:
             new_funcs[name] = self.process_func(func)
         if all(new_funcs[name] is ir_module.functions[name] for name in new_funcs):
             return ir_module
-        else:
-            return ir_module.copy().reset_funcs(new_funcs, ir_module.global_vars)
+        return ir_module.with_functions(new_funcs, ir_module.global_vars)
 
     def process_func(self, func: Function) -> Function:
         return func

--- a/python/tilus/hidet/transforms/flatten_tensor_index.py
+++ b/python/tilus/hidet/transforms/flatten_tensor_index.py
@@ -152,8 +152,7 @@ class FlattenTensorIndexPass(Pass):
 
         if all(new_funcs[name] is ir_module.functions[name] for name in new_funcs):
             return ir_module
-        else:
-            return ir_module.copy().reset_funcs(new_funcs, ir_module.global_vars)
+        return ir_module.with_functions(new_funcs, ir_module.global_vars)
 
 
 def flatten_tensor_index_pass():

--- a/python/tilus/hidet/transforms/generate_launch_func.py
+++ b/python/tilus/hidet/transforms/generate_launch_func.py
@@ -54,7 +54,7 @@ def _rewrite_dim3(dim3: Tuple[Expr, Expr, Expr], param2arg: Dict[Expr, Expr]) ->
     return rewrite(dim3[0], param2arg), rewrite(dim3[1], param2arg), rewrite(dim3[2], param2arg)
 
 
-def add_launch_func(ir_module: IRModule, kernel_func: Function):
+def add_launch_func(ir_module: IRModule, kernel_func: Function) -> IRModule:
     with FunctionBuilder(name="launch", kind="public") as fb:
         params = [Var(param.name, param.type) for param in kernel_func.params]
         param_remap = {a: b for a, b in zip(kernel_func.params, params)}
@@ -98,7 +98,7 @@ def add_launch_func(ir_module: IRModule, kernel_func: Function):
             raise NotImplementedError("Unsupported function kind: {}".format(kernel_func.kind))
 
     launch: Function = fb.func
-    ir_module.add_function(launch.name, launch)
+    return ir_module.with_added_functions({launch.name: launch})
 
 
 class GenerateLaunchFuncPass(Pass):
@@ -125,11 +125,7 @@ class GenerateLaunchFuncPass(Pass):
                 kind=host_func.kind,
                 attrs=host_func.attrs,
             )
-            del ir_module.functions[old_name]
-            if old_name in ir_module.global_vars:
-                del ir_module.global_vars[old_name]
-            ir_module.add_function("launch", renamed)
-            return ir_module
+            return ir_module.with_removed_functions([old_name]).with_added_functions({"launch": renamed})
 
         # Multiple or no host functions: generate a launch function from the kernel
         kernel_functions: Dict[str, Function] = {
@@ -142,8 +138,7 @@ class GenerateLaunchFuncPass(Pass):
         if len(kernel_functions) > 1:
             raise NotImplementedError("Can only handle one kernel function in a module")
         kernel_func = next(iter(kernel_functions.values()))
-        add_launch_func(ir_module, kernel_func)
-        return ir_module
+        return add_launch_func(ir_module, kernel_func)
 
 
 def generate_launch_func(ir_module: IRModule) -> IRModule:

--- a/python/tilus/hidet/transforms/import_primitive_functions.py
+++ b/python/tilus/hidet/transforms/import_primitive_functions.py
@@ -51,14 +51,8 @@ class ImportPrimitiveFunctionPass(Pass):
 
         if len(primitive_funcs) == 0:
             return ir_module
-        else:
-            new_ir_module = ir_module.copy().reset_funcs()
-            for func_name, func in ir_module.functions.items():
-                new_ir_module.add_function(func_name, func)
-            for func in primitive_funcs:
-                if func.name not in new_ir_module.functions:
-                    new_ir_module.add_function(func.name, func)
-            return new_ir_module
+        new_funcs = {func.name: func for func in primitive_funcs if func.name not in ir_module.functions}
+        return ir_module.with_added_functions(new_funcs)
 
 
 def import_primitive_functions_pass() -> Pass:

--- a/python/tilus/hidet/transforms/inline_function.py
+++ b/python/tilus/hidet/transforms/inline_function.py
@@ -133,44 +133,45 @@ def inline_callees(caller: Function, updated_ir_module: IRModule) -> Function:
     return rewriter.inline(caller)
 
 
-class PruneUnusedFunctionRewriter(IRRewriter):
-    def visit_IRModule(self, module: IRModule):
-        call_graph = CallGraph(module, allow_missing=True)
-        unused_func_names: Set[str] = set()
-        for node in call_graph.nodes:
-            func: Function = node.func
-            if func.kind in ["public", "cpu_kernel", "cuda_kernel", "hip_kernel"]:
-                continue
-            if len(node.callers) == 0:
-                unused_func_names.add(func.name)
-        for func_name in unused_func_names:
-            del module.functions[func_name]
-            if func_name in module.global_vars:
-                del module.global_vars[func_name]
-
-        return module
-
-
-def prune_unused_functions(ir_module: IRModule):
-    rewriter = PruneUnusedFunctionRewriter()
-    return rewriter.visit(ir_module)
+def prune_unused_functions(ir_module: IRModule) -> IRModule:
+    call_graph = CallGraph(ir_module, allow_missing=True)
+    unused_func_names: Set[str] = set()
+    for node in call_graph.nodes:
+        func: Function = node.func
+        if func.kind in ["public", "cpu_kernel", "cuda_kernel", "hip_kernel"]:
+            continue
+        if len(node.callers) == 0:
+            unused_func_names.add(func.name)
+    if not unused_func_names:
+        return ir_module
+    return ir_module.with_removed_functions(unused_func_names)
 
 
 class InlineFunctionPass(Pass):
     def process_module(self, ir_module: IRModule) -> IRModule:
         call_graph = CallGraph(ir_module, allow_missing=True)
-        updated_ir_module = ir_module.copy().reset_funcs()
+        # Accumulate inlined functions in a fresh IRModule so the rewriter can see the
+        # already-inlined definitions when processing their callers.
+        updated_ir_module = ir_module.with_functions(functions={}, global_vars={})
         for node in call_graph.reversed_order:
             assert isinstance(node, CallGraphNode)
             func = inline_callees(node.func, updated_ir_module)
-            updated_ir_module.functions[func.name] = func
+            new_functions = dict(updated_ir_module.functions)
+            new_functions[func.name] = func
+            updated_ir_module = updated_ir_module.with_functions(
+                functions=new_functions, global_vars=updated_ir_module.global_vars
+            )
 
         updated_ir_module = prune_unused_functions(updated_ir_module)
 
-        # add global variables that are not functions
-        updated_ir_module.global_vars.update(
-            {name: var for name, var in ir_module.global_vars.items() if name not in ir_module.functions}
-        )
+        # Preserve global variables that are not tied to a function definition.
+        non_func_globals = {name: var for name, var in ir_module.global_vars.items() if name not in ir_module.functions}
+        if non_func_globals:
+            merged_globals = dict(updated_ir_module.global_vars)
+            merged_globals.update(non_func_globals)
+            updated_ir_module = updated_ir_module.with_functions(
+                functions=updated_ir_module.functions, global_vars=merged_globals
+            )
 
         return updated_ir_module
 

--- a/python/tilus/hidet/transforms/lower_fast_div.py
+++ b/python/tilus/hidet/transforms/lower_fast_div.py
@@ -222,7 +222,7 @@ class LowerFastDivPass(Pass):
                     attrs=func.attrs,
                 )
 
-        return ir_module.copy().reset_funcs(new_funcs, ir_module.global_vars)
+        return ir_module.with_functions(new_funcs, ir_module.global_vars)
 
     @staticmethod
     def _build_precompute(

--- a/python/tilus/hidet/transforms/lower_integer_subbyte.py
+++ b/python/tilus/hidet/transforms/lower_integer_subbyte.py
@@ -385,8 +385,7 @@ class LowerIntegerSubbytePass(Pass):
             new_funcs[name] = self.process_func(func)
         if all(new_funcs[name] is ir_module.functions[name] for name in new_funcs):
             return ir_module
-        else:
-            return ir_module.copy().reset_funcs(new_funcs, ir_module.global_vars)
+        return ir_module.with_functions(new_funcs, ir_module.global_vars)
 
 
 def lower_integer_subbyte_pass() -> Pass:

--- a/python/tilus/utils/py.py
+++ b/python/tilus/utils/py.py
@@ -260,8 +260,6 @@ def _is_immutable(obj):
     try:
         from tilus.hidet.ir.expr import Constant
 
-        if isinstance(obj, Constant) and obj.type.is_tensor():
-            return False
         if isinstance(obj, Constant):
             return True
     except Exception:


### PR DESCRIPTION
Prep work for the py_class migration: IRModule updates are now pure-functional, and Constant only covers scalar/string/pointer values.

IRModule:
- Remove the in-place mutators add_function and reset_funcs.
- Add functional updates: with_functions(functions, global_vars=None), with_added_functions(...), with_removed_functions(names).
- lookup_var no longer lazily populates self.global_vars. The constructor eagerly synthesizes global_var entries for every function so global_vars is always in sync, and lookup_var is a pure read.
- merge_ir_modules rewritten to build fresh dicts/lists and construct one new IRModule at the end.
- Audit all callers: transforms/base, flatten_tensor_index, lower_integer_subbyte, lower_fast_div, generate_launch_func, inline_function, import_primitive_functions, renamer, and module_functor all switch to the functional API. InlineFunctionPass threads an updated IRModule through with_functions each iteration; PruneUnusedFunctionRewriter flattened to a pure prune_unused_functions helper.

Constant:
- Drop tensor-constant support entirely (no callers in python/, tests/, or examples/): remove Constant.is_tensor / Constant.array, the const_tensor() helper, and the TensorType branch in constant(). Also drop np.ndarray from Constant.value and __init__ type annotations, and the matching dead branches in codegen's visit_Constant, printer's visit_Constant, and utils.py._is_immutable.