### PR TITLE
[Instruction] Add tile-level atomic RMW and scatter-store instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,7 @@ Call `tilus.option.debug.dump_ir()` before running the kernel. The IR after each
 ## Testing After Refactors
 
 After a large refactor, first run `tests/kernels/matmul/test_matmul_v2.py` as a smoke test before running the full suite — the full suite is slow. Fix any matmul_v2 failures first, then expand to more tests.
+
+## Before Committing
+
+Run `pre-commit run --all` to apply the project's linters/formatters and fix any pre-commit issues before creating the commit. Re-stage any files the hooks modify, then commit.

--- a/docs/source/programming-guides/instructions.rst
+++ b/docs/source/programming-guides/instructions.rst
@@ -44,14 +44,19 @@ Load and Store
 ~~~~~~~~~~~~~~
 
 Transfer data between memory spaces. Load instructions copy data from global or shared memory into
-register tensors; store instructions write register data back.
+register tensors; store instructions write register data back. The ``*_scatter`` variants perform
+non-atomic scatter writes driven by a per-lane ``indices`` tile along one axis — use them when the
+scatter is guaranteed collision-free, and reach for :ref:`self.atomic.*_scatter_* <atomic-group>`
+otherwise.
 
 .. autosummary::
 
    load_global
    store_global
+   store_global_scatter
    load_shared
    store_shared
+   store_shared_scatter
 
 
 Asynchronous Copy (SM80+)
@@ -166,12 +171,13 @@ Synchronize threads within a block or across a cluster. ``sync`` is the block-le
    sync
 
 
-Atomic and Semaphore
-~~~~~~~~~~~~~~~~~~~~
+Semaphores
+~~~~~~~~~~
 
 Inter-block synchronization using global memory semaphores. ``lock_semaphore`` spins until the
 semaphore reaches a target value; ``release_semaphore`` sets it to signal other blocks. Both
-must be called from a single thread (``self.single_thread()``).
+must be called from a single thread (``self.single_thread()``). For tile-level atomic RMW (element-wise
+and scatter), see :ref:`self.atomic <atomic-group>`.
 
 .. autosummary::
 
@@ -337,5 +343,46 @@ take over the canceled cluster's work. See :doc:`../python-api/instruction-group
 
    try_cancel
    query_response
+
+.. currentmodule:: tilus.Script
+
+
+.. _atomic-group:
+
+Atomic (``self.atomic``)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tile-level atomic read-modify-write on shared and global memory. Two shapes are exposed:
+**element-wise** (``dst.shape == values.shape``, each lane atomically updates its own element)
+and **scatter** (``torch.scatter_add_``-style, with a per-lane ``indices`` tile picking the
+destination along a compile-time ``dim``). Each method takes ``sem`` / ``scope`` PTX qualifiers and
+an optional ``output`` register that receives the pre-RMW value — when unused, codegen lowers to
+the cheaper destination-less ``red.*`` form automatically. See
+:doc:`../python-api/instruction-groups/atomic`.
+
+.. currentmodule:: tilus.lang.instructions.atomic.AtomicInstructionGroup
+
+.. autosummary::
+
+   shared_add
+   shared_sub
+   shared_min
+   shared_max
+   shared_exch
+   shared_cas
+   global_add
+   global_sub
+   global_min
+   global_max
+   global_exch
+   global_cas
+   shared_scatter_add
+   shared_scatter_sub
+   shared_scatter_min
+   shared_scatter_max
+   global_scatter_add
+   global_scatter_sub
+   global_scatter_min
+   global_scatter_max
 
 .. currentmodule:: tilus.Script

--- a/docs/source/python-api/instruction-groups/atomic.rst
+++ b/docs/source/python-api/instruction-groups/atomic.rst
@@ -1,0 +1,163 @@
+Script.atomic
+=============
+
+.. currentmodule:: tilus.lang.instructions.atomic
+
+.. autoclass:: AtomicInstructionGroup
+   :no-autosummary:
+   :no-members:
+   :exclude-members: __init__, __new__
+
+
+Element-wise vs. scatter
+------------------------
+
+Two shapes of tile-level atomic RMW are exposed:
+
+**Element-wise** --- :meth:`~AtomicInstructionGroup.shared_add` and friends.
+``dst.shape == values.shape`` and each lane contributes its own slice of
+``values`` into the matching slice of ``dst`` under the chosen PTX
+``atom.*`` op. There is no broadcast and no reduction: this is the right
+primitive when each address is written independently, e.g. updating a
+per-element counter or applying a reduction across thread groups.
+
+.. code-block:: python
+
+   # Each lane contributes its own value to dst[lane]; one atomic op per lane.
+   self.atomic.shared_add(dst, values)
+
+**Scatter** --- :meth:`~AtomicInstructionGroup.shared_scatter_add` and
+friends. Modelled after ``torch.scatter_add_``: a compile-time ``dim`` plus
+an ``indices`` register tile picks the destination along that axis, while
+the non-scatter axes come from the lane's own tile position. This is the
+right primitive for histograms and other data-dependent address patterns.
+
+.. code-block:: python
+
+   # Each lane picks bin = indices[lane] and atomic-adds 1 into that bin.
+   self.atomic.shared_scatter_add(
+       hist, dim=0, indices=bins, values=ones)
+
+
+Op family
+---------
+
+The element-wise family is ``add`` / ``sub`` / ``min`` / ``max`` / ``exch``
+/ ``cas``. The scatter family drops ``exch`` and ``cas`` --- their
+semantics under duplicate indices are not well defined --- and keeps
+``add`` / ``sub`` / ``min`` / ``max``.
+
+PTX has no native ``atom.sub``, so ``sub`` variants lower to ``atom.add``
+with a negated operand at codegen time.
+
+In v1 only the ``int32`` dtype is supported. ``float32`` and ``uint32``
+coverage can be added by extending the dtype table in the underlying hidet
+primitive layer.
+
+
+sem and scope qualifiers
+------------------------
+
+All instructions accept two PTX qualifiers:
+
+- ``sem``: memory-ordering qualifier, one of ``'relaxed'``, ``'acquire'``,
+  ``'release'``, ``'acq_rel'``. Defaults to ``'relaxed'``. Matches the
+  ``atom.{sem}.*`` PTX syntax.
+- ``scope``: sync-scope qualifier, one of ``'cta'``, ``'cluster'``,
+  ``'gpu'``, ``'sys'``. Defaults to ``'cta'`` on shared-memory ops and
+  ``'gpu'`` on global-memory ops.
+
+Both are passed through to the generated ``atom.{sem}.{scope}.{space}.
+{op}.{dtype}`` (or ``red.*``) instruction.
+
+
+Optional output register
+------------------------
+
+Every atomic method accepts an optional ``output`` register tile that
+receives the **pre-RMW** value at each destination location. When the
+returned register is not consumed by any downstream instruction, the DCE
+pass rewrites the instruction to carry ``output=None`` and codegen
+lowers it to the destination-less ``red.*`` PTX form instead of
+``atom.*``. The net effect is that you only pay for the register return
+when your code actually uses it:
+
+.. code-block:: python
+
+   # No caller reads the return value → lowers to `red.*`.
+   self.atomic.shared_scatter_add(hist, dim=0, indices=bins, values=ones)
+
+   # Caller consumes `old` → lowers to `atom.*` with a destination register.
+   old = self.atomic.shared_cas(lock, compare=zero, values=one)
+   with self.if_then(old == 0):
+       ...
+
+``exch`` and ``cas`` have no ``red.*`` counterpart in PTX, so their
+output is effectively always bound --- if unused the register simply goes
+to waste.
+
+
+Related: non-atomic scatter stores
+----------------------------------
+
+When the scatter targets are guaranteed collision-free (e.g. a
+permutation), the cheaper non-atomic variants are available directly on
+``self``:
+
+- :meth:`tilus.Script.store_shared_scatter`
+- :meth:`tilus.Script.store_global_scatter`
+
+They share the same ``dim`` / ``indices`` / ``values`` contract as the
+atomic scatter ops. Under duplicate ``indices`` they give last-writer-wins
+with an unspecified winner; use the atomic form if correctness under
+duplicates matters.
+
+
+Instructions
+------------
+
+.. currentmodule:: tilus.lang.instructions.atomic.AtomicInstructionGroup
+
+.. rubric:: Element-wise (shared memory)
+
+.. autosummary::
+   :toctree: generated
+
+   shared_add
+   shared_sub
+   shared_min
+   shared_max
+   shared_exch
+   shared_cas
+
+.. rubric:: Element-wise (global memory)
+
+.. autosummary::
+   :toctree: generated
+
+   global_add
+   global_sub
+   global_min
+   global_max
+   global_exch
+   global_cas
+
+.. rubric:: Scatter (shared memory)
+
+.. autosummary::
+   :toctree: generated
+
+   shared_scatter_add
+   shared_scatter_sub
+   shared_scatter_min
+   shared_scatter_max
+
+.. rubric:: Scatter (global memory)
+
+.. autosummary::
+   :toctree: generated
+
+   global_scatter_add
+   global_scatter_sub
+   global_scatter_min
+   global_scatter_max

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -106,7 +106,9 @@ Instructions
    square
    squeeze
    store_global
+   store_global_scatter
    store_shared
+   store_shared_scatter
    sum
    sync
    transpose
@@ -128,6 +130,7 @@ Instruction Groups
    instruction-groups/clc
    instruction-groups/cluster
    instruction-groups/wgmma
+   instruction-groups/atomic
 
 .. list-table::
    :widths: 20 80
@@ -146,6 +149,8 @@ Instruction Groups
      - Block cluster synchronization and shared memory access.
    * - :doc:`wgmma <instruction-groups/wgmma>`
      - Warp Group Matrix Multiply-Accumulate (Hopper) instructions.
+   * - :doc:`atomic <instruction-groups/atomic>`
+     - Tile-level atomic RMW (element-wise and scatter) on shared and global memory.
 
 
 Script Attributes

--- a/python/tilus/backends/emitters/__init__.py
+++ b/python/tilus/backends/emitters/__init__.py
@@ -16,6 +16,7 @@
 from . import (
     allocate,
     assign,
+    atomic,
     cast,
     control,
     cuda,
@@ -26,6 +27,7 @@ from . import (
     random,
     reduce,
     regs,
+    scatter_ldst,
     shared_ldst,
     shuffle,
     smem,

--- a/python/tilus/backends/emitters/atomic.py
+++ b/python/tilus/backends/emitters/atomic.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Emitters for element-wise and scatter atomic RMW instructions.
+
+Iterates over each thread's local slice of the input register tile,
+reconstructs the tile-global indices from the register layout, computes the
+destination byte/element offset, and dispatches to the corresponding hidet
+``atom.*`` / ``red.*`` primitive.
+
+When the ``output`` register of an atomic instruction is ``None`` (either
+passed as such by the user or nulled by the DCE pass), the emitter uses the
+destination-less ``red.*`` primitive instead of ``atom.*``.
+
+Supported dtypes in v1: ``int32``.
+
+Non-atomic scatter stores (``StoreSharedScatterInst``/``StoreGlobalScatterInst``)
+live next to the other load/store emitters in
+:mod:`tilus.backends.emitters.scatter_ldst`.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from tilus.backends.emitter import BaseInstEmitter, register_emitter
+from tilus.hidet.ir.dtypes import int32
+from tilus.hidet.ir.expr import Expr, Var, cast, index_vars
+from tilus.hidet.ir.primitives.cuda.atomic_tile import atom_rmw, red_rmw
+from tilus.hidet.ir.tools.rewriter import rewrite
+from tilus.hidet.ir.type import DataType
+from tilus.ir.instructions.cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
+from tilus.ir.layout import RegisterLayout
+from tilus.target import nvgpu_sm70
+
+
+def _append_atomic(
+    emitter: BaseInstEmitter,
+    *,
+    op: str,
+    sem: str,
+    scope: str,
+    space: str,
+    dtype: DataType,
+    addr: Expr,
+    value: Expr,
+    compare: Expr | None,
+    old: Var | None,
+    old_index: Expr | int | None,
+) -> None:
+    """Dispatch one element's atomic op to the right hidet primitive.
+
+    ``old`` is the per-thread register buffer receiving the pre-RMW value, and
+    ``old_index`` is the local element slot to write into. When ``old`` is
+    ``None`` the emitter falls back to the destination-less ``red.*`` form.
+
+    PTX has no ``atom.sub``; we express ``sub`` as ``add`` with a negated
+    operand here, so the primitive side only sees ``add``.
+    """
+    if op == "sub":
+        op = "add"
+        value = -cast(value, dtype)
+
+    if old is None:
+        # Destination-less red.* — also our path for ops (e.g. exch/cas) that
+        # require an output is blocked upstream, so here op is in _RED_OPS.
+        if op in ("exch", "cas"):
+            raise ValueError(f"atom.{op} requires a destination register; output cannot be None")
+        emitter.append(red_rmw(op=op, sem=sem, scope=scope, space=space, dtype=dtype, addr=addr, value=value))
+    else:
+        call = atom_rmw(
+            op=op,
+            sem=sem,
+            scope=scope,
+            space=space,
+            dtype=dtype,
+            addr=addr,
+            value=value,
+            compare=compare,
+        )
+        emitter.buffer_store(buf=old, indices=[old_index], value=call)
+
+
+# ----------------------------------------------------------------------------
+# Element-wise atomics
+# ----------------------------------------------------------------------------
+
+
+@register_emitter(AtomicSharedInst, target=nvgpu_sm70)
+class AtomicSharedInstEmitter(BaseInstEmitter):
+    def emit(self, inst: AtomicSharedInst) -> None:
+        dst = inst.inputs[0].as_shared_tensor()
+        values = inst.inputs[1].as_register_tensor()
+        compare = inst.inputs[2].as_register_tensor() if inst.op == "cas" else None
+
+        dtype: DataType = dst.dtype
+        layout: RegisterLayout = values.layout
+        values_buf: Var = self.get_or_allocate_var(values)
+        compare_buf: Var | None = self.get_or_allocate_var(compare) if compare is not None else None
+        old_buf: Var | None = self.get_or_allocate_var(inst.register_output) if inst.output is not None else None
+
+        # Shared-space base address as a 32-bit int.
+        smem_base = self.declare_var("smem_addr", tp=int32, init=self.shared_tensor_shared_space_addr[dst])
+
+        rank = len(dst.shape)
+        shared_axes = index_vars(num_vars=rank)
+        byte_offset_template: Expr = dst.layout.byte_offset(*shared_axes, nbytes=dtype.nbytes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            rewrite_map = {axis: idx for axis, idx in zip(shared_axes, global_indices)}
+            byte_offset = rewrite(byte_offset_template, rewrite_map=rewrite_map)
+            addr = smem_base + byte_offset
+            _append_atomic(
+                self,
+                op=inst.op,
+                sem=inst.sem,
+                scope=inst.scope,
+                space="shared",
+                dtype=dtype,
+                addr=addr,
+                value=values_buf[i],
+                compare=compare_buf[i] if compare_buf is not None else None,
+                old=old_buf,
+                old_index=i,
+            )
+
+
+@register_emitter(AtomicGlobalInst, target=nvgpu_sm70)
+class AtomicGlobalInstEmitter(BaseInstEmitter):
+    def emit(self, inst: AtomicGlobalInst) -> None:
+        dst = inst.inputs[0].as_global_tensor()
+        values = inst.inputs[1].as_register_tensor()
+        compare = inst.inputs[2].as_register_tensor() if inst.op == "cas" else None
+
+        dtype: DataType = dst.dtype
+        layout: RegisterLayout = values.layout
+        values_buf: Var = self.get_or_allocate_var(values)
+        gmem_buf: Var = self.get_or_allocate_var(dst)
+        compare_buf: Var | None = self.get_or_allocate_var(compare) if compare is not None else None
+        old_buf: Var | None = self.get_or_allocate_var(inst.register_output) if inst.output is not None else None
+
+        rank = len(dst.shape)
+        global_axes = index_vars(num_vars=rank)
+        offset_template: Expr = dst.layout(*global_axes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            rewrite_map = {axis: idx for axis, idx in zip(global_axes, global_indices)}
+            offset = rewrite(offset_template, rewrite_map=rewrite_map)
+            addr = cast(~gmem_buf[offset], ~dtype)
+            _append_atomic(
+                self,
+                op=inst.op,
+                sem=inst.sem,
+                scope=inst.scope,
+                space="global",
+                dtype=dtype,
+                addr=addr,
+                value=values_buf[i],
+                compare=compare_buf[i] if compare_buf is not None else None,
+                old=old_buf,
+                old_index=i,
+            )
+
+
+# ----------------------------------------------------------------------------
+# Scatter atomics
+# ----------------------------------------------------------------------------
+
+
+def _scatter_dst_indices(tile_global_indices: Sequence[Expr], scatter_idx: Expr, dim: int) -> list[Expr]:
+    """Replace ``tile_global_indices[dim]`` with ``scatter_idx`` to form dst indices."""
+    out = list(tile_global_indices)
+    out[dim] = scatter_idx
+    return out
+
+
+@register_emitter(AtomicScatterSharedInst, target=nvgpu_sm70)
+class AtomicScatterSharedInstEmitter(BaseInstEmitter):
+    def emit(self, inst: AtomicScatterSharedInst) -> None:
+        dst = inst.inputs[0].as_shared_tensor()
+        indices = inst.inputs[1].as_register_tensor()
+        values = inst.inputs[2].as_register_tensor()
+
+        dtype: DataType = dst.dtype
+        layout: RegisterLayout = indices.layout
+        indices_buf: Var = self.get_or_allocate_var(indices)
+        values_buf: Var = self.get_or_allocate_var(values)
+        old_buf: Var | None = self.get_or_allocate_var(inst.register_output) if inst.output is not None else None
+
+        smem_base = self.declare_var("smem_addr", tp=int32, init=self.shared_tensor_shared_space_addr[dst])
+
+        rank = len(dst.shape)
+        shared_axes = index_vars(num_vars=rank)
+        byte_offset_template: Expr = dst.layout.byte_offset(*shared_axes, nbytes=dtype.nbytes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            tile_global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            scatter_idx = indices_buf[i]
+            dst_indices = _scatter_dst_indices(tile_global_indices, scatter_idx, inst.dim)
+            rewrite_map = {axis: idx for axis, idx in zip(shared_axes, dst_indices)}
+            byte_offset = rewrite(byte_offset_template, rewrite_map=rewrite_map)
+            addr = smem_base + byte_offset
+            _append_atomic(
+                self,
+                op=inst.op,
+                sem=inst.sem,
+                scope=inst.scope,
+                space="shared",
+                dtype=dtype,
+                addr=addr,
+                value=values_buf[i],
+                compare=None,
+                old=old_buf,
+                old_index=i,
+            )
+
+
+@register_emitter(AtomicScatterGlobalInst, target=nvgpu_sm70)
+class AtomicScatterGlobalInstEmitter(BaseInstEmitter):
+    def emit(self, inst: AtomicScatterGlobalInst) -> None:
+        dst = inst.inputs[0].as_global_tensor()
+        indices = inst.inputs[1].as_register_tensor()
+        values = inst.inputs[2].as_register_tensor()
+
+        dtype: DataType = dst.dtype
+        layout: RegisterLayout = indices.layout
+        indices_buf: Var = self.get_or_allocate_var(indices)
+        values_buf: Var = self.get_or_allocate_var(values)
+        gmem_buf: Var = self.get_or_allocate_var(dst)
+        old_buf: Var | None = self.get_or_allocate_var(inst.register_output) if inst.output is not None else None
+
+        rank = len(dst.shape)
+        global_axes = index_vars(num_vars=rank)
+        offset_template: Expr = dst.layout(*global_axes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            tile_global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            scatter_idx = indices_buf[i]
+            dst_indices = _scatter_dst_indices(tile_global_indices, scatter_idx, inst.dim)
+            rewrite_map = {axis: idx for axis, idx in zip(global_axes, dst_indices)}
+            offset = rewrite(offset_template, rewrite_map=rewrite_map)
+            addr = cast(~gmem_buf[offset], ~dtype)
+            _append_atomic(
+                self,
+                op=inst.op,
+                sem=inst.sem,
+                scope=inst.scope,
+                space="global",
+                dtype=dtype,
+                addr=addr,
+                value=values_buf[i],
+                compare=None,
+                old=old_buf,
+                old_index=i,
+            )

--- a/python/tilus/backends/emitters/scatter_ldst.py
+++ b/python/tilus/backends/emitters/scatter_ldst.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Emitters for non-atomic scatter stores.
+
+``StoreSharedScatterInst`` / ``StoreGlobalScatterInst`` are plain stores — each
+lane writes its ``values[k]`` into ``dst[..., indices[k], ...]`` at the tile's
+non-scatter global position. Duplicate indices give last-writer-wins; callers
+who need well-defined behaviour under duplicates should use the atomic scatter
+variants (emitters in :mod:`tilus.backends.emitters.atomic`).
+
+The emitters sit next to the regular load/store emitters rather than under the
+atomic namespace, matching the IR placement in :mod:`tilus.ir.instructions.generic`.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from tilus.backends.emitter import BaseInstEmitter, register_emitter
+from tilus.hidet.ir.expr import Expr, Var, index_vars
+from tilus.hidet.ir.tools.rewriter import rewrite
+from tilus.ir.instructions import StoreGlobalScatterInst, StoreSharedScatterInst
+from tilus.ir.layout import RegisterLayout
+
+
+def _scatter_dst_indices(tile_global_indices: Sequence[Expr], scatter_idx: Expr, dim: int) -> list[Expr]:
+    """Replace ``tile_global_indices[dim]`` with ``scatter_idx`` to form dst indices."""
+    out = list(tile_global_indices)
+    out[dim] = scatter_idx
+    return out
+
+
+@register_emitter(StoreSharedScatterInst)
+class StoreSharedScatterInstEmitter(BaseInstEmitter):
+    def emit(self, inst: StoreSharedScatterInst) -> None:
+        dst = inst.inputs[0].as_shared_tensor()
+        indices = inst.inputs[1].as_register_tensor()
+        values = inst.inputs[2].as_register_tensor()
+
+        layout: RegisterLayout = indices.layout
+        indices_buf: Var = self.get_or_allocate_var(indices)
+        values_buf: Var = self.get_or_allocate_var(values)
+        smem_buf: Var = self.get_or_allocate_var(dst)
+
+        rank = len(dst.shape)
+        shared_axes = index_vars(num_vars=rank)
+        offset_template: Expr = dst.layout(*shared_axes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            tile_global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            scatter_idx = indices_buf[i]
+            dst_indices = _scatter_dst_indices(tile_global_indices, scatter_idx, inst.dim)
+            rewrite_map = {axis: idx for axis, idx in zip(shared_axes, dst_indices)}
+            offset = rewrite(offset_template, rewrite_map=rewrite_map)
+            self.buffer_store(buf=smem_buf, indices=[offset], value=values_buf[i])
+
+
+@register_emitter(StoreGlobalScatterInst)
+class StoreGlobalScatterInstEmitter(BaseInstEmitter):
+    def emit(self, inst: StoreGlobalScatterInst) -> None:
+        dst = inst.inputs[0].as_global_tensor()
+        indices = inst.inputs[1].as_register_tensor()
+        values = inst.inputs[2].as_register_tensor()
+
+        layout: RegisterLayout = indices.layout
+        indices_buf: Var = self.get_or_allocate_var(indices)
+        values_buf: Var = self.get_or_allocate_var(values)
+        gmem_buf: Var = self.get_or_allocate_var(dst)
+
+        rank = len(dst.shape)
+        global_axes = index_vars(num_vars=rank)
+        offset_template: Expr = dst.layout(*global_axes)
+
+        with self.for_range(layout.local_size, attr="u") as i:
+            tile_global_indices = layout.get_global(local_index=i, spatial_index=self.current_thread)
+            scatter_idx = indices_buf[i]
+            dst_indices = _scatter_dst_indices(tile_global_indices, scatter_idx, inst.dim)
+            rewrite_map = {axis: idx for axis, idx in zip(global_axes, dst_indices)}
+            offset = rewrite(offset_template, rewrite_map=rewrite_map)
+            self.buffer_store(buf=gmem_buf, indices=[offset], value=values_buf[i])

--- a/python/tilus/hidet/ir/primitives/cuda/atomic_tile.py
+++ b/python/tilus/hidet/ir/primitives/cuda/atomic_tile.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PTX ``atom.*`` and ``red.*`` primitives for tile-level atomic instructions.
+
+Each call lazily registers the underlying hidet primitive the first time a
+given ``(op, sem, scope, space, dtype, form)`` combination is needed. This
+keeps the registry footprint proportional to what the compiled program
+actually uses rather than eagerly enumerating all variants.
+
+Form:
+- ``atom_rmw(...)`` → emits ``atom.{sem}.{scope}.{space}.{op}.{dtype}`` and
+  returns the old value as an ``Expr``. Supports ``op`` in ``add / min / max /
+  exch`` and ``op="cas"`` with an extra ``compare`` argument.
+- ``red_rmw(...)`` → emits the destination-less ``red.{sem}.{scope}.{space}.
+  {op}.{dtype}`` and returns a void call. Supports ``add / min / max`` only
+  (PTX ``red.*`` does not define ``exch`` or ``cas``).
+
+Address types:
+- ``space="global"`` → ``addr`` is typed as ``~dtype`` (a 64-bit generic
+  pointer), which hidet's asm constraint mapper translates to ``"l"``.
+- ``space="shared"`` → ``addr`` is typed as ``uint32`` (the 32-bit shared-
+  space integer address produced by ``cvta.to.shared.u32``), which maps to
+  ``"r"``.
+
+Supported dtypes in v1: ``int32`` and ``uint32``. Extending to ``float32`` or
+``float64`` is a matter of adding entries to :data:`_PTX_DTYPE_SUFFIX`.
+
+Note: ``from __future__ import annotations`` is intentionally NOT used in
+this module because hidet's ``@script`` decorator inspects parameter type
+annotations at decoration time and does not support string-form annotations.
+"""
+
+from typing import Dict, FrozenSet, Optional
+
+from tilus.hidet.ir.dtypes import uint32
+from tilus.hidet.ir.expr import Expr
+from tilus.hidet.ir.primitives.func import call_primitive_func, is_primitive_function, register_primitive_function
+from tilus.hidet.ir.type import DataType
+
+# Map hidet DataType.name -> PTX dtype suffix. Note that hidet's `short_name`
+# uses `i32` for signed ints whereas PTX spells it `s32`, so we keep our own
+# mapping table instead of relying on `short_name`.
+_PTX_DTYPE_SUFFIX: Dict[str, str] = {
+    "int32": "s32",
+    "uint32": "u32",
+}
+
+# Allowed PTX memory-ordering semantics / sync scopes / state spaces.
+_SEMS: FrozenSet[str] = frozenset({"relaxed", "acquire", "release", "acq_rel"})
+_SCOPES: FrozenSet[str] = frozenset({"cta", "cluster", "gpu", "sys"})
+_SPACES: FrozenSet[str] = frozenset({"global", "shared"})
+
+# Ops expressible by `red.*` (destination-less). `exch`/`cas` always need an
+# output register, so they only ride on `atom.*`.
+_RED_OPS: FrozenSet[str] = frozenset({"add", "min", "max"})
+
+
+def _atom_func_name(op: str, sem: str, scope: str, space: str, dtype_name: str, form: str) -> str:
+    # form is one of: "atom", "red", "cas"
+    return f"cuda_{form}_{op}_{sem}_{scope}_{space}_{dtype_name}"
+
+
+def _check(op: str, sem: str, scope: str, space: str, dtype: DataType) -> None:
+    if sem not in _SEMS:
+        raise ValueError(f"atom/red sem must be one of {sorted(_SEMS)}, got {sem!r}")
+    if scope not in _SCOPES:
+        raise ValueError(f"atom/red scope must be one of {sorted(_SCOPES)}, got {scope!r}")
+    if space not in _SPACES:
+        raise ValueError(f"atom/red space must be one of {sorted(_SPACES)}, got {space!r}")
+    if dtype.name not in _PTX_DTYPE_SUFFIX:
+        raise NotImplementedError(
+            f"atom/red on dtype {dtype.name!r} is not supported yet. Supported: {sorted(_PTX_DTYPE_SUFFIX)}"
+        )
+
+
+def _register_if_needed(
+    *,
+    op: str,
+    sem: str,
+    scope: str,
+    space: str,
+    dtype: DataType,
+    form: str,  # "atom" | "red" | "cas"
+) -> str:
+    """Register the primitive for this (op, sem, scope, space, dtype, form) if not already, return the name."""
+    from tilus.hidet.lang import asm, attrs, script
+
+    _check(op, sem, scope, space, dtype)
+    dt_suffix = _PTX_DTYPE_SUFFIX[dtype.name]
+    func_name = _atom_func_name(op, sem, scope, space, dtype.name, form)
+    if is_primitive_function(func_name):
+        return func_name
+
+    # Build the PTX template.
+    if form == "cas":
+        template = f"atom.{sem}.{scope}.{space}.cas.{dt_suffix} %0, [%1], %2, %3;"
+    elif form == "atom":
+        template = f"atom.{sem}.{scope}.{space}.{op}.{dt_suffix} %0, [%1], %2;"
+    elif form == "red":
+        if op not in _RED_OPS:
+            raise ValueError(f"red.* does not support op={op!r}; supported: {sorted(_RED_OPS)}")
+        template = f"red.{sem}.{scope}.{space}.{op}.{dt_suffix} [%0], %1;"
+    else:
+        raise ValueError(f"unknown form {form!r}")
+
+    # Emit the @script function. Closures over `template`, `func_name`, and
+    # `dtype` are baked in at decoration time; `addr` type differs per space.
+    if space == "global":
+        if form == "cas":
+
+            @script
+            def func(addr: ~dtype, cmp_val: dtype, new_val: dtype) -> dtype:
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                ret = dtype.zero
+                asm(template, outputs=[ret], inputs=[addr, cmp_val, new_val], is_volatile=True)
+                return ret
+
+        elif form == "atom":
+
+            @script
+            def func(addr: ~dtype, v: dtype) -> dtype:
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                ret = dtype.zero
+                asm(template, outputs=[ret], inputs=[addr, v], is_volatile=True)
+                return ret
+
+        else:  # red
+
+            @script
+            def func(addr: ~dtype, v: dtype):
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                asm(template, inputs=[addr, v], is_volatile=True)
+
+    else:  # shared: addr is uint32 (shared-space address)
+        if form == "cas":
+
+            @script
+            def func(addr: uint32, cmp_val: dtype, new_val: dtype) -> dtype:
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                ret = dtype.zero
+                asm(template, outputs=[ret], inputs=[addr, cmp_val, new_val], is_volatile=True)
+                return ret
+
+        elif form == "atom":
+
+            @script
+            def func(addr: uint32, v: dtype) -> dtype:
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                ret = dtype.zero
+                asm(template, outputs=[ret], inputs=[addr, v], is_volatile=True)
+                return ret
+
+        else:  # red
+
+            @script
+            def func(addr: uint32, v: dtype):
+                attrs.func_kind = "cuda_internal"
+                attrs.func_name = func_name
+                asm(template, inputs=[addr, v], is_volatile=True)
+
+    register_primitive_function(name=func_name, func_or_type=func)
+    return func_name
+
+
+def atom_rmw(
+    *,
+    op: str,
+    sem: str,
+    scope: str,
+    space: str,
+    dtype: DataType,
+    addr: Expr,
+    value: Expr,
+    compare: Optional[Expr] = None,
+) -> Expr:
+    """Emit ``atom.{sem}.{scope}.{space}.{op}.{dtype}`` returning the old value.
+
+    For ``op="cas"`` pass the compare operand; it is rejected for every other op.
+    """
+    if op == "cas":
+        if compare is None:
+            raise ValueError("atom.cas requires a compare operand")
+        name = _register_if_needed(op=op, sem=sem, scope=scope, space=space, dtype=dtype, form="cas")
+        return call_primitive_func(name, [addr, compare, value])
+    if compare is not None:
+        raise ValueError(f"compare is only valid for op='cas', got op={op!r}")
+    name = _register_if_needed(op=op, sem=sem, scope=scope, space=space, dtype=dtype, form="atom")
+    return call_primitive_func(name, [addr, value])
+
+
+def red_rmw(
+    *,
+    op: str,
+    sem: str,
+    scope: str,
+    space: str,
+    dtype: DataType,
+    addr: Expr,
+    value: Expr,
+) -> Expr:
+    """Emit the destination-less ``red.{sem}.{scope}.{space}.{op}.{dtype}``.
+
+    Supported ops: ``add``, ``min``, ``max``. Returns a void call expression the
+    caller should ``append`` into the current scope.
+    """
+    name = _register_if_needed(op=op, sem=sem, scope=scope, space=space, dtype=dtype, form="red")
+    return call_primitive_func(name, [addr, value])

--- a/python/tilus/ir/builders/stmt_builder.py
+++ b/python/tilus/ir/builders/stmt_builder.py
@@ -24,6 +24,12 @@ from tilus.hidet.ir.type import BaseType, DataType
 from tilus.hidet.ir.utils import broadcast_shapes, can_broadcast
 from tilus.hidet.utils import prod, same_list
 from tilus.ir.inst import Instruction, InstructionError
+from tilus.ir.instructions.cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
 from tilus.ir.instructions.cuda.clc import ClusterLaunchControlQueryResponseInst, ClusterLaunchControlTryCancelInst
 from tilus.ir.instructions.cuda.cluster_sync import ClusterSyncThreadsInst
 from tilus.ir.instructions.cuda.cp_async import (
@@ -111,7 +117,9 @@ from tilus.ir.instructions.generic import (
     SqueezeInst,
     StoreGlobalGenericInst,
     StoreGlobalInst,
+    StoreGlobalScatterInst,
     StoreSharedInst,
+    StoreSharedScatterInst,
     SubInst,
     SyncReduceThreadsInst,
     SyncThreadsInst,
@@ -1185,6 +1193,17 @@ class StmtBuilder(StmtBuilderCore):
         inst = StoreSharedInst.create(dst=dst, src=src)
         self.append(inst)
 
+    def store_shared_scatter(
+        self,
+        dst: SharedTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+    ) -> None:
+        inst = StoreSharedScatterInst.create(dst=dst, indices=indices, values=values, dim=dim)
+        self.append(inst)
+
     # global memory operations
     def global_view(self, ptr: Expr, dtype: DataType, layout: GlobalLayout) -> GlobalTensor:
         inst = GlobalViewInst.create(output=GlobalTensor.create(dtype=dtype, layout=layout), ptr=ptr)
@@ -1227,6 +1246,17 @@ class StmtBuilder(StmtBuilderCore):
         inst = StoreGlobalInst.create(dst=dst, x=src, offsets=[as_expr(ofs) for ofs in offsets], dims=dims)
         self.append(inst)
 
+    def store_global_scatter(
+        self,
+        dst: GlobalTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+    ) -> None:
+        inst = StoreGlobalScatterInst.create(dst=dst, indices=indices, values=values, dim=dim)
+        self.append(inst)
+
     def store_global_generic(
         self,
         x: RegisterTensor,
@@ -1254,6 +1284,115 @@ class StmtBuilder(StmtBuilderCore):
         inst = LoadGlobalGenericInst.create(ptr=ptr, f_offset=f_offset, f_mask=f_mask, output=out)
         self.append(inst)
         return inst.register_output
+
+    # atomic operations
+    def atomic_shared(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+        compare: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        if output is None:
+            output = RegisterTensor.create(dtype=dst.dtype, shape=dst.shape, optional_layout=values.optional_layout)
+        inst = AtomicSharedInst.create(
+            dst=dst,
+            values=values,
+            op=op,
+            sem=sem,
+            scope=scope,
+            output=output,
+            compare=compare,
+        )
+        self.append(inst)
+        return inst.register_output if inst.output is not None else None
+
+    def atomic_global(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+        compare: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        if output is None:
+            output = RegisterTensor.create(dtype=dst.dtype, shape=dst.shape, optional_layout=values.optional_layout)
+        inst = AtomicGlobalInst.create(
+            dst=dst,
+            values=values,
+            op=op,
+            sem=sem,
+            scope=scope,
+            output=output,
+            compare=compare,
+        )
+        self.append(inst)
+        return inst.register_output if inst.output is not None else None
+
+    def atomic_shared_scatter(
+        self,
+        dst: SharedTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        if output is None:
+            output = RegisterTensor.create(
+                dtype=dst.dtype, shape=indices.shape, optional_layout=indices.optional_layout
+            )
+        inst = AtomicScatterSharedInst.create(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op=op,
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+        self.append(inst)
+        return inst.register_output if inst.output is not None else None
+
+    def atomic_global_scatter(
+        self,
+        dst: GlobalTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        if output is None:
+            output = RegisterTensor.create(
+                dtype=dst.dtype, shape=indices.shape, optional_layout=indices.optional_layout
+            )
+        inst = AtomicScatterGlobalInst.create(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op=op,
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+        self.append(inst)
+        return inst.register_output if inst.output is not None else None
 
     # semaphore
     def lock_semaphore(self, semaphore: Expr, value: Expr | int) -> None:

--- a/python/tilus/ir/instructions/__init__.py
+++ b/python/tilus/ir/instructions/__init__.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 from tilus.ir.inst import Instruction
 
+from .cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
 from .cuda.cluster_sync import ClusterSyncThreadsInst
 from .cuda.cp_async import (
     CopyAsyncCommitGroupInst,
@@ -69,7 +75,9 @@ from .generic import (
     SqueezeInst,
     StoreGlobalGenericInst,
     StoreGlobalInst,
+    StoreGlobalScatterInst,
     StoreSharedInst,
+    StoreSharedScatterInst,
     SubInst,
     SyncReduceThreadsInst,
     SyncThreadsInst,

--- a/python/tilus/ir/instructions/cuda/atomic.py
+++ b/python/tilus/ir/instructions/cuda/atomic.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tile-level atomic RMW instructions (element-wise and scatter).
+
+The non-atomic scatter-store siblings (``StoreGlobalScatterInst`` /
+``StoreSharedScatterInst``) live in :mod:`tilus.ir.instructions.generic` next
+to the regular store instructions, since they are plain stores rather than
+atomics. The shape-validation helper they share with the atomic scatter
+variants is :func:`tilus.ir.instructions.generic.check_scatter_shapes`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from tilus.ir.inst import Instruction, InstructionError
+from tilus.ir.instructions.generic import check_scatter_shapes
+from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor
+
+# Allowed RMW opcodes shared by element-wise and scatter atomic instructions.
+ATOMIC_OPS: tuple[str, ...] = ("add", "sub", "min", "max", "exch", "cas")
+# Allowed PTX memory-ordering semantics.
+ATOMIC_SEMS: tuple[str, ...] = ("relaxed", "acquire", "release", "acq_rel")
+# Allowed PTX sync scopes.
+ATOMIC_SCOPES: tuple[str, ...] = ("cta", "cluster", "gpu", "sys")
+
+
+def _check_op_sem_scope(op: str, sem: str, scope: str) -> None:
+    if op not in ATOMIC_OPS:
+        raise InstructionError(f"atomic op must be one of {ATOMIC_OPS}, got {op!r}")
+    if sem not in ATOMIC_SEMS:
+        raise InstructionError(f"atomic sem must be one of {ATOMIC_SEMS}, got {sem!r}")
+    if scope not in ATOMIC_SCOPES:
+        raise InstructionError(f"atomic scope must be one of {ATOMIC_SCOPES}, got {scope!r}")
+
+
+@dataclass(frozen=True, eq=False)
+class AtomicSharedInst(Instruction):
+    """Element-wise atomic RMW on a shared tensor.
+
+    For each logical element i of ``dst``, performs ``dst[i] = op(dst[i], values[i])``
+    atomically. ``dst.shape`` and ``values.shape`` must be equal, and the register
+    layout of ``values`` must match ``dst``'s shared layout element-for-element.
+
+    The optional ``output`` register tensor receives the per-element pre-RMW values
+    of ``dst``. When ``output`` is ``None`` (set by DCE or the user), codegen emits
+    the destination-less PTX form.
+
+    Extra inputs for the ``cas`` opcode (``dst = (dst == compare) ? values : dst``):
+    pass ``compare`` as the third input tensor.
+    """
+
+    op: str
+    sem: str
+    scope: str
+    VALID_OPS: ClassVar[tuple[str, ...]] = ATOMIC_OPS
+
+    @staticmethod
+    def create(
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+        compare: Optional[RegisterTensor] = None,
+    ) -> AtomicSharedInst:
+        _check_op_sem_scope(op, sem, scope)
+        if dst.dtype != values.dtype:
+            raise InstructionError(
+                f"atomic_shared_{op}: dst dtype {dst.dtype.name} != values dtype {values.dtype.name}"
+            )
+        if tuple(dst.shape) != tuple(values.shape):
+            raise InstructionError(
+                f"atomic_shared_{op}: dst shape {list(dst.shape)} != values shape {list(values.shape)}"
+            )
+        if op == "cas":
+            if compare is None:
+                raise InstructionError("atomic_shared_cas requires a compare tensor")
+            if compare.dtype != dst.dtype or tuple(compare.shape) != tuple(dst.shape):
+                raise InstructionError(
+                    f"atomic_shared_cas: compare must match dst in dtype/shape, got "
+                    f"{compare.dtype.name}{list(compare.shape)} vs {dst.dtype.name}{list(dst.shape)}"
+                )
+            inputs: tuple = (dst, values, compare)
+        else:
+            if compare is not None:
+                raise InstructionError(f"atomic_shared_{op}: compare is only valid for op='cas'")
+            inputs = (dst, values)
+        return AtomicSharedInst(output=output, inputs=inputs, op=op, sem=sem, scope=scope)
+
+
+@dataclass(frozen=True, eq=False)
+class AtomicGlobalInst(Instruction):
+    """Element-wise atomic RMW on a global tensor. Semantics mirror ``AtomicSharedInst``."""
+
+    op: str
+    sem: str
+    scope: str
+    VALID_OPS: ClassVar[tuple[str, ...]] = ATOMIC_OPS
+
+    @staticmethod
+    def create(
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+        compare: Optional[RegisterTensor] = None,
+    ) -> AtomicGlobalInst:
+        _check_op_sem_scope(op, sem, scope)
+        if dst.dtype != values.dtype:
+            raise InstructionError(
+                f"atomic_global_{op}: dst dtype {dst.dtype.name} != values dtype {values.dtype.name}"
+            )
+        if tuple(dst.shape) != tuple(values.shape):
+            raise InstructionError(
+                f"atomic_global_{op}: dst shape {list(dst.shape)} != values shape {list(values.shape)}"
+            )
+        if op == "cas":
+            if compare is None:
+                raise InstructionError("atomic_global_cas requires a compare tensor")
+            if compare.dtype != dst.dtype or tuple(compare.shape) != tuple(dst.shape):
+                raise InstructionError(
+                    f"atomic_global_cas: compare must match dst in dtype/shape, got "
+                    f"{compare.dtype.name}{list(compare.shape)} vs {dst.dtype.name}{list(dst.shape)}"
+                )
+            inputs: tuple = (dst, values, compare)
+        else:
+            if compare is not None:
+                raise InstructionError(f"atomic_global_{op}: compare is only valid for op='cas'")
+            inputs = (dst, values)
+        return AtomicGlobalInst(output=output, inputs=inputs, op=op, sem=sem, scope=scope)
+
+
+@dataclass(frozen=True, eq=False)
+class AtomicScatterSharedInst(Instruction):
+    """Scatter atomic RMW on a shared tensor.
+
+    For each tile element k in ``indices``/``values``, performs
+    ``dst[..., indices[k], ...] = op(dst[..., indices[k], ...], values[k])``
+    atomically, where ``indices`` picks positions along ``dim``.
+
+    ``indices.shape == values.shape`` strictly, with identical RegisterLayout.
+    Non-``dim`` axes of ``dst`` must match the corresponding axes of ``indices``;
+    along ``dim``, ``dst.shape[dim]`` can be larger than ``indices.shape[dim]``.
+    Out-of-range index values are undefined (no runtime bounds check).
+
+    The optional ``output`` register tensor has shape ``indices.shape`` and
+    receives the per-element pre-RMW values at each scattered location. CAS and
+    exchange are not supported in the scatter form (semantics under duplicate
+    indices are unclear); use the element-wise variant instead.
+    """
+
+    op: str
+    dim: int
+    sem: str
+    scope: str
+    VALID_OPS: ClassVar[tuple[str, ...]] = ("add", "sub", "min", "max")
+
+    @staticmethod
+    def create(
+        dst: SharedTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> AtomicScatterSharedInst:
+        if op not in AtomicScatterSharedInst.VALID_OPS:
+            raise InstructionError(
+                f"atomic_shared_scatter op must be one of {AtomicScatterSharedInst.VALID_OPS}, got {op!r}"
+            )
+        if sem not in ATOMIC_SEMS:
+            raise InstructionError(f"atomic sem must be one of {ATOMIC_SEMS}, got {sem!r}")
+        if scope not in ATOMIC_SCOPES:
+            raise InstructionError(f"atomic scope must be one of {ATOMIC_SCOPES}, got {scope!r}")
+        check_scatter_shapes(
+            "atomic_shared_scatter", dst_shape=dst.shape, dst_dtype=dst.dtype, indices=indices, values=values, dim=dim
+        )
+        return AtomicScatterSharedInst(
+            output=output,
+            inputs=(dst, indices, values),
+            op=op,
+            dim=dim,
+            sem=sem,
+            scope=scope,
+        )
+
+
+@dataclass(frozen=True, eq=False)
+class AtomicScatterGlobalInst(Instruction):
+    """Scatter atomic RMW on a global tensor. Semantics mirror ``AtomicScatterSharedInst``."""
+
+    op: str
+    dim: int
+    sem: str
+    scope: str
+    VALID_OPS: ClassVar[tuple[str, ...]] = ("add", "sub", "min", "max")
+
+    @staticmethod
+    def create(
+        dst: GlobalTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> AtomicScatterGlobalInst:
+        if op not in AtomicScatterGlobalInst.VALID_OPS:
+            raise InstructionError(
+                f"atomic_global_scatter op must be one of {AtomicScatterGlobalInst.VALID_OPS}, got {op!r}"
+            )
+        if sem not in ATOMIC_SEMS:
+            raise InstructionError(f"atomic sem must be one of {ATOMIC_SEMS}, got {sem!r}")
+        if scope not in ATOMIC_SCOPES:
+            raise InstructionError(f"atomic scope must be one of {ATOMIC_SCOPES}, got {scope!r}")
+        check_scatter_shapes(
+            "atomic_global_scatter", dst_shape=dst.shape, dst_dtype=dst.dtype, indices=indices, values=values, dim=dim
+        )
+        return AtomicScatterGlobalInst(
+            output=output,
+            inputs=(dst, indices, values),
+            op=op,
+            dim=dim,
+            sem=sem,
+            scope=scope,
+        )

--- a/python/tilus/ir/instructions/generic.py
+++ b/python/tilus/ir/instructions/generic.py
@@ -22,7 +22,7 @@ from tilus.hidet.ir import primitives
 from tilus.hidet.ir.dtypes import DataType, boolean, i32
 from tilus.hidet.ir.expr import Expr, Var, as_expr, index_vars
 from tilus.hidet.ir.tools import rewrite
-from tilus.ir.inst import Instruction
+from tilus.ir.inst import Instruction, InstructionError
 from tilus.ir.layout import RegisterLayout
 from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor, Tensor
 
@@ -122,6 +122,96 @@ class StoreSharedInst(Instruction):
     @staticmethod
     def create(dst: SharedTensor, src: RegisterTensor) -> StoreSharedInst:
         return StoreSharedInst(output=None, inputs=(dst, src))
+
+
+def check_scatter_shapes(
+    ctx: str,
+    *,
+    dst_shape: Sequence,
+    dst_dtype: DataType,
+    indices: RegisterTensor,
+    values: RegisterTensor,
+    dim: int,
+) -> None:
+    """Validate scatter instruction shapes.
+
+    Shared by :class:`StoreSharedScatterInst` / :class:`StoreGlobalScatterInst`
+    and their atomic variants. The rules are identical regardless of atomicity:
+    ``indices.shape == values.shape`` strictly, ranks match ``dst``, non-scatter
+    axes are size-equal, and ``dim`` is in range.
+    """
+    if dst_dtype != values.dtype:
+        raise InstructionError(f"{ctx}: dst dtype {dst_dtype.name} != values dtype {values.dtype.name}")
+    if tuple(indices.shape) != tuple(values.shape):
+        raise InstructionError(f"{ctx}: indices.shape {list(indices.shape)} != values.shape {list(values.shape)}")
+    if len(dst_shape) != len(indices.shape):
+        raise InstructionError(f"{ctx}: dst rank {len(dst_shape)} != indices rank {len(indices.shape)}")
+    if not (0 <= dim < len(dst_shape)):
+        raise InstructionError(f"{ctx}: dim {dim} out of range for rank-{len(dst_shape)} dst")
+    for d in range(len(dst_shape)):
+        if d == dim:
+            continue
+        if int(dst_shape[d]) != int(indices.shape[d]):
+            raise InstructionError(
+                f"{ctx}: non-scatter axis {d} mismatch, dst.shape[{d}]={dst_shape[d]}, "
+                f"indices.shape[{d}]={indices.shape[d]}"
+            )
+
+
+@dataclass(frozen=True, eq=False)
+class StoreSharedScatterInst(Instruction):
+    """Non-atomic scatter store into a shared tensor.
+
+    For each tile element k: ``dst[..., indices[k], ...] = values[k]``.
+    Semantics under duplicate ``indices`` is last-writer-wins (undefined which
+    lane wins); use an atomic scatter op if correctness under duplicates is
+    required.
+    """
+
+    dim: int
+
+    @staticmethod
+    def create(
+        dst: SharedTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+    ) -> StoreSharedScatterInst:
+        check_scatter_shapes(
+            "store_shared_scatter",
+            dst_shape=dst.shape,
+            dst_dtype=dst.dtype,
+            indices=indices,
+            values=values,
+            dim=dim,
+        )
+        return StoreSharedScatterInst(output=None, inputs=(dst, indices, values), dim=dim)
+
+
+@dataclass(frozen=True, eq=False)
+class StoreGlobalScatterInst(Instruction):
+    """Non-atomic scatter store into a global tensor. Semantics mirror :class:`StoreSharedScatterInst`."""
+
+    dim: int
+
+    @staticmethod
+    def create(
+        dst: GlobalTensor,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        dim: int,
+    ) -> StoreGlobalScatterInst:
+        check_scatter_shapes(
+            "store_global_scatter",
+            dst_shape=dst.shape,
+            dst_dtype=dst.dtype,
+            indices=indices,
+            values=values,
+            dim=dim,
+        )
+        return StoreGlobalScatterInst(output=None, inputs=(dst, indices, values), dim=dim)
 
 
 @dataclass(frozen=True, eq=False)

--- a/python/tilus/ir/layout/inference/inference_rules/__init__.py
+++ b/python/tilus/ir/layout/inference/inference_rules/__init__.py
@@ -15,6 +15,7 @@
 from . import (
     allocate_shared,
     assign,
+    atomic,
     cp_async,
     elementwise_binary,
     elementwise_unary,
@@ -26,6 +27,7 @@ from . import (
     philox,
     reduce,
     reshape_shared,
+    scatter,
     slice_register,
     store_shared,
     tcgen05,

--- a/python/tilus/ir/layout/inference/inference_rules/atomic.py
+++ b/python/tilus/ir/layout/inference/inference_rules/atomic.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Layout inference for element-wise atomic RMW instructions.
+
+Scatter variants (atomic and non-atomic) use the same layout rule; that rule
+lives in :mod:`.scatter` since it applies equally to the non-atomic stores.
+
+For the element-wise atomics handled here: ``values``, the optional ``output``,
+and the ``compare`` tensor for ``cas`` all share a single RegisterLayout so
+each lane reads its own element at the same local index.
+
+The rule picks ``auto_local_spatial`` over the ``values`` shape as a
+reasonable default; downstream analyses or a user-supplied ``annotate_layout``
+can still pin a different layout.
+"""
+
+from __future__ import annotations
+
+from tilus.ir.instructions import AtomicGlobalInst, AtomicSharedInst
+from tilus.ir.layout import RegisterLayout
+from tilus.ir.layout.inference.rule import LayoutInferenceContext, LayoutInferenceRule, register_rule
+from tilus.ir.layout.ops.register_ops import auto_local_spatial
+from tilus.ir.tensor import RegisterTensor
+
+
+def _choose_layout(tensor: RegisterTensor, num_threads: int) -> RegisterLayout:
+    if tensor.optional_layout:
+        return tensor.optional_layout
+    return auto_local_spatial(num_threads=num_threads, shape=list(tensor.shape))
+
+
+@register_rule(AtomicSharedInst)
+@register_rule(AtomicGlobalInst)
+class AtomicElementWiseRule(LayoutInferenceRule):
+    @staticmethod
+    def inference(
+        ctx: LayoutInferenceContext, inst: AtomicSharedInst | AtomicGlobalInst
+    ) -> dict[RegisterTensor, RegisterLayout]:
+        values = inst.inputs[1].as_register_tensor()
+        layout = _choose_layout(values, ctx.num_threads)
+        out: dict[RegisterTensor, RegisterLayout] = {values: layout}
+        if inst.output is not None:
+            out[inst.register_output] = layout
+        # cas carries a third tensor (compare) that must share the layout too.
+        if inst.op == "cas":
+            compare = inst.inputs[2].as_register_tensor()
+            out[compare] = layout
+        return out

--- a/python/tilus/ir/layout/inference/inference_rules/scatter.py
+++ b/python/tilus/ir/layout/inference/inference_rules/scatter.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Layout inference for scatter instructions (atomic and non-atomic).
+
+All four variants (``AtomicScatterSharedInst``, ``AtomicScatterGlobalInst``,
+``StoreSharedScatterInst``, ``StoreGlobalScatterInst``) need the same rule:
+``indices``, ``values``, and the optional ``output`` must share a single
+RegisterLayout so each lane reads its own element at the same local index
+across all three tensors.
+
+The rule picks ``auto_local_spatial`` over the ``indices`` shape as a
+reasonable default; downstream analyses or a user-supplied ``annotate_layout``
+can still pin a different layout.
+"""
+
+from __future__ import annotations
+
+from tilus.ir.instructions import (
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    StoreGlobalScatterInst,
+    StoreSharedScatterInst,
+)
+from tilus.ir.layout import RegisterLayout
+from tilus.ir.layout.inference.rule import LayoutInferenceContext, LayoutInferenceRule, register_rule
+from tilus.ir.layout.ops.register_ops import auto_local_spatial
+from tilus.ir.tensor import RegisterTensor
+
+
+def _choose_layout(tensor: RegisterTensor, num_threads: int) -> RegisterLayout:
+    if tensor.optional_layout:
+        return tensor.optional_layout
+    return auto_local_spatial(num_threads=num_threads, shape=list(tensor.shape))
+
+
+@register_rule(AtomicScatterSharedInst)
+@register_rule(AtomicScatterGlobalInst)
+@register_rule(StoreSharedScatterInst)
+@register_rule(StoreGlobalScatterInst)
+class ScatterRule(LayoutInferenceRule):
+    @staticmethod
+    def inference(
+        ctx: LayoutInferenceContext,
+        inst: (AtomicScatterSharedInst | AtomicScatterGlobalInst | StoreSharedScatterInst | StoreGlobalScatterInst),
+    ) -> dict[RegisterTensor, RegisterLayout]:
+        indices = inst.inputs[1].as_register_tensor()
+        values = inst.inputs[2].as_register_tensor()
+        layout = _choose_layout(indices, ctx.num_threads)
+        out: dict[RegisterTensor, RegisterLayout] = {indices: layout, values: layout}
+        # Atomic scatter variants carry an optional output; non-atomic store
+        # variants do not.
+        if getattr(inst, "output", None) is not None:
+            out[inst.register_output] = layout
+        return out

--- a/python/tilus/ir/layout/inference/order.py
+++ b/python/tilus/ir/layout/inference/order.py
@@ -19,6 +19,7 @@ from tilus.utils import initialize
 
 from .inference_rules.allocate_shared import AllocateSharedRule
 from .inference_rules.assign import AssignRule
+from .inference_rules.atomic import AtomicElementWiseRule
 from .inference_rules.clc import ClusterLaunchControlQueryResponseInstRule, ClusterLaunchControlTryCancelInstRule
 from .inference_rules.cp_async import CopyAsyncRule
 from .inference_rules.elementwise_binary import BinaryRule
@@ -37,6 +38,7 @@ from .inference_rules.mma_dot import MmaDotRule
 from .inference_rules.philox import Philox4x32InferenceRule
 from .inference_rules.reduce import ReduceRule
 from .inference_rules.reshape_shared import ReshapeSharedRule
+from .inference_rules.scatter import ScatterRule
 from .inference_rules.slice_register import SliceAssignRule, SliceRegisterRule
 from .inference_rules.store_shared import StoreSharedSwizzleRule
 from .inference_rules.tcgen05.alloc import Tcgen05AllocRule
@@ -67,6 +69,10 @@ inference_order: list[list[Type[LayoutInferenceRule]]] = [
     [WhereRule],
     [AssignRule],
     [StoreGlobalRule],
+    # Atomic / scatter-store rules: run alongside StoreGlobalRule so that their
+    # register tensors pick up a reasonable default layout when no other
+    # instruction constrains them.
+    [AtomicElementWiseRule, ScatterRule],
     [ClusterLaunchControlTryCancelInstRule, ClusterLaunchControlQueryResponseInstRule, MapSharedAddrRule],
     [EmptyRule],
     # shared memory rules

--- a/python/tilus/ir/layout/inference/validation_rules/always_ok.py
+++ b/python/tilus/ir/layout/inference/validation_rules/always_ok.py
@@ -16,6 +16,10 @@ from tilus.ir.instructions import (
     AllocateRegisterInst,
     AllocateSharedInst,
     AllocBarrierInst,
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
     CopyAsyncGenericInst,
     CopyAsyncInst,
     FormatPrintInst,
@@ -32,7 +36,9 @@ from tilus.ir.instructions import (
     SliceSharedInst,
     StoreGlobalGenericInst,
     StoreGlobalInst,
+    StoreGlobalScatterInst,
     StoreSharedInst,
+    StoreSharedScatterInst,
 )
 from tilus.ir.instructions.cuda.clc import ClusterLaunchControlQueryResponseInst, ClusterLaunchControlTryCancelInst
 from tilus.ir.instructions.cuda.cp_async_bulk import (
@@ -72,6 +78,12 @@ from tilus.ir.layout.inference.rule import LayoutValidationRule, register_rule
 @register_rule(MapSharedAddrInst)
 @register_rule(ClusterLaunchControlTryCancelInst)
 @register_rule(ClusterLaunchControlQueryResponseInst)
+@register_rule(AtomicSharedInst)
+@register_rule(AtomicGlobalInst)
+@register_rule(AtomicScatterSharedInst)
+@register_rule(AtomicScatterGlobalInst)
+@register_rule(StoreSharedScatterInst)
+@register_rule(StoreGlobalScatterInst)
 @register_rule(StoreSharedInst)
 @register_rule(PrintTensorInst)
 @register_rule(FormatPrintInst)

--- a/python/tilus/lang/instructions/__init__.py
+++ b/python/tilus/lang/instructions/__init__.py
@@ -15,6 +15,7 @@
 from tilus.ir.builders import StmtBuilder
 from tilus.ir.inst import InstructionError
 
+from .atomic import AtomicInstructionGroup
 from .base import InstructionGroup, builder_context
 from .clc import ClusterLaunchControlInstructionGroup
 from .cluster import BlockClusterInstructionGroup
@@ -34,3 +35,4 @@ class InstructionInterface(RootInstructionGroup):
     clc = ClusterLaunchControlInstructionGroup()
     cluster = BlockClusterInstructionGroup()
     wgmma = WgmmaInstructionGroup()
+    atomic = AtomicInstructionGroup()

--- a/python/tilus/lang/instructions/atomic.py
+++ b/python/tilus/lang/instructions/atomic.py
@@ -1,0 +1,772 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""User-facing atomic tile operations exposed as ``self.atomic.*``.
+
+See :doc:`/python-api/instruction-groups/atomic` for a detailed guide on the
+element-wise vs. scatter forms and the ``sem`` / ``scope`` semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor
+
+from .base import InstructionGroup
+
+
+class AtomicInstructionGroup(InstructionGroup):
+    """Tile-level atomic read-modify-write instructions.
+
+    Two flavours are offered. The **element-wise** form (:meth:`shared_add` and
+    friends) operates tile-to-tile: each lane contributes its own element of a
+    register tile into the matching element of a shared or global tile, under
+    the requested PTX ``atom.*`` operation. The **scatter** form
+    (:meth:`shared_scatter_add` and friends) follows ``torch.scatter_add_``
+    semantics --- a compile-time ``dim`` axis plus a per-lane ``indices`` tile
+    picks the destination offset; the non-scatter axes come from the tile's
+    global position.
+
+    The full element-wise family is ``add`` / ``sub`` / ``min`` / ``max`` /
+    ``exch`` / ``cas``. The scatter family drops ``exch`` and ``cas`` (their
+    semantics under duplicate indices are unclear) and keeps just ``add`` /
+    ``sub`` / ``min`` / ``max``.
+
+    All methods accept two optional PTX qualifiers:
+
+    - ``sem``: the memory-ordering qualifier. Candidates: ``'relaxed'``,
+      ``'acquire'``, ``'release'``, ``'acq_rel'``. Defaults to ``'relaxed'``.
+    - ``scope``: the sync-scope qualifier. Candidates: ``'cta'``, ``'cluster'``,
+      ``'gpu'``, ``'sys'``. Defaults to ``'cta'`` on shared ops and ``'gpu'``
+      on global ops.
+
+    And an optional ``output`` register tensor that receives the per-element
+    **pre-RMW** value at each target location. When no downstream code uses the
+    returned register, the dead-code-elimination pass rewrites the instruction
+    to carry ``output=None`` and codegen lowers to the destination-less
+    ``red.*`` PTX form --- so the return value is free when unused.
+
+    See Also
+    --------
+    :meth:`tilus.Script.store_shared_scatter` / :meth:`tilus.Script.store_global_scatter`
+        Non-atomic scatter stores that share the same ``indices`` / ``values``
+        contract. Use them when the scatter is guaranteed collision-free.
+    """
+
+    # ------------------------------------------------------------------
+    # Element-wise atomics (shared)
+    # ------------------------------------------------------------------
+
+    def shared_add(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = dst[i] + values[i]`` atomically, on shared memory.
+
+        ``dst.shape`` and ``values.shape`` must be equal, and each lane contributes
+        its own slice of ``values`` to the matching slice of ``dst`` with no
+        broadcast or reduction.
+
+        Parameters
+        ----------
+        dst: SharedTensor
+            Destination tile in shared memory.
+        values: RegisterTensor
+            Per-lane contribution; same shape as ``dst``.
+        sem: str
+            PTX memory-ordering qualifier. Candidates: ``'relaxed'``, ``'acquire'``,
+            ``'release'``, ``'acq_rel'``.
+        scope: str
+            PTX sync scope. Candidates: ``'cta'``, ``'cluster'``, ``'gpu'``,
+            ``'sys'``.
+        output: RegisterTensor, optional
+            If provided, the per-element pre-RMW value at each location is written
+            into this register tile (same shape as ``dst``).
+
+        Returns
+        -------
+        RegisterTensor or None
+            The pre-RMW register tile when ``output`` is consumed downstream; ``None``
+            when unused (the DCE pass rewrites the instruction to the cheaper
+            ``red.*`` form in that case).
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.add.s32`` (or ``red.*`` when the
+          output is unused).
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="add",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_sub(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = dst[i] - values[i]`` atomically, on shared memory.
+
+        PTX has no native ``atom.sub``; the codegen lowers this to ``atom.add``
+        with the negated operand. See :meth:`shared_add` for the full parameter
+        description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.add.s32`` with a negated input.
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="sub",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_min(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = min(dst[i], values[i])`` atomically, on shared memory.
+
+        See :meth:`shared_add` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.min.s32``.
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="min",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_max(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = max(dst[i], values[i])`` atomically, on shared memory.
+
+        See :meth:`shared_add` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.max.s32``.
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="max",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_exch(
+        self,
+        dst: SharedTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``old = dst[i]; dst[i] = values[i]`` atomically (exchange).
+
+        Unlike the arithmetic ops, ``exch`` has no ``red.*`` counterpart in PTX,
+        so ``output`` is effectively always bound. Callers that don't need the
+        old value should prefer a plain store.
+
+        See :meth:`shared_add` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.exch.s32``.
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="exch",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_cas(
+        self,
+        dst: SharedTensor,
+        compare: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise compare-and-swap on shared memory.
+
+        Per element: ``old = dst[i]; if (old == compare[i]) dst[i] = values[i]``,
+        atomically. The returned ``output`` (if bound) holds ``old``, which the
+        caller typically inspects to decide whether the swap succeeded.
+
+        Parameters
+        ----------
+        dst: SharedTensor
+            Destination tile in shared memory.
+        compare: RegisterTensor
+            Expected-old-value tile; same shape and dtype as ``dst``.
+        values: RegisterTensor
+            Tile of replacement values; same shape and dtype as ``dst``.
+        sem, scope, output
+            See :meth:`shared_add`.
+
+        Returns
+        -------
+        RegisterTensor or None
+            Pre-CAS value at each element when ``output`` is consumed; ``None``
+            otherwise. Note that, unlike the arithmetic ops, CAS has no ``red.*``
+            form, so an unused output still costs a register allocation at the
+            PTX level.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.cas.s32``.
+        """
+        return self._builder.atomic_shared(
+            dst=dst,
+            values=values,
+            op="cas",
+            sem=sem,
+            scope=scope,
+            output=output,
+            compare=compare,
+        )
+
+    # ------------------------------------------------------------------
+    # Element-wise atomics (global)
+    # ------------------------------------------------------------------
+
+    def global_add(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = dst[i] + values[i]`` atomically, on global memory.
+
+        See :meth:`shared_add` for the full parameter description; the only
+        difference is that ``dst`` is a :class:`~tilus.ir.GlobalTensor` and the
+        default scope is ``'gpu'`` rather than ``'cta'``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.add.s32`` (or ``red.*`` when the
+          output is unused).
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="add",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_sub(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = dst[i] - values[i]`` atomically, on global memory.
+
+        Lowered to ``atom.add`` with a negated operand; see :meth:`global_add`.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.add.s32`` with a negated input.
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="sub",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_min(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = min(dst[i], values[i])`` atomically, on global memory.
+
+        See :meth:`global_add` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.min.s32``.
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="min",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_max(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise ``dst[i] = max(dst[i], values[i])`` atomically, on global memory.
+
+        See :meth:`global_add` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.max.s32``.
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="max",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_exch(
+        self,
+        dst: GlobalTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise atomic exchange on global memory.
+
+        ``old = dst[i]; dst[i] = values[i]``. See :meth:`shared_exch` for the
+        caveat about ``exch`` having no ``red.*`` counterpart.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.exch.s32``.
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="exch",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_cas(
+        self,
+        dst: GlobalTensor,
+        compare: RegisterTensor,
+        values: RegisterTensor,
+        *,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Element-wise compare-and-swap on global memory.
+
+        Per element: ``old = dst[i]; if (old == compare[i]) dst[i] = values[i]``.
+        See :meth:`shared_cas` for the full parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.cas.s32``.
+        """
+        return self._builder.atomic_global(
+            dst=dst,
+            values=values,
+            op="cas",
+            sem=sem,
+            scope=scope,
+            output=output,
+            compare=compare,
+        )
+
+    # ------------------------------------------------------------------
+    # Scatter atomics (shared)
+    # ------------------------------------------------------------------
+
+    def shared_scatter_add(
+        self,
+        dst: SharedTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-add into a shared tile along ``dim``.
+
+        For each tile element *k*, performs
+        ``dst[..., indices[k], ...] = dst[..., indices[k], ...] + values[k]``
+        atomically, where ``indices`` picks positions along ``dim`` and the
+        non-scatter axes come from the lane's own tile position.
+
+        ``indices.shape == values.shape`` strictly (identical RegisterLayout);
+        ``dst``'s non-``dim`` axes must match ``indices`` exactly. Out-of-range
+        index values are undefined --- there is no runtime bounds check.
+
+        Parameters
+        ----------
+        dst: SharedTensor
+            Destination tile in shared memory.
+        dim: int
+            Compile-time scatter axis into ``dst``.
+        indices: RegisterTensor
+            Per-lane integer indices along ``dim``.
+        values: RegisterTensor
+            Per-lane contributions; same shape and layout as ``indices``.
+        sem: str
+            PTX memory-ordering qualifier. See :class:`AtomicInstructionGroup`
+            for the accepted values.
+        scope: str
+            PTX sync scope. See :class:`AtomicInstructionGroup`.
+        output: RegisterTensor, optional
+            If provided, receives the per-element pre-RMW value at each
+            scattered location (same shape as ``indices``).
+
+        Returns
+        -------
+        RegisterTensor or None
+            Pre-RMW values when ``output`` is consumed downstream; ``None``
+            when unused (the DCE pass rewrites the instruction to the cheaper
+            ``red.*`` form).
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.add.s32`` (or ``red.*`` when the
+          output is unused).
+        """
+        return self._builder.atomic_shared_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="add",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_scatter_sub(
+        self,
+        dst: SharedTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-sub into a shared tile along ``dim``; lowered to ``atom.add`` with a negated value.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.add.s32`` with a negated input.
+        """
+        return self._builder.atomic_shared_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="sub",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_scatter_min(
+        self,
+        dst: SharedTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-min into a shared tile along ``dim``.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.min.s32``.
+        """
+        return self._builder.atomic_shared_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="min",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def shared_scatter_max(
+        self,
+        dst: SharedTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "cta",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-max into a shared tile along ``dim``.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.shared.max.s32``.
+        """
+        return self._builder.atomic_shared_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="max",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    # ------------------------------------------------------------------
+    # Scatter atomics (global)
+    # ------------------------------------------------------------------
+
+    def global_scatter_add(
+        self,
+        dst: GlobalTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-add into a global tile along ``dim``.
+
+        Same contract as :meth:`shared_scatter_add` but the destination is a
+        :class:`~tilus.ir.GlobalTensor` and the default scope is ``'gpu'``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.add.s32`` (or ``red.*`` when the
+          output is unused).
+        """
+        return self._builder.atomic_global_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="add",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_scatter_sub(
+        self,
+        dst: GlobalTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-sub into a global tile along ``dim``; lowered to ``atom.add`` with a negated value.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.add.s32`` with a negated input.
+        """
+        return self._builder.atomic_global_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="sub",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_scatter_min(
+        self,
+        dst: GlobalTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-min into a global tile along ``dim``.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.min.s32``.
+        """
+        return self._builder.atomic_global_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="min",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )
+
+    def global_scatter_max(
+        self,
+        dst: GlobalTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+        sem: str = "relaxed",
+        scope: str = "gpu",
+        output: Optional[RegisterTensor] = None,
+    ) -> Optional[RegisterTensor]:
+        """Scatter-max into a global tile along ``dim``.
+
+        See :meth:`shared_scatter_add` for the parameter description.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        - **Hardware**: Requires compute capability 7.0+ (sm_70).
+        - **PTX**: ``atom.{sem}.{scope}.global.max.s32``.
+        """
+        return self._builder.atomic_global_scatter(
+            dst=dst,
+            indices=indices,
+            values=values,
+            dim=dim,
+            op="max",
+            sem=sem,
+            scope=scope,
+            output=output,
+        )

--- a/python/tilus/lang/instructions/root.py
+++ b/python/tilus/lang/instructions/root.py
@@ -565,6 +565,53 @@ class RootInstructionGroup(InstructionGroup):
             )
         return self._builder.store_global(dst=dst, src=src, offsets=offsets, dims=dims)
 
+    def store_global_scatter(
+        self,
+        dst: GlobalTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+    ) -> None:
+        """Non-atomic scatter store into a global tensor.
+
+        For each tile element ``k``, writes ``dst[..., indices[k], ...] = values[k]``
+        where ``indices`` selects positions along ``dim``. ``indices.shape`` and
+        ``values.shape`` must match exactly and share a RegisterLayout.
+
+        Under duplicate ``indices`` the outcome is last-writer-wins with unspecified
+        winner; use :meth:`atomic.global_scatter_add()
+        <tilus.lang.instructions.atomic.AtomicInstructionGroup.global_scatter_add>`
+        (or similar) if correctness under duplicates matters.
+
+        Parameters
+        ----------
+        dst: GlobalTensor
+            Destination tensor.
+        dim: int
+            Compile-time scatter axis.
+        indices: RegisterTensor
+            Integer indices along ``dim``.
+        values: RegisterTensor
+            Values to write; ``values.shape == indices.shape``, identical layout.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group.
+        """
+        self._builder.store_global_scatter(dst=dst, indices=indices, values=values, dim=dim)
+
+    def store_shared_scatter(
+        self,
+        dst: SharedTensor,
+        *,
+        dim: int,
+        indices: RegisterTensor,
+        values: RegisterTensor,
+    ) -> None:
+        """Non-atomic scatter store into a shared tensor. See :meth:`store_global_scatter`."""
+        self._builder.store_shared_scatter(dst=dst, indices=indices, values=values, dim=dim)
+
     def load_shared(
         self,
         src: SharedTensor,

--- a/python/tilus/transforms/dead_code_elimination.py
+++ b/python/tilus/transforms/dead_code_elimination.py
@@ -16,8 +16,15 @@
 Dead code elimination pass for Tilus IR.
 
 Removes functional instructions whose output tensors are never consumed by any other instruction.
+
+Also handles a second category of instructions: those that are side-effecting (the instruction
+must stay for its memory effect) but whose output register binding is optional. For these, the
+pass rewrites the instruction to carry ``output=None`` when the output is unused, so codegen
+can emit the destination-less PTX form. Atomic instructions are the canonical example: the
+RMW must happen either way, but the returned "old value" register is often ignored.
 """
 
+import dataclasses
 from typing import Type
 
 from tilus.hidet.ir.expr import Expr, Var
@@ -25,6 +32,12 @@ from tilus.hidet.ir.tools import collect as hidet_collect
 from tilus.ir.func import Function
 from tilus.ir.functors import IRRewriter, IRVisitor
 from tilus.ir.inst import Instruction
+from tilus.ir.instructions.cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
 from tilus.ir.instructions.cuda.clc import ClusterLaunchControlQueryResponseInst
 from tilus.ir.instructions.cuda.mapa import MapSharedAddrInst
 from tilus.ir.instructions.cuda.mbarrier import AllocBarrierInst
@@ -100,8 +113,24 @@ FUNCTIONAL_INST_TYPES: tuple[Type[Instruction], ...] = (
 )
 
 
+# Side-effecting instructions that expose an optional output register binding.
+# The instruction itself is never eliminated (the memory side effect must stay),
+# but when its output register is not consumed the DCE pass rewrites the instruction
+# to carry ``output=None`` so codegen can skip the destination register.
+SIDE_EFFECTING_WITH_OPTIONAL_OUTPUT_INST_TYPES: tuple[Type[Instruction], ...] = (
+    AtomicSharedInst,
+    AtomicGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicScatterGlobalInst,
+)
+
+
 def _is_functional(inst: Instruction) -> bool:
     return isinstance(inst, FUNCTIONAL_INST_TYPES)
+
+
+def _is_side_effecting_with_optional_output(inst: Instruction) -> bool:
+    return isinstance(inst, SIDE_EFFECTING_WITH_OPTIONAL_OUTPUT_INST_TYPES)
 
 
 class UsedTensorCollector(IRVisitor):
@@ -123,6 +152,10 @@ class UsedTensorCollector(IRVisitor):
         super().__init__()
         self.used_tensors: set[int] = set()  # set of id(tensor)
         self.functional_insts: list[Instruction] = []
+        # Side-effecting instructions whose output register binding is optional.
+        # Their inputs are already marked unconditionally used; we track them here
+        # so the eliminator can rewrite ``output`` to ``None`` when it's unused.
+        self.side_effecting_optional_insts: list[Instruction] = []
         # Deferred: TensorItem stmts whose liveness depends on Var usage
         self.tensor_item_stmts: list[TensorItemValueStmt | TensorItemPtrStmt] = []
         # All Vars referenced in expressions (collected after traversal).
@@ -137,6 +170,8 @@ class UsedTensorCollector(IRVisitor):
             # Side-effecting: all inputs are unconditionally used
             for tensor in inst.inputs:
                 self.used_tensors.add(id(tensor))
+            if _is_side_effecting_with_optional_output(inst):
+                self.side_effecting_optional_insts.append(inst)
         # Collect Vars from all Expr-typed attributes so that TensorItemValueStmt
         # vars referenced in instruction attributes are tracked.
         for value in inst.attributes.values():
@@ -195,7 +230,12 @@ class UsedTensorCollector(IRVisitor):
 
 
 class DeadCodeEliminator(IRRewriter):
-    """Eliminates dead functional instructions and dead TensorItem stmts."""
+    """Eliminates dead functional instructions and dead TensorItem stmts.
+
+    For instructions registered in ``SIDE_EFFECTING_WITH_OPTIONAL_OUTPUT_INST_TYPES``,
+    the instruction itself is kept (side effect preserved) but its output register is
+    nulled when unused.
+    """
 
     def __init__(self, used_tensors: set[int]) -> None:
         super().__init__()
@@ -204,6 +244,13 @@ class DeadCodeEliminator(IRRewriter):
     def visit_Instruction(self, inst: Instruction) -> Instruction | None:
         if _is_functional(inst) and inst.output is not None and id(inst.output) not in self.used_tensors:
             return None
+        if (
+            _is_side_effecting_with_optional_output(inst)
+            and inst.output is not None
+            and id(inst.output) not in self.used_tensors
+        ):
+            # Keep the side effect; drop the register binding.
+            return dataclasses.replace(inst, output=None)
         return super().visit_Instruction(inst)
 
     def visit_TensorItemValueStmt(self, stmt: TensorItemValueStmt) -> Stmt:
@@ -225,10 +272,17 @@ class DeadCodeEliminationPass(Pass):
         collector.propagate()
 
         # Check if there's anything to eliminate
-        has_dead = any(
-            inst.output is not None and id(inst.output) not in collector.used_tensors
-            for inst in collector.functional_insts
-        ) or any(id(stmt.tensor) not in collector.used_tensors for stmt in collector.tensor_item_stmts)
+        has_dead = (
+            any(
+                inst.output is not None and id(inst.output) not in collector.used_tensors
+                for inst in collector.functional_insts
+            )
+            or any(
+                inst.output is not None and id(inst.output) not in collector.used_tensors
+                for inst in collector.side_effecting_optional_insts
+            )
+            or any(id(stmt.tensor) not in collector.used_tensors for stmt in collector.tensor_item_stmts)
+        )
 
         if not has_dead:
             return function

--- a/tests/instructions/test_atomic.py
+++ b/tests/instructions/test_atomic.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests for ``self.atomic.*`` and non-atomic scatter stores.
+
+Each test builds a small kernel, runs it on the GPU, and checks the result
+against a reference computed with torch/python. Together they exercise:
+
+- element-wise atomic add/max on global memory (no contention path)
+- scatter atomic add on shared and global memory (contention path)
+- DCE of unused output on scatter atomic add
+- non-atomic scatter stores to shared and global memory
+"""
+
+import pytest
+import tilus
+import torch
+from tilus import int32
+
+
+class GlobalAtomicAddTile(tilus.Script):
+    """Each thread contributes values[i] = i+1 to dst[i] via atomic add."""
+
+    def __init__(self, n: int = 32):
+        super().__init__()
+        self.n = n
+
+    def __call__(self, dst_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1  # 32 threads match n=32
+
+        g = self.global_view(dst_ptr, dtype=int32, shape=[self.n])
+        # values = [1, 2, ..., n], one element per thread under default spatial layout
+        values = self.register_tensor(dtype=int32, shape=[self.n], init=lambda i: i + 1)  # type: ignore[arg-type, misc]
+        self.atomic.global_add(g, values)
+
+
+def test_atomic_global_add_no_contention():
+    n = 32
+    dst = torch.zeros(n, dtype=torch.int32, device="cuda")
+    GlobalAtomicAddTile(n=n)(dst)
+    expected = torch.arange(1, n + 1, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(dst, expected)
+
+
+class GlobalAtomicMaxTile(tilus.Script):
+    """Each thread proposes max candidate thread_id to a pre-filled dst."""
+
+    def __init__(self, n: int = 32):
+        super().__init__()
+        self.n = n
+
+    def __call__(self, dst_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1
+
+        g = self.global_view(dst_ptr, dtype=int32, shape=[self.n])
+        values = self.register_tensor(dtype=int32, shape=[self.n], init=lambda i: i)  # type: ignore[arg-type, misc]
+        self.atomic.global_max(g, values)
+
+
+def test_atomic_global_max_no_contention():
+    n = 32
+    # Start dst[i] = n - i. After atomicMax with candidate i, dst[i] = max(n-i, i).
+    dst = torch.arange(n, 0, -1, dtype=torch.int32, device="cuda")
+    expected = torch.maximum(dst.clone(), torch.arange(n, dtype=torch.int32, device="cuda"))
+    GlobalAtomicMaxTile(n=n)(dst)
+    torch.testing.assert_close(dst, expected)
+
+
+class SharedScatterHistogram(tilus.Script):
+    """Build a shared histogram with scatter-add then flush to global.
+
+    Each of the 32 threads computes ``bin = thread_id % num_bins`` and scatters
+    1 into that bin, so the expected histogram is
+    ``[32 // num_bins] * num_bins`` (exact because 32 % num_bins == 0 here).
+
+    The scatter atomic is called without consuming its return value; DCE will
+    rewrite it to the destination-less ``red.*`` PTX form.
+    """
+
+    def __init__(self, num_threads: int = 32, num_bins: int = 4):
+        super().__init__()
+        self.num_threads = num_threads
+        self.num_bins = num_bins
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = self.num_threads // 32
+
+        bins = self.register_tensor(dtype=int32, shape=[self.num_threads], init=lambda i: i % self.num_bins)  # type: ignore[arg-type, misc]
+        ones = self.register_tensor(dtype=int32, shape=[self.num_threads], init=1)
+
+        s_hist = self.shared_tensor(dtype=int32, shape=[self.num_bins])
+        # Seed shared memory from the caller-provided (zeroed) output buffer.
+        # This sidesteps the missing register-layout rule for StoreSharedInst
+        # when the producing register is an init-only AllocateRegister.
+        g_out = self.global_view(out_ptr, dtype=int32, shape=[self.num_bins])
+        init = self.load_global(g_out, offsets=[0], shape=[self.num_bins])
+        self.store_shared(s_hist, init)
+        self.sync()
+
+        # Scatter-add 1 at bins[t] for each thread t.
+        self.atomic.shared_scatter_add(s_hist, dim=0, indices=bins, values=ones)
+        self.sync()
+
+        # Flush shared histogram back to global.
+        r_hist = self.load_shared(s_hist)
+        self.store_global(g_out, r_hist, offsets=[0])
+
+
+@pytest.mark.parametrize("num_bins", [4, 8, 16])
+def test_atomic_shared_scatter_histogram(num_bins):
+    num_threads = 32
+    out = torch.zeros(num_bins, dtype=torch.int32, device="cuda")
+    SharedScatterHistogram(num_threads=num_threads, num_bins=num_bins)(out)
+    expected = torch.full((num_bins,), num_threads // num_bins, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(out, expected)
+
+
+class GlobalScatterHistogram(tilus.Script):
+    """Global-memory scatter histogram — same as shared but on global."""
+
+    def __init__(self, num_threads: int = 32, num_bins: int = 4):
+        super().__init__()
+        self.num_threads = num_threads
+        self.num_bins = num_bins
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = self.num_threads // 32
+
+        bins = self.register_tensor(dtype=int32, shape=[self.num_threads], init=lambda i: i % self.num_bins)  # type: ignore[arg-type, misc]
+        ones = self.register_tensor(dtype=int32, shape=[self.num_threads], init=1)
+
+        g_hist = self.global_view(out_ptr, dtype=int32, shape=[self.num_bins])
+        self.atomic.global_scatter_add(g_hist, dim=0, indices=bins, values=ones)
+
+
+@pytest.mark.parametrize("num_bins", [4, 8])
+def test_atomic_global_scatter_histogram(num_bins):
+    num_threads = 32
+    out = torch.zeros(num_bins, dtype=torch.int32, device="cuda")
+    GlobalScatterHistogram(num_threads=num_threads, num_bins=num_bins)(out)
+    expected = torch.full((num_bins,), num_threads // num_bins, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(out, expected)
+
+
+class GlobalScatterPermutation(tilus.Script):
+    """Permutation write via non-atomic scatter: dst[perm[t]] = values[t]."""
+
+    def __init__(self, n: int = 32):
+        super().__init__()
+        self.n = n
+
+    def __call__(self, dst_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1
+
+        # dst[n-1-t] = t+100 for thread t.
+        n = self.n
+        perm = self.register_tensor(dtype=int32, shape=[n], init=lambda i: (n - 1) - i)  # type: ignore[arg-type, misc]
+        values = self.register_tensor(dtype=int32, shape=[n], init=lambda i: i + 100)  # type: ignore[arg-type, misc]
+
+        g = self.global_view(dst_ptr, dtype=int32, shape=[n])
+        self.store_global_scatter(g, dim=0, indices=perm, values=values)
+
+
+def test_store_global_scatter_permutation():
+    n = 32
+    dst = torch.full((n,), -1, dtype=torch.int32, device="cuda")
+    GlobalScatterPermutation(n=n)(dst)
+    expected = torch.arange(100, 100 + n, dtype=torch.int32, device="cuda").flip(0)
+    torch.testing.assert_close(dst, expected)
+
+
+class SharedScatterRoundtrip(tilus.Script):
+    """Scatter into shared then dump to global — tests store_shared_scatter."""
+
+    def __init__(self, n: int = 32):
+        super().__init__()
+        self.n = n
+
+    def __call__(self, dst_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1
+
+        n = self.n
+        perm = self.register_tensor(dtype=int32, shape=[n], init=lambda i: (n - 1) - i)  # type: ignore[arg-type, misc]
+        values = self.register_tensor(dtype=int32, shape=[n], init=lambda i: i + 7)  # type: ignore[arg-type, misc]
+
+        s = self.shared_tensor(dtype=int32, shape=[n])
+        # Seed shared with the caller-provided (-1-filled) buffer so a scatter
+        # miss would be observable downstream.
+        g = self.global_view(dst_ptr, dtype=int32, shape=[n])
+        fill = self.load_global(g, offsets=[0], shape=[n])
+        self.store_shared(s, fill)
+        self.sync()
+
+        self.store_shared_scatter(s, dim=0, indices=perm, values=values)
+        self.sync()
+
+        r = self.load_shared(s)
+        self.store_global(g, r, offsets=[0])
+
+
+def test_store_shared_scatter_permutation():
+    n = 32
+    dst = torch.zeros(n, dtype=torch.int32, device="cuda")
+    SharedScatterRoundtrip(n=n)(dst)
+    expected = (torch.arange(n, dtype=torch.int32, device="cuda") + 7).flip(0)
+    torch.testing.assert_close(dst, expected)
+
+
+class SharedAtomicAddElementwise(tilus.Script):
+    """Two disjoint warps both atomic-add into the same shared tile.
+
+    Warp 0 contributes 1 per lane; warp 1 contributes 10 per lane. Expected
+    final tile is [11]*32. Exercises the element-wise shared path across warps
+    with real cross-thread contention on every address.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, dst_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 2
+
+        s = self.shared_tensor(dtype=int32, shape=[32])
+        # Seed shared from the caller-provided (zeroed) output buffer.
+        g = self.global_view(dst_ptr, dtype=int32, shape=[32])
+        with self.single_warp(warp=0):
+            seed = self.load_global(g, offsets=[0], shape=[32])
+            self.store_shared(s, seed)
+        self.sync()
+
+        with self.single_warp(warp=0):
+            v = self.register_tensor(dtype=int32, shape=[32], init=1)
+            self.atomic.shared_add(s, v, scope="cta")
+        with self.single_warp(warp=1):
+            v = self.register_tensor(dtype=int32, shape=[32], init=10)
+            self.atomic.shared_add(s, v, scope="cta")
+        self.sync()
+
+        with self.single_warp(warp=0):
+            r = self.load_shared(s)
+            self.store_global(g, r, offsets=[0])
+
+
+def test_atomic_shared_add_two_warps():
+    dst = torch.zeros(32, dtype=torch.int32, device="cuda")
+    SharedAtomicAddElementwise()(dst)
+    expected = torch.full((32,), 11, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(dst, expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ir/instructions/test_atomic_validation.py
+++ b/tests/ir/instructions/test_atomic_validation.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""IR-level validation tests for atomic and scatter instructions.
+
+These tests exercise the ``*.create(...)`` validators directly; they do not
+require a GPU or compile any CUDA code.
+"""
+
+import pytest
+from tilus.hidet.ir.dtypes import float32, int32
+from tilus.ir.inst import InstructionError
+from tilus.ir.instructions.cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
+from tilus.ir.instructions.generic import StoreGlobalScatterInst, StoreSharedScatterInst
+from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor
+
+
+def _reg(shape=(8,), dtype=int32) -> RegisterTensor:
+    return RegisterTensor.create(dtype=dtype, shape=shape)
+
+
+def _smem(shape=(8,), dtype=int32) -> SharedTensor:
+    return SharedTensor.create(dtype=dtype, shape=shape)
+
+
+def _gmem(shape=(8,), dtype=int32) -> GlobalTensor:
+    from tilus.ir.layout import global_row_major
+
+    return GlobalTensor.create(dtype=dtype, layout=global_row_major(*shape))
+
+
+# ---------------------------------------------------------------------------
+# Element-wise atomic: validation
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_shared_add_accepts_matched_shape_dtype():
+    dst = _smem(shape=(8,))
+    values = _reg(shape=(8,))
+    inst = AtomicSharedInst.create(dst=dst, values=values, op="add")
+    assert inst.op == "add"
+    assert inst.sem == "relaxed"
+    assert inst.scope == "cta"
+    assert inst.inputs == (dst, values)
+
+
+def test_atomic_shared_rejects_unknown_op():
+    dst = _smem()
+    values = _reg()
+    with pytest.raises(InstructionError, match="atomic op must be one of"):
+        AtomicSharedInst.create(dst=dst, values=values, op="bogus")
+
+
+def test_atomic_shared_rejects_unknown_sem_and_scope():
+    dst = _smem()
+    values = _reg()
+    with pytest.raises(InstructionError, match="atomic sem must be one of"):
+        AtomicSharedInst.create(dst=dst, values=values, op="add", sem="strong")
+    with pytest.raises(InstructionError, match="atomic scope must be one of"):
+        AtomicSharedInst.create(dst=dst, values=values, op="add", scope="block")
+
+
+def test_atomic_shared_rejects_shape_mismatch():
+    dst = _smem(shape=(8,))
+    values = _reg(shape=(16,))
+    with pytest.raises(InstructionError, match="dst shape"):
+        AtomicSharedInst.create(dst=dst, values=values, op="add")
+
+
+def test_atomic_shared_rejects_dtype_mismatch():
+    dst = _smem(dtype=int32)
+    values = _reg(dtype=float32)
+    with pytest.raises(InstructionError, match="dtype"):
+        AtomicSharedInst.create(dst=dst, values=values, op="add")
+
+
+def test_atomic_shared_cas_requires_compare():
+    dst = _smem()
+    values = _reg()
+    with pytest.raises(InstructionError, match="requires a compare"):
+        AtomicSharedInst.create(dst=dst, values=values, op="cas")
+
+
+def test_atomic_shared_compare_rejected_for_non_cas():
+    dst = _smem()
+    values = _reg()
+    compare = _reg()
+    with pytest.raises(InstructionError, match="compare is only valid"):
+        AtomicSharedInst.create(dst=dst, values=values, op="add", compare=compare)
+
+
+def test_atomic_shared_cas_validates_compare_shape_dtype():
+    dst = _smem(shape=(8,), dtype=int32)
+    values = _reg(shape=(8,), dtype=int32)
+    compare_bad_shape = _reg(shape=(4,), dtype=int32)
+    with pytest.raises(InstructionError, match="compare must match"):
+        AtomicSharedInst.create(dst=dst, values=values, op="cas", compare=compare_bad_shape)
+    compare_bad_dtype = _reg(shape=(8,), dtype=float32)
+    with pytest.raises(InstructionError, match="compare must match"):
+        AtomicSharedInst.create(dst=dst, values=values, op="cas", compare=compare_bad_dtype)
+
+
+def test_atomic_global_mirrors_shared_rules():
+    dst = _gmem(shape=(16,))
+    values = _reg(shape=(16,))
+    inst = AtomicGlobalInst.create(dst=dst, values=values, op="max")
+    assert inst.scope == "gpu"  # default differs from shared
+    with pytest.raises(InstructionError, match="shape"):
+        AtomicGlobalInst.create(dst=dst, values=_reg(shape=(8,)), op="add")
+
+
+# ---------------------------------------------------------------------------
+# Scatter atomic: validation
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_shared_scatter_accepts_matched():
+    dst = _smem(shape=(16, 8))
+    indices = _reg(shape=(4, 8))
+    values = _reg(shape=(4, 8))
+    inst = AtomicScatterSharedInst.create(dst=dst, indices=indices, values=values, dim=0, op="add")
+    assert inst.dim == 0
+
+
+def test_atomic_shared_scatter_rejects_cas_exch():
+    dst = _smem(shape=(16, 8))
+    indices = _reg(shape=(4, 8))
+    values = _reg(shape=(4, 8))
+    with pytest.raises(InstructionError, match="atomic_shared_scatter op must be one of"):
+        AtomicScatterSharedInst.create(dst=dst, indices=indices, values=values, dim=0, op="cas")
+    with pytest.raises(InstructionError, match="atomic_shared_scatter op must be one of"):
+        AtomicScatterSharedInst.create(dst=dst, indices=indices, values=values, dim=0, op="exch")
+
+
+def test_atomic_shared_scatter_shape_rules():
+    dst = _smem(shape=(16, 8))
+    # non-dim axis must match exactly
+    with pytest.raises(InstructionError, match="non-scatter axis"):
+        AtomicScatterSharedInst.create(dst=dst, indices=_reg(shape=(4, 4)), values=_reg(shape=(4, 4)), dim=0, op="add")
+    # indices.shape must equal values.shape
+    with pytest.raises(InstructionError, match="indices.shape"):
+        AtomicScatterSharedInst.create(dst=dst, indices=_reg(shape=(4, 8)), values=_reg(shape=(8, 8)), dim=0, op="add")
+    # rank mismatch
+    with pytest.raises(InstructionError, match="dst rank"):
+        AtomicScatterSharedInst.create(dst=dst, indices=_reg(shape=(4,)), values=_reg(shape=(4,)), dim=0, op="add")
+    # dim out of range
+    with pytest.raises(InstructionError, match="dim 3 out of range"):
+        AtomicScatterSharedInst.create(dst=dst, indices=_reg(shape=(4, 8)), values=_reg(shape=(4, 8)), dim=3, op="add")
+
+
+def test_atomic_global_scatter_mirrors_rules():
+    dst = _gmem(shape=(16, 8))
+    indices = _reg(shape=(4, 8))
+    values = _reg(shape=(4, 8))
+    inst = AtomicScatterGlobalInst.create(dst=dst, indices=indices, values=values, dim=0, op="min")
+    assert inst.op == "min"
+    with pytest.raises(InstructionError, match="atomic_global_scatter op must be one of"):
+        AtomicScatterGlobalInst.create(dst=dst, indices=indices, values=values, dim=0, op="cas")
+
+
+# ---------------------------------------------------------------------------
+# Non-atomic scatter stores: validation
+# ---------------------------------------------------------------------------
+
+
+def test_store_shared_scatter_shape_rules():
+    dst = _smem(shape=(16, 8))
+    inst = StoreSharedScatterInst.create(dst=dst, indices=_reg(shape=(4, 8)), values=_reg(shape=(4, 8)), dim=0)
+    assert inst.dim == 0
+    assert inst.output is None
+
+
+def test_store_global_scatter_shape_rules():
+    dst = _gmem(shape=(16, 8))
+    inst = StoreGlobalScatterInst.create(dst=dst, indices=_reg(shape=(4, 8)), values=_reg(shape=(4, 8)), dim=0)
+    assert inst.dim == 0
+    with pytest.raises(InstructionError, match="indices.shape"):
+        StoreGlobalScatterInst.create(dst=dst, indices=_reg(shape=(4, 8)), values=_reg(shape=(2, 8)), dim=0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/transforms/test_dead_code_elimination.py
+++ b/tests/transforms/test_dead_code_elimination.py
@@ -20,17 +20,26 @@ from tilus.hidet.ir.expr import Var, as_expr
 from tilus.hidet.ir.primitives.cuda.vars import blockIdx
 from tilus.hidet.ir.type import PointerType
 from tilus.ir.func import Function, Metadata
+from tilus.ir.instructions.cuda.atomic import (
+    AtomicGlobalInst,
+    AtomicScatterGlobalInst,
+    AtomicScatterSharedInst,
+    AtomicSharedInst,
+)
 from tilus.ir.instructions.generic import (
     AddInst,
     AllocateRegisterInst,
+    AllocateSharedInst,
     CastInst,
+    GlobalViewInst,
     MulInst,
     StoreGlobalGenericInst,
     SyncThreadsInst,
 )
+from tilus.ir.layout import global_row_major
 from tilus.ir.prog import Program
 from tilus.ir.stmt import InstStmt, SeqStmt
-from tilus.ir.tensor import RegisterTensor
+from tilus.ir.tensor import GlobalTensor, RegisterTensor, SharedTensor
 from tilus.ir.tools.instruction_collector import collect_instructions
 from tilus.transforms.dead_code_elimination import dead_code_elimination_pass
 
@@ -219,6 +228,116 @@ def test_diamond_dependency():
 
     assert _count_insts(opt_prog, AddInst) == 2
     assert _count_insts(opt_prog, MulInst) == 1
+
+
+# ---------------------------------------------------------------------------
+# Atomic / scatter DCE behavior
+# ---------------------------------------------------------------------------
+#
+# Atomic instructions are side-effecting (the RMW must happen) but their
+# ``output`` register is optional. DCE must NEVER drop the instruction itself,
+# only rewrite ``output=None`` when the returned pre-RMW register is unused.
+
+
+def _smem(shape=(4,), dtype=float32) -> tuple[AllocateSharedInst, SharedTensor]:
+    out = SharedTensor.create(dtype=dtype, shape=shape)
+    return AllocateSharedInst.create(output=out), out
+
+
+def _gmem(shape=(4,), dtype=float32) -> tuple[GlobalViewInst, GlobalTensor]:
+    out = GlobalTensor.create(dtype=dtype, layout=global_row_major(*shape))
+    p = Var("p", PointerType(dtype))
+    return GlobalViewInst.create(output=out, ptr=p), out
+
+
+def test_atomic_shared_unused_output_is_nulled_not_eliminated():
+    """DCE must keep the atomic RMW but null its unused output register."""
+    alloc_a, a = _alloc(shape=(4,), dtype=float32)  # values
+    alloc_s, s = _smem(shape=(4,))
+    old = RegisterTensor.create(dtype=float32, shape=(4,))
+    atomic = AtomicSharedInst.create(dst=s, values=a, op="add", output=old)
+
+    prog = _make_program([alloc_a, alloc_s, atomic])
+    opt_prog = dead_code_elimination_pass()(prog)
+
+    # The atomic itself must survive; its output must be nulled.
+    assert _count_insts(opt_prog, AtomicSharedInst) == 1
+    opt_func = list(opt_prog.functions.values())[0]
+    [new_atomic] = [i for i in collect_instructions(opt_func) if isinstance(i, AtomicSharedInst)]
+    assert new_atomic.output is None
+
+
+def test_atomic_shared_used_output_is_preserved():
+    """When the output is consumed downstream, it must be kept as-is."""
+    alloc_a, a = _alloc(shape=(4,), dtype=float32)
+    alloc_s, s = _smem(shape=(4,))
+    old = RegisterTensor.create(dtype=float32, shape=(4,))
+    atomic = AtomicSharedInst.create(dst=s, values=a, op="add", output=old)
+    store = _store(old)
+
+    prog = _make_program([alloc_a, alloc_s, atomic, store])
+    opt_prog = dead_code_elimination_pass()(prog)
+
+    [new_atomic] = [
+        i for i in collect_instructions(list(opt_prog.functions.values())[0]) if isinstance(i, AtomicSharedInst)
+    ]
+    assert new_atomic.output is old
+
+
+def test_atomic_global_unused_output_is_nulled():
+    alloc_a, a = _alloc(shape=(4,), dtype=float32)
+    view, g = _gmem(shape=(4,))
+    old = RegisterTensor.create(dtype=float32, shape=(4,))
+    atomic = AtomicGlobalInst.create(dst=g, values=a, op="max", output=old)
+
+    prog = _make_program([alloc_a, view, atomic])
+    opt_prog = dead_code_elimination_pass()(prog)
+
+    assert _count_insts(opt_prog, AtomicGlobalInst) == 1
+    [new_atomic] = [
+        i for i in collect_instructions(list(opt_prog.functions.values())[0]) if isinstance(i, AtomicGlobalInst)
+    ]
+    assert new_atomic.output is None
+
+
+def test_atomic_scatter_unused_output_is_nulled():
+    alloc_idx, idx = _alloc(shape=(4,), dtype=float32)  # dtype placeholder
+    # Use int32 for indices/values, float32 placeholder unused here
+    idx2 = RegisterTensor.create(dtype=float32, shape=(4,))
+    alloc_idx2 = AllocateRegisterInst.create(output=idx2, f_init=lambda _: float32.zero)
+    values = RegisterTensor.create(dtype=float32, shape=(4,))
+    alloc_values = AllocateRegisterInst.create(output=values, f_init=lambda _: float32.zero)
+    alloc_s, s = _smem(shape=(16,))
+    old = RegisterTensor.create(dtype=float32, shape=(4,))
+    scatter = AtomicScatterSharedInst.create(dst=s, indices=idx2, values=values, dim=0, op="add", output=old)
+
+    prog = _make_program([alloc_idx2, alloc_values, alloc_s, scatter])
+    opt_prog = dead_code_elimination_pass()(prog)
+
+    assert _count_insts(opt_prog, AtomicScatterSharedInst) == 1
+    [new_scatter] = [
+        i for i in collect_instructions(list(opt_prog.functions.values())[0]) if isinstance(i, AtomicScatterSharedInst)
+    ]
+    assert new_scatter.output is None
+
+
+def test_atomic_scatter_global_unused_output_is_nulled():
+    idx = RegisterTensor.create(dtype=float32, shape=(4,))
+    alloc_idx = AllocateRegisterInst.create(output=idx, f_init=lambda _: float32.zero)
+    values = RegisterTensor.create(dtype=float32, shape=(4,))
+    alloc_values = AllocateRegisterInst.create(output=values, f_init=lambda _: float32.zero)
+    view, g = _gmem(shape=(16,))
+    old = RegisterTensor.create(dtype=float32, shape=(4,))
+    scatter = AtomicScatterGlobalInst.create(dst=g, indices=idx, values=values, dim=0, op="min", output=old)
+
+    prog = _make_program([alloc_idx, alloc_values, view, scatter])
+    opt_prog = dead_code_elimination_pass()(prog)
+
+    assert _count_insts(opt_prog, AtomicScatterGlobalInst) == 1
+    [new_scatter] = [
+        i for i in collect_instructions(list(opt_prog.functions.values())[0]) if isinstance(i, AtomicScatterGlobalInst)
+    ]
+    assert new_scatter.output is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the atomic RMW family and non-atomic scatter stores called out as PR 1–3 in the DSV3.2 indexer design report.

Element-wise atomics — tile-to-tile RMW where dst.shape and values.shape must match exactly:
`  self.atomic.{shared,global}_{add,sub,min,max,exch,cas}(dst, values, ...)`

Scatter atomics — torch.scatter-style, with a compile-time `dim` and strict indices.shape == values.shape:
`  self.atomic.{shared,global}_scatter_{add,sub,min,max}(
      dst, dim=..., indices=..., values=...)`

Non-atomic scatter stores — same indices/values contract, last-writer-wins under duplicate indices (cheaper than the atomic variants when scatters are known to be collision-free):
`  self.store_{shared,global}_scatter(dst, dim=..., indices=..., values=...)`

Each atomic op takes `sem` (PTX memory ordering) and `scope` (sync scope), plus an optional `output` register that receives the per-element pre-RMW value.

Pieces landing in this PR:

- IR. AtomicSharedInst / AtomicGlobalInst and their scatter variants live in tilus.ir.instructions.cuda.atomic. The non-atomic scatter stores live in tilus.ir.instructions.generic next to StoreSharedInst / StoreGlobalInst since they are plain stores rather than atomics. The shape validation helper is shared across all four scatter variants.

- Builder / lang. StmtBuilder gets atomic_{shared,global}[_scatter] plus store_{shared,global}_scatter. The Script surface exposes a new AtomicInstructionGroup at self.atomic.* for the atomic ops; the non-atomic scatter stores sit on the root group alongside store_shared / store_global.

- Codegen. Each (op, sem, scope, space, dtype, form) tuple lazy-registers a cuda_internal @script function in tilus.hidet.ir.primitives.cuda.atomic_tile that wraps `atom.{sem}.{scope}.{space}.{op}.{dtype}` or its destination-less `red.*` counterpart. The emitter calls these via atom_rmw / red_rmw so the inline PTX lives inside hidet primitives rather than raw AsmStmt. Register constraints fall out of the parameter types — generic pointer → "l", uint32 shared-space address → "r".

- Layout inference. AtomicElementWiseRule binds a common RegisterLayout across values / compare / output. ScatterRule does the same for indices / values / output of both atomic and non-atomic scatter (the rule is identical regardless of atomicity).

- DCE. Atomic instructions are side-effecting but expose an optional output register. A new SIDE_EFFECTING_WITH_OPTIONAL_OUTPUT_INST_TYPES hook lets the pass keep the RMW but rewrite output=None when the register is unused, so codegen emits the cheaper `red.*` form automatically.

- Docs. New docs/source/python-api/instruction-groups/atomic.rst covering element-wise vs. scatter, sem/scope, and the atom.* ↔ red.* switch. New "Atomic (self.atomic)" entry in programming-guides/instructions.rst, and `store_{shared,global}_scatter` added to the root Script instruction list.

- Tests. 15 IR validation tests (op / sem / scope / shape / dtype / CAS compare), 5 DCE tests covering the null-output rewrite, and 10 end-to-end GPU tests (element-wise global add/max, shared + global scatter-add histograms, shared + global non-atomic scatter permutation, and a cross-warp shared atomic add with real contention).

Not in scope: float32 / non-s32/u32 dtype coverage, cluster remote-shared atomics (self.cluster.map_shared — PR 4 in the design report), tile-level scan (PR 5).