### PR TITLE
[Instruction] Add tile-level prefix scan (self.scan / cumsum / cumprod)

### DIFF
--- a/docs/source/programming-guides/instructions.rst
+++ b/docs/source/programming-guides/instructions.rst
@@ -143,6 +143,24 @@ for in-place output.
    sum
 
 
+Prefix Scan
+~~~~~~~~~~~
+
+Tile-level prefix scan along one dimension. The output preserves the input's shape; along ``dim``,
+element ``i`` holds the ⊕-combination of positions ``[0, i]`` (inclusive) or ``[0, i)`` with the
+op's identity at ``i == 0`` (exclusive). Supported ops: ``add`` / ``mul`` / ``max`` / ``min`` plus
+the bitwise ``and`` / ``or`` / ``xor`` for integer tiles. The lowering is Blelloch's up-sweep +
+down-sweep, bit-local at every round, so every valid tilus register layout is handled — intra-
+thread, intra-warp, inter-warp, and any mixture. ``cumsum`` / ``cumprod`` are convenience
+shortcuts for ``op='add'`` / ``op='mul'``.
+
+.. autosummary::
+
+   scan
+   cumsum
+   cumprod
+
+
 Transform
 ~~~~~~~~~
 

--- a/docs/source/python-api/tilus-script.rst
+++ b/docs/source/python-api/tilus-script.rst
@@ -72,6 +72,8 @@ Instructions
    copy_async_commit_group
    copy_async_wait_all
    copy_async_wait_group
+   cumprod
+   cumsum
    dot
    exp
    exp2
@@ -100,6 +102,7 @@ Instructions
    reshape_shared
    round
    rsqrt
+   scan
    shared_tensor
    sin
    sqrt

--- a/python/tilus/backends/emitter.py
+++ b/python/tilus/backends/emitter.py
@@ -105,6 +105,35 @@ class BaseInstEmitter(StmtBuilder):
             raise RuntimeError("Current thread is not set")
         return self._codegen.current_thread
 
+    def lane_id(self, name: str = "lane_id") -> Var:
+        """Declare and return ``current_thread % 32`` as an int32 variable.
+
+        Emitters that read the lane id across multiple emitted statements should
+        cache it once via this helper rather than re-deriving ``current_thread
+        % 32`` at each use, both for readability and to let the compiler see a
+        single value.
+        """
+        return self.declare_var(name, int32, self.current_thread % 32)
+
+    def warp_id(self, name: str = "warp_id") -> Var:
+        """Declare and return the warp id as a **warp-uniform** int32 variable.
+
+        The raw expression ``current_thread // 32`` is warp-uniform on NVIDIA
+        GPUs, but nvcc often can't prove that from the division alone and
+        conservatively assumes lanes within a warp can disagree. We broadcast
+        via ``__shfl_sync`` from lane 0 so the compiler sees a value every lane
+        provably agrees on — this tends to hoist warp-id-only addressing out of
+        per-lane loops and eliminate warp-divergent guards.
+        """
+        from tilus.hidet.ir.primitives.cuda.shfl import shfl_sync
+
+        raw = self.declare_var(name + "_raw", int32, self.current_thread // 32)
+        return self.declare_var(
+            name,
+            int32,
+            shfl_sync(uint32(0xFFFFFFFF), raw, src_lane=0, width=32),
+        )
+
     @property
     def current_num_threads(self) -> int:
         return self._codegen.thread_group_stack.num_threads[-1]

--- a/python/tilus/backends/emitters/__init__.py
+++ b/python/tilus/backends/emitters/__init__.py
@@ -27,6 +27,7 @@ from . import (
     random,
     reduce,
     regs,
+    scan,
     scatter_ldst,
     shared_ldst,
     shuffle,

--- a/python/tilus/backends/emitters/scan.py
+++ b/python/tilus/backends/emitters/scan.py
@@ -1,0 +1,666 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Layout-agnostic prefix scan via Blelloch's algorithm.
+
+Blelloch is bit-local: every round's data movement is between positions ``i``
+and ``i XOR 2**d`` for a single bit ``d``. That single bit maps cleanly to one
+level of the register layout --- a local-idx bit (intra-thread register
+combine), a lane-id bit (``shfl_xor_sync``), or a warp-id bit (shared-memory
+exchange). So the same algorithm works for any tilus register layout,
+including interleaved dim-axis bit orderings, without layout-classification
+heuristics.
+
+Cost: ``2 * log2(dim_extent)`` rounds (one up-sweep + one down-sweep), each
+round a single primitive.
+
+Kogge-Stone-style specialization for grouped layouts is a reasonable
+follow-up optimization but not needed for correctness or the first pass.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from tilus.backends.emitter import BaseInstEmitter, register_emitter
+from tilus.hidet import boolean
+from tilus.hidet.ir import DataType
+from tilus.hidet.ir.dtypes import int32, uint32
+from tilus.hidet.ir.expr import Expr, Var, bitwise_and, bitwise_not, bitwise_or, bitwise_xor, cast, logical_and
+from tilus.hidet.ir.primitives.cuda.shfl import shfl_xor_sync
+from tilus.hidet.ir.type import tensor_pointer_type
+from tilus.hidet.ir.utils.index_transform import index_deserialize, index_serialize
+from tilus.ir.instructions.generic import ScanInst
+from tilus.ir.layout import RegisterLayout
+from tilus.ir.tensor import RegisterTensor
+from tilus.target import nvgpu_any
+
+# ---------------------------------------------------------------------------
+# Op semantics
+# ---------------------------------------------------------------------------
+
+
+def _identity(op: str, dtype: DataType) -> Expr:
+    if op == "add":
+        return dtype.zero
+    if op == "mul":
+        return dtype.one
+    if op == "max":
+        return dtype.min_value
+    if op == "min":
+        return dtype.max_value
+    if op == "or":
+        return dtype.zero
+    if op == "xor":
+        return dtype.zero
+    if op == "and":
+        # All-ones of the dtype — identity for bitwise AND.
+        return bitwise_not(dtype.zero)
+    raise NotImplementedError(f"scan op {op!r} has no registered identity")
+
+
+def _combine(op: str, lhs: Expr, rhs: Expr) -> Expr:
+    from tilus.hidet.ir.primitives import max as prim_max
+    from tilus.hidet.ir.primitives import min as prim_min
+
+    if op == "add":
+        return lhs + rhs
+    if op == "mul":
+        return lhs * rhs
+    if op == "max":
+        return prim_max(lhs, rhs)
+    if op == "min":
+        return prim_min(lhs, rhs)
+    if op == "and":
+        return bitwise_and(lhs, rhs)
+    if op == "or":
+        return bitwise_or(lhs, rhs)
+    if op == "xor":
+        return bitwise_xor(lhs, rhs)
+    raise NotImplementedError(f"scan op {op!r} has no registered combine")
+
+
+# ---------------------------------------------------------------------------
+# Bit classification
+# ---------------------------------------------------------------------------
+
+DimBitLevel = Literal["local", "lane", "warp"]
+
+
+@dataclass(frozen=True)
+class DimBit:
+    """One dim-axis bit, classified by where it lives in the layout.
+
+    ``level`` says which coord space this bit belongs to, and ``pos`` is the
+    bit's position within that coord space.
+
+    For ``level == "local"`` or ``level == "warp"``, ``partner_delta_in_local``
+    is the XOR delta in the local-idx serialization (for local bits) or left
+    unused (warp bits use ``pos`` directly). For lane bits ``pos`` is the lane
+    bit to XOR via shfl.
+    """
+
+    level: DimBitLevel
+    pos: int  # bit position within local_idx / lane_id / warp_id
+
+
+def _classify_dim_bits(layout: RegisterLayout, dim: int) -> list[DimBit]:
+    """Return the dim-axis bits of ``dim`` in dim-axis order (low to high).
+
+    Walks ``grouped_modes[dim]`` from innermost mode (smallest stride in the
+    shape axis) outward; within each mode, from LSB to MSB. Each bit is
+    classified as living in a local_idx, lane_id, or warp_id bit position.
+    """
+    dim_modes = layout.grouped_modes[dim]
+
+    # For each mode, precompute its bit-range in local_idx or spatial_id.
+    local_bit_start: dict[int, int] = {}
+    offset = 0
+    for lm in reversed(layout.local_modes):
+        num_bits = int(math.log2(layout.mode_shape[lm]))
+        local_bit_start[lm] = offset
+        offset += num_bits
+
+    spatial_bit_start: dict[int, int] = {}
+    offset = 0
+    for sm in reversed(layout.spatial_modes):
+        if sm < 0:
+            mode_size = -sm
+        else:
+            mode_size = layout.mode_shape[sm]
+            spatial_bit_start[sm] = offset
+        num_bits = int(math.log2(mode_size))
+        offset += num_bits
+
+    bits: list[DimBit] = []
+    # Innermost mode first (smallest stride = lowest dim-axis bits)
+    for mode in reversed(dim_modes):
+        mode_extent = layout.mode_shape[mode]
+        num_bits = int(math.log2(mode_extent))
+        if mode in layout.local_modes:
+            start = local_bit_start[mode]
+            for b in range(num_bits):
+                bits.append(DimBit(level="local", pos=start + b))
+        else:
+            start = spatial_bit_start[mode]
+            for b in range(num_bits):
+                spatial_bit = start + b
+                if spatial_bit < 5:
+                    bits.append(DimBit(level="lane", pos=spatial_bit))
+                else:
+                    bits.append(DimBit(level="warp", pos=spatial_bit - 5))
+    return bits
+
+
+# ---------------------------------------------------------------------------
+# Guard masks
+# ---------------------------------------------------------------------------
+
+
+def _level_masks(bits: list[DimBit], up_to: int) -> tuple[int, int, int]:
+    """Return (local_mask, lane_mask, warp_mask) over dim bits [0..up_to]."""
+    local_mask = lane_mask = warp_mask = 0
+    for b in bits[: up_to + 1]:
+        if b.level == "local":
+            local_mask |= 1 << b.pos
+        elif b.level == "lane":
+            lane_mask |= 1 << b.pos
+        else:
+            warp_mask |= 1 << b.pos
+    return local_mask, lane_mask, warp_mask
+
+
+def _build_guard(
+    *,
+    local_mask: int,
+    lane_mask: int,
+    warp_mask: int,
+    local_expected: int | None = None,
+    lane_expected: int | None = None,
+    warp_expected: int | None = None,
+    local_idx_expr: Expr,
+    lane_id_expr: Expr,
+    warp_id_expr: Expr,
+) -> Expr:
+    """Guard: for each level, ``(coord & mask) == expected`` on the dim bits.
+
+    Default ``expected`` equals the mask, i.e., all dim bits up to and
+    including round ``d`` are set. To express "lower bits all set AND this
+    bit clear" (the left-child guard in Blelloch down-sweep), pass a
+    non-default ``*_expected`` that has this-round's bit cleared.
+    """
+    if local_expected is None:
+        local_expected = local_mask
+    if lane_expected is None:
+        lane_expected = lane_mask
+    if warp_expected is None:
+        warp_expected = warp_mask
+    parts: list[Expr] = []
+    if local_mask:
+        parts.append((bitwise_and(local_idx_expr, local_mask)) == local_expected)
+    if lane_mask:
+        parts.append((bitwise_and(lane_id_expr, lane_mask)) == lane_expected)
+    if warp_mask:
+        parts.append((bitwise_and(warp_id_expr, warp_mask)) == warp_expected)
+    if not parts:
+        return boolean.true
+    expr = parts[0]
+    for p in parts[1:]:
+        expr = logical_and(expr, p)
+    return expr
+
+
+# ---------------------------------------------------------------------------
+# Emitter
+# ---------------------------------------------------------------------------
+
+
+@register_emitter(ScanInst, target=nvgpu_any)
+class ScanInstEmitter(BaseInstEmitter):
+    def emit(self, inst: ScanInst) -> None:
+        x: RegisterTensor = inst.register_input
+        y: RegisterTensor = inst.register_output
+        layout = x.layout
+        dtype = x.dtype
+        op = inst.op
+        dim = inst.dim
+        exclusive = inst.exclusive
+
+        dim_bits = _classify_dim_bits(layout, dim)
+        n_bits = len(dim_bits)
+        if n_bits == 0:
+            # Scan along a size-1 dim is a no-op (exclusive returns identity, inclusive returns input).
+            self._copy_buffer(x, y)
+            if exclusive:
+                self._fill_with_identity(y, op, dtype)
+            return
+
+        x_buf: Var = self.get_or_allocate_var(x)
+        y_buf: Var = self.get_or_allocate_var(y)
+        input_is_output = x is y
+
+        # For inclusive with input-is-output, we need to save the original input
+        # before Blelloch overwrites it.
+        scratch_buf: Var | None = None
+        if (not exclusive) and input_is_output:
+            scratch = RegisterTensor.create(dtype=dtype, shape=x.shape, optional_layout=x.optional_layout)
+            scratch_buf = self.get_or_allocate_var(scratch)
+            with self.for_range(layout.local_size, attr="u") as i_local:
+                self.buffer_store(scratch_buf, indices=[i_local], value=x_buf[i_local])
+
+        # Copy input → output (if they're distinct tensors).
+        if not input_is_output:
+            with self.for_range(layout.local_size, attr="u") as i_local:
+                self.buffer_store(y_buf, indices=[i_local], value=x_buf[i_local])
+
+        lane_id = self.lane_id("scan_lane_id")
+        warp_id = self.warp_id("scan_warp_id")
+
+        # Up-sweep: d = 0, 1, ..., n_bits - 1
+        for d in range(n_bits):
+            self._sweep_round(
+                inst_op=op,
+                dtype=dtype,
+                layout=layout,
+                y_buf=y_buf,
+                dim_bits=dim_bits,
+                round_d=d,
+                lane_id=lane_id,
+                warp_id=warp_id,
+                up_sweep=True,
+            )
+
+        # Zero the root (set the "all dim-axis bits set" position to identity).
+        self._write_identity_at_full_mask(
+            op=op,
+            dtype=dtype,
+            layout=layout,
+            y_buf=y_buf,
+            dim_bits=dim_bits,
+            lane_id=lane_id,
+            warp_id=warp_id,
+        )
+
+        # Down-sweep: d = n_bits - 1, ..., 1, 0
+        for d in reversed(range(n_bits)):
+            self._sweep_round(
+                inst_op=op,
+                dtype=dtype,
+                layout=layout,
+                y_buf=y_buf,
+                dim_bits=dim_bits,
+                round_d=d,
+                lane_id=lane_id,
+                warp_id=warp_id,
+                up_sweep=False,
+            )
+
+        # Inclusive: y[i] = y[i] ⊕ original_x[i].
+        if not exclusive:
+            src_buf = scratch_buf if input_is_output else x_buf
+            with self.for_range(layout.local_size, attr="u") as i_local:
+                self.buffer_store(
+                    y_buf,
+                    indices=[i_local],
+                    value=_combine(op, y_buf[i_local], src_buf[i_local]),
+                )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _copy_buffer(self, x: RegisterTensor, y: RegisterTensor) -> None:
+        if x is y:
+            return
+        x_buf = self.get_or_allocate_var(x)
+        y_buf = self.get_or_allocate_var(y)
+        with self.for_range(x.layout.local_size, attr="u") as i_local:
+            self.buffer_store(y_buf, indices=[i_local], value=x_buf[i_local])
+
+    def _fill_with_identity(self, y: RegisterTensor, op: str, dtype: DataType) -> None:
+        y_buf = self.get_or_allocate_var(y)
+        with self.for_range(y.layout.local_size, attr="u") as i_local:
+            self.buffer_store(y_buf, indices=[i_local], value=_identity(op, dtype))
+
+    def _write_identity_at_full_mask(
+        self,
+        *,
+        op: str,
+        dtype: DataType,
+        layout: RegisterLayout,
+        y_buf: Var,
+        dim_bits: list[DimBit],
+        lane_id: Expr,
+        warp_id: Expr,
+    ) -> None:
+        """Set the register slot at the full-dim-bits-set position to the op's identity."""
+        local_mask, lane_mask, warp_mask = _level_masks(dim_bits, up_to=len(dim_bits) - 1)
+        local_shape = layout.local_shape
+
+        with self.for_range(layout.local_size, attr="u") as i_local:
+            local_indices = index_deserialize(i_local, shape=local_shape)
+            local_idx_expr = self._local_indices_to_local_idx(layout, local_indices)
+            guard = _build_guard(
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                local_idx_expr=local_idx_expr,
+                lane_id_expr=lane_id,
+                warp_id_expr=warp_id,
+            )
+            with self.if_then(guard):
+                self.buffer_store(y_buf, indices=[i_local], value=_identity(op, dtype))
+
+    def _sweep_round(
+        self,
+        *,
+        inst_op: str,
+        dtype: DataType,
+        layout: RegisterLayout,
+        y_buf: Var,
+        dim_bits: list[DimBit],
+        round_d: int,
+        lane_id: Expr,
+        warp_id: Expr,
+        up_sweep: bool,
+    ) -> None:
+        """One round of Blelloch sweep at dim-axis bit ``round_d``.
+
+        Up-sweep: if guard set (bits 0..d all set), y[i] = combine(y[i], y[partner]).
+        Down-sweep: if guard set, swap and combine:
+            temp = y[partner]
+            y[partner] = y[i]
+            y[i] = combine(y[i], temp)
+        """
+        this_bit = dim_bits[round_d]
+        local_mask, lane_mask, warp_mask = _level_masks(dim_bits, up_to=round_d)
+
+        if this_bit.level == "local":
+            self._round_local(
+                inst_op=inst_op,
+                dtype=dtype,
+                layout=layout,
+                y_buf=y_buf,
+                partner_delta_local=1 << this_bit.pos,
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                lane_id=lane_id,
+                warp_id=warp_id,
+                up_sweep=up_sweep,
+            )
+        elif this_bit.level == "lane":
+            self._round_lane(
+                inst_op=inst_op,
+                dtype=dtype,
+                layout=layout,
+                y_buf=y_buf,
+                lane_bit=this_bit.pos,
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                lane_id=lane_id,
+                warp_id=warp_id,
+                up_sweep=up_sweep,
+            )
+        else:
+            self._round_warp(
+                inst_op=inst_op,
+                dtype=dtype,
+                layout=layout,
+                y_buf=y_buf,
+                warp_bit=this_bit.pos,
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                lane_id=lane_id,
+                warp_id=warp_id,
+                up_sweep=up_sweep,
+            )
+
+    # ---- Round implementations ---------------------------------------
+
+    def _round_local(
+        self,
+        *,
+        inst_op: str,
+        dtype: DataType,
+        layout: RegisterLayout,
+        y_buf: Var,
+        partner_delta_local: int,  # XOR delta in the local_idx serialization
+        local_mask: int,
+        lane_mask: int,
+        warp_mask: int,
+        lane_id: Expr,
+        warp_id: Expr,
+        up_sweep: bool,
+    ) -> None:
+        """Combine within a single thread: partner at same thread, different local_idx."""
+        local_shape = layout.local_shape
+        # Note: local_idx serialization order depends on layout.local_modes. The
+        # XOR delta in local_idx flips a bit. We enumerate i_local via
+        # for_range, decode to get the local_idx, and combine with partner.
+        with self.for_range(layout.local_size, attr="u") as i_local:
+            local_indices = index_deserialize(i_local, shape=local_shape)
+            local_idx_expr = self._local_indices_to_local_idx(layout, local_indices)
+            # Partner slot is local_idx XOR partner_delta_local. Since local_idx
+            # serialization is row-major over local_shape, XORing the flat
+            # loop index is equivalent.
+            i_partner = bitwise_xor(i_local, int32(partner_delta_local))
+            guard = _build_guard(
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                local_idx_expr=local_idx_expr,
+                lane_id_expr=lane_id,
+                warp_id_expr=warp_id,
+            )
+            with self.if_then(guard):
+                if up_sweep:
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], y_buf[i_partner]),
+                    )
+                else:
+                    # Down-sweep swap-and-combine.
+                    tmp = self.declare_var("scan_tmp", tp=dtype, init=y_buf[i_partner])
+                    self.buffer_store(y_buf, indices=[i_partner], value=y_buf[i_local])
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], tmp),
+                    )
+
+    def _round_lane(
+        self,
+        *,
+        inst_op: str,
+        dtype: DataType,
+        layout: RegisterLayout,
+        y_buf: Var,
+        lane_bit: int,
+        local_mask: int,
+        lane_mask: int,
+        warp_mask: int,
+        lane_id: Expr,
+        warp_id: Expr,
+        up_sweep: bool,
+    ) -> None:
+        """Combine between lanes via shfl_xor_sync.
+
+        The shfl is called unconditionally by every lane (required for
+        well-defined semantics with a full warp mask) and its result captured
+        into a local variable; the guards then gate the actual updates using
+        that pre-snapshotted partner value.
+        """
+        local_shape = layout.local_shape
+        delta = 1 << lane_bit
+        with self.for_range(layout.local_size, attr="u") as i_local:
+            local_indices = index_deserialize(i_local, shape=local_shape)
+            local_idx_expr = self._local_indices_to_local_idx(layout, local_indices)
+
+            # Snapshot: every lane reads its partner before any conditional update.
+            partner_val = self.declare_var(
+                "scan_partner",
+                tp=dtype,
+                init=shfl_xor_sync(
+                    uint32(0xFFFFFFFF),
+                    y_buf[i_local],
+                    lane_mask=int32(delta),
+                    width=int32(32),
+                ),
+            )
+
+            right_guard = _build_guard(
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                local_idx_expr=local_idx_expr,
+                lane_id_expr=lane_id,
+                warp_id_expr=warp_id,
+            )
+            if up_sweep:
+                with self.if_then(right_guard):
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], partner_val),
+                    )
+            else:
+                # Down-sweep: right_child_new = right_old ⊕ left_old,
+                #             left_child_new  = right_old.
+                # Both lanes use the snapshotted partner value, so ordering is fine.
+                left_guard = _build_guard(
+                    local_mask=local_mask,
+                    lane_mask=lane_mask,
+                    warp_mask=warp_mask,
+                    lane_expected=lane_mask ^ delta,
+                    local_idx_expr=local_idx_expr,
+                    lane_id_expr=lane_id,
+                    warp_id_expr=warp_id,
+                )
+                with self.if_then(right_guard):
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], partner_val),
+                    )
+                with self.if_then(left_guard):
+                    self.buffer_store(y_buf, indices=[i_local], value=partner_val)
+
+    def _round_warp(
+        self,
+        *,
+        inst_op: str,
+        dtype: DataType,
+        layout: RegisterLayout,
+        y_buf: Var,
+        warp_bit: int,
+        local_mask: int,
+        lane_mask: int,
+        warp_mask: int,
+        lane_id: Expr,
+        warp_id: Expr,
+        up_sweep: bool,
+    ) -> None:
+        """Combine between warps via shared memory.
+
+        Each thread writes its current local-buffer slot to shared; sync; threads
+        whose guard holds read from the partner warp's slot and combine (up-sweep)
+        or swap-and-combine (down-sweep); sync.
+        """
+        local_shape = layout.local_shape
+        local_size = layout.local_size
+        spatial_size = layout.spatial_size
+        # Shared scratch: one slot per thread per local element.
+        # Index: (warp_id * 32 + lane_id) * local_size + i_local
+        scratch_size = spatial_size * local_size
+        smem_ctx = self.contexts.smem_alloc_ctx
+        smem_ptr = smem_ctx.request_shared_workspace(dtype.nbytes * scratch_size)
+        smem_buf = self.declare_var(
+            "scan_smem",
+            tensor_pointer_type(dtype=dtype, shape=[scratch_size]),
+            init=cast(smem_ptr, ~dtype),
+        )
+
+        delta = 1 << warp_bit
+        partner_warp = bitwise_xor(warp_id, int32(delta))
+
+        # Phase A: write my values into shared.
+        with self.for_range(local_size, attr="u") as i_local:
+            slot = (warp_id * 32 + lane_id) * local_size + i_local
+            self.buffer_store(smem_buf, indices=[slot], value=y_buf[i_local])
+
+        self.sync()
+
+        # Phase B: read partner values and combine under guard.
+        with self.for_range(local_size, attr="u") as i_local:
+            local_indices = index_deserialize(i_local, shape=local_shape)
+            local_idx_expr = self._local_indices_to_local_idx(layout, local_indices)
+            partner_slot = (partner_warp * 32 + lane_id) * local_size + i_local
+            partner_val = smem_buf[partner_slot]
+
+            guard = _build_guard(
+                local_mask=local_mask,
+                lane_mask=lane_mask,
+                warp_mask=warp_mask,
+                local_idx_expr=local_idx_expr,
+                lane_id_expr=lane_id,
+                warp_id_expr=warp_id,
+            )
+
+            if up_sweep:
+                with self.if_then(guard):
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], partner_val),
+                    )
+            else:
+                # Down-sweep: right child combines, left child receives parent's prefix.
+                left_guard = _build_guard(
+                    local_mask=local_mask,
+                    lane_mask=lane_mask,
+                    warp_mask=warp_mask,
+                    warp_expected=warp_mask ^ delta,
+                    local_idx_expr=local_idx_expr,
+                    lane_id_expr=lane_id,
+                    warp_id_expr=warp_id,
+                )
+                with self.if_then(guard):
+                    self.buffer_store(
+                        y_buf,
+                        indices=[i_local],
+                        value=_combine(inst_op, y_buf[i_local], partner_val),
+                    )
+                with self.if_then(left_guard):
+                    self.buffer_store(y_buf, indices=[i_local], value=partner_val)
+
+        self.sync()
+
+    # ---- Utility -----------------------------------------------------
+
+    @staticmethod
+    def _local_indices_to_local_idx(layout: RegisterLayout, local_indices: list[Expr]) -> Expr:
+        """Serialize local_indices (per local_mode) back to the flat local_idx.
+
+        Note: ``local_indices`` is already the row-major decomposition of the
+        flat ``i_local`` using ``local_shape``; serializing back gives the same
+        ``i_local`` numeric. We return this expression so the guard masks can
+        compare against it directly.
+        """
+        return index_serialize(local_indices, shape=layout.local_shape)

--- a/python/tilus/ir/builders/stmt_builder.py
+++ b/python/tilus/ir/builders/stmt_builder.py
@@ -110,6 +110,7 @@ from tilus.ir.instructions.generic import (
     RepeatInst,
     RepeatInterleaveInst,
     ReshapeSharedInst,
+    ScanInst,
     SliceAssignInst,
     SliceGlobalInst,
     SliceRegisterInst,
@@ -860,6 +861,21 @@ class StmtBuilder(StmtBuilderCore):
                 raise NotImplementedError(f"Unsupported reduction operation: {op}")
             out = RegisterTensor.create(dtype=dtype, shape=shape)
         inst = ReduceInst.create(x=x, output=out, dim=dim, op=op, keepdim=keepdim)
+        self.append(inst)
+        return inst.register_output
+
+    def scan(
+        self,
+        x: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        exclusive: bool = False,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        if out is None:
+            out = RegisterTensor.create(dtype=x.dtype, shape=x.shape, optional_layout=x.optional_layout)
+        inst = ScanInst.create(x=x, output=out, dim=dim, op=op, exclusive=exclusive)
         self.append(inst)
         return inst.register_output
 

--- a/python/tilus/ir/instructions/__init__.py
+++ b/python/tilus/ir/instructions/__init__.py
@@ -66,6 +66,7 @@ from .generic import (
     RepeatInst,
     RepeatInterleaveInst,
     ReshapeSharedInst,
+    ScanInst,
     ShuffleDownInst,
     ShuffleUpInst,
     SliceAssignInst,

--- a/python/tilus/ir/instructions/generic.py
+++ b/python/tilus/ir/instructions/generic.py
@@ -516,6 +516,50 @@ class ReduceInst(Instruction):
         return ReduceInst(output=output, inputs=(x,), dim=dim, keepdim=keepdim, op=op)
 
 
+# Scan opcodes. `add`/`mul`/`max`/`min` accept any numeric dtype; the bitwise
+# variants (`and`/`or`/`xor`) require an integer dtype.
+SCAN_OPS: tuple[str, ...] = ("add", "mul", "max", "min", "and", "or", "xor")
+SCAN_BITWISE_OPS: tuple[str, ...] = ("and", "or", "xor")
+
+
+@dataclass(frozen=True, eq=False)
+class ScanInst(Instruction):
+    """Tile-level prefix scan along a single axis.
+
+    Output shape == input shape (no dim collapse, unlike reduce). The scan is
+    performed independently for each non-``dim`` coordinate; along ``dim`` the
+    result at position ``i`` is the ⊕-combination of input positions
+    ``0..i`` (inclusive) or ``0..i-1`` (exclusive), with the op's identity at
+    the boundary.
+    """
+
+    dim: int
+    op: str
+    exclusive: bool
+    VALID_OPS: ClassVar[tuple[str, ...]] = SCAN_OPS
+
+    @staticmethod
+    def create(
+        x: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        exclusive: bool,
+        output: RegisterTensor,
+    ) -> ScanInst:
+        if op not in SCAN_OPS:
+            raise InstructionError(f"scan op must be one of {SCAN_OPS}, got {op!r}")
+        if not (0 <= dim < len(x.shape)):
+            raise InstructionError(f"scan dim {dim} out of range for rank-{len(x.shape)} input")
+        if tuple(x.shape) != tuple(output.shape):
+            raise InstructionError(f"scan: input shape {list(x.shape)} != output shape {list(output.shape)}")
+        if x.dtype != output.dtype:
+            raise InstructionError(f"scan: input dtype {x.dtype.name} != output dtype {output.dtype.name}")
+        if op in SCAN_BITWISE_OPS and not x.dtype.is_integer():
+            raise InstructionError(f"scan op {op!r} requires an integer dtype, got {x.dtype.name}")
+        return ScanInst(output=output, inputs=(x,), dim=dim, op=op, exclusive=exclusive)
+
+
 @dataclass(frozen=True, eq=False)
 class ViewInst(Instruction):
     local_offset: Expr

--- a/python/tilus/ir/layout/inference/inference_rules/scan.py
+++ b/python/tilus/ir/layout/inference/inference_rules/scan.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Layout inference for ``ScanInst``.
+
+Unlike reduce, scan preserves the axis being operated on — the output shape
+equals the input shape. The input and output therefore share a single
+RegisterLayout: whichever side is pinned drives the other.
+"""
+
+from tilus import RegisterLayout
+from tilus.ir.instructions import ScanInst
+from tilus.ir.layout.inference.rule import LayoutInferenceContext, LayoutInferenceRule, register_rule
+from tilus.ir.tensor import RegisterTensor
+
+
+@register_rule(ScanInst)
+class ScanRule(LayoutInferenceRule):
+    @staticmethod
+    def inference(ctx: LayoutInferenceContext, inst: ScanInst) -> dict[RegisterTensor, RegisterLayout]:
+        x = inst.register_input
+        y = inst.register_output
+
+        if x.optional_layout is not None and y.optional_layout is None:
+            return {y: x.layout}
+        if y.optional_layout is not None and x.optional_layout is None:
+            return {x: y.layout}
+        return {}

--- a/python/tilus/ir/layout/inference/order.py
+++ b/python/tilus/ir/layout/inference/order.py
@@ -38,6 +38,7 @@ from .inference_rules.mma_dot import MmaDotRule
 from .inference_rules.philox import Philox4x32InferenceRule
 from .inference_rules.reduce import ReduceRule
 from .inference_rules.reshape_shared import ReshapeSharedRule
+from .inference_rules.scan import ScanRule
 from .inference_rules.scatter import ScatterRule
 from .inference_rules.slice_register import SliceAssignRule, SliceRegisterRule
 from .inference_rules.store_shared import StoreSharedSwizzleRule
@@ -65,6 +66,7 @@ inference_order: list[list[Type[LayoutInferenceRule]]] = [
     [BinaryRule, UnaryRule],
     [LoadGlobalRule],
     [ReduceRule],
+    [ScanRule],
     [TransposeRule, SqueezeRule, UnsqueezeRule],
     [WhereRule],
     [AssignRule],

--- a/python/tilus/ir/layout/inference/validation_rules/__init__.py
+++ b/python/tilus/ir/layout/inference/validation_rules/__init__.py
@@ -19,6 +19,7 @@ from . import (
     elementwise_unary,
     mma_dot,
     reduce,
+    scan,
     transform,
     transpose,
     view,

--- a/python/tilus/ir/layout/inference/validation_rules/scan.py
+++ b/python/tilus/ir/layout/inference/validation_rules/scan.py
@@ -12,29 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from . import (
-    allocate_shared,
-    assign,
-    atomic,
-    cp_async,
-    elementwise_binary,
-    elementwise_unary,
-    empty_rule,
-    ldst_global,
-    load_shared,
-    mbarrier,
-    mma_dot,
-    philox,
-    reduce,
-    reshape_shared,
-    scan,
-    scatter,
-    slice_register,
-    store_shared,
-    tcgen05,
-    transform,
-    transform_shared,
-    transpose,
-    wgmma,
-    where,
-)
+from tilus.ir.instructions import ScanInst
+from tilus.ir.layout.inference.rule import LayoutValidationRule, register_rule
+
+
+@register_rule(ScanInst)
+class ScanRule(LayoutValidationRule):
+    @staticmethod
+    def validate(inst: ScanInst) -> bool:
+        """Input and output must share a single register layout (scan preserves shape + layout)."""
+        return inst.register_input.layout == inst.register_output.layout

--- a/python/tilus/lang/instructions/root.py
+++ b/python/tilus/lang/instructions/root.py
@@ -1652,6 +1652,75 @@ class RootInstructionGroup(InstructionGroup):
             raise InstructionError("The input tensor must be a boolean tensor.")
         return self._reduce(x, dim=dim, keepdim=keepdim, op="all", out=out)
 
+    def scan(
+        self,
+        x: RegisterTensor,
+        *,
+        dim: int,
+        op: str,
+        exclusive: bool = False,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Prefix scan along ``dim``.
+
+        For each non-``dim`` coordinate independently, the output at position
+        ``i`` along ``dim`` is the ⊕-combination of the input values at
+        positions ``[0, i]`` (inclusive mode, default) or ``[0, i)`` with the
+        identity at position ``0`` (exclusive mode).
+
+        Parameters
+        ----------
+        x: RegisterTensor
+            Input tile.
+        dim: int
+            Compile-time scan axis.
+        op: str
+            One of ``'add'``, ``'mul'``, ``'max'``, ``'min'``, ``'and'``,
+            ``'or'``, ``'xor'``. Bitwise ops (``'and'`` / ``'or'`` / ``'xor'``)
+            require an integer dtype.
+        exclusive: bool
+            If ``True``, return the exclusive prefix (identity at the boundary);
+            otherwise the inclusive prefix.
+        out: RegisterTensor, optional
+            Output tile. Must match ``x`` in shape and dtype. If not provided,
+            a new tile is allocated with the same layout as ``x``. Passing
+            ``out=x`` performs the scan in-place (the emitter saves the
+            original values when needed).
+
+        Returns
+        -------
+        ret: RegisterTensor
+            The scanned tile, same shape and dtype as ``x``.
+
+        Notes
+        -----
+        - **Thread group**: Can be executed by any sized thread group whose
+          size matches the input layout's ``spatial_size``.
+        """
+        return self._builder.scan(x, dim=dim, op=op, exclusive=exclusive, out=out)
+
+    def cumsum(
+        self,
+        x: RegisterTensor,
+        *,
+        dim: int,
+        exclusive: bool = False,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Inclusive (or exclusive) cumulative sum along ``dim``. Shortcut for :meth:`scan` with ``op='add'``."""
+        return self._builder.scan(x, dim=dim, op="add", exclusive=exclusive, out=out)
+
+    def cumprod(
+        self,
+        x: RegisterTensor,
+        *,
+        dim: int,
+        exclusive: bool = False,
+        out: Optional[RegisterTensor] = None,
+    ) -> RegisterTensor:
+        """Inclusive (or exclusive) cumulative product along ``dim``. Shortcut for :meth:`scan` with ``op='mul'``."""
+        return self._builder.scan(x, dim=dim, op="mul", exclusive=exclusive, out=out)
+
     def add(self, lhs: RegisterTensor, rhs: RegisterTensor, out: Optional[RegisterTensor] = None) -> RegisterTensor:
         """Element-wise addition with broadcasting.
 

--- a/tests/instructions/test_scan.py
+++ b/tests/instructions/test_scan.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests for ``self.scan`` / ``self.cumsum`` / ``self.cumprod`` across layouts.
+
+Covers the layout classes called out in the design matrix:
+
+- pure intra-warp
+- pure intra-thread (2D tile, dim in local-only axis)
+- intra-thread + intra-warp
+- pure inter-warp
+- all three phases (intra-thread + intra-warp + inter-warp)
+- 2D tiles (scan one axis only)
+
+Plus the op family (add / mul / max / min / and / or / xor), inclusive +
+exclusive modes, and the input-is-output (``out=x``) edge case.
+"""
+
+import functools
+
+import pytest
+import tilus
+import torch
+from tilus import int32
+
+# ---------------------------------------------------------------------------
+# Reference scan implementations (CPU/torch)
+# ---------------------------------------------------------------------------
+
+
+def _identity(op, dtype):
+    if op == "add":
+        return 0
+    if op == "mul":
+        return 1
+    if op == "max":
+        return torch.iinfo(dtype).min if dtype.is_signed else 0
+    if op == "min":
+        return torch.iinfo(dtype).max
+    if op == "and":
+        return -1 if dtype.is_signed else torch.iinfo(dtype).max
+    if op == "or":
+        return 0
+    if op == "xor":
+        return 0
+    raise ValueError(op)
+
+
+def _combine(op, a, b):
+    if op == "add":
+        return a + b
+    if op == "mul":
+        return a * b
+    if op == "max":
+        return torch.maximum(a, b)
+    if op == "min":
+        return torch.minimum(a, b)
+    if op == "and":
+        return torch.bitwise_and(a, b)
+    if op == "or":
+        return torch.bitwise_or(a, b)
+    if op == "xor":
+        return torch.bitwise_xor(a, b)
+    raise ValueError(op)
+
+
+def _reference_scan(x: torch.Tensor, dim: int, op: str, exclusive: bool) -> torch.Tensor:
+    # Move dim to the front, do the scan, then move back. Keeps the logic 1D.
+    x = x.clone()
+    x = x.movedim(dim, 0)
+    out = torch.empty_like(x)
+    acc = torch.full_like(x[0], _identity(op, x.dtype))
+    for i in range(x.shape[0]):
+        if exclusive:
+            out[i] = acc
+            acc = _combine(op, acc, x[i])
+        else:
+            acc = _combine(op, acc, x[i])
+            out[i] = acc
+    return out.movedim(0, dim).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Kernels: one class per layout class; op/exclusive/axis are ``__init__`` args
+# so the compiler sees them as compile-time constants.
+# ---------------------------------------------------------------------------
+
+
+class _ScanKernel1D(tilus.Script):
+    """Generic 1D scan template; the layout is whatever ``load_global`` picks."""
+
+    def __init__(self, n: int, op: str, exclusive: bool, num_warps: int = 1, in_place: bool = False):
+        super().__init__()
+        self.n = n
+        self.op = op
+        self.exclusive = exclusive
+        self.num_warps = num_warps
+        self.in_place = in_place
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = self.num_warps
+        g = self.global_view(out_ptr, dtype=int32, shape=[self.n])
+        x = self.load_global(g, offsets=[0], shape=[self.n])
+        if self.in_place:
+            y = self.scan(x, dim=0, op=self.op, exclusive=self.exclusive, out=x)
+        else:
+            y = self.scan(x, dim=0, op=self.op, exclusive=self.exclusive)
+        self.store_global(g, y, offsets=[0])
+
+
+class _ScanKernel2D(tilus.Script):
+    """2D scan template: scan along ``dim`` of a ``[H, W]`` tile."""
+
+    def __init__(self, h: int, w: int, dim: int, op: str, exclusive: bool, num_warps: int = 1):
+        super().__init__()
+        self.h = h
+        self.w = w
+        self.dim = dim
+        self.op = op
+        self.exclusive = exclusive
+        self.num_warps = num_warps
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = self.num_warps
+        g = self.global_view(out_ptr, dtype=int32, shape=[self.h, self.w])
+        x = self.load_global(g, offsets=[0, 0], shape=[self.h, self.w])
+        y = self.scan(x, dim=self.dim, op=self.op, exclusive=self.exclusive)
+        self.store_global(g, y, offsets=[0, 0])
+
+
+# ---------------------------------------------------------------------------
+# Input generators — cover corners that might expose overflow or identity bugs.
+# ---------------------------------------------------------------------------
+
+
+def _input_for_op(op: str, shape, device="cuda") -> torch.Tensor:
+    # Use uint32 for bitwise ops to exercise the bitwise path; int32 otherwise.
+    dtype = torch.int32
+    if op == "mul":
+        # Keep values small to avoid int32 overflow in cumprod over 32+ elements.
+        return torch.randint(-2, 3, shape, dtype=dtype, device=device)
+    if op in ("add",):
+        return torch.arange(
+            1, int(functools.reduce(lambda a, b: a * b, shape)) + 1, dtype=dtype, device=device
+        ).reshape(shape)
+    if op in ("max", "min"):
+        return torch.randint(-100, 100, shape, dtype=dtype, device=device)
+    if op in ("and", "or", "xor"):
+        return torch.randint(0, 0xFFFF, shape, dtype=dtype, device=device)
+    raise ValueError(op)
+
+
+# ---------------------------------------------------------------------------
+# Parametrized matrix: each row is (label, num_warps, shape, builder)
+# ---------------------------------------------------------------------------
+
+_LAYOUT_CASES_1D = [
+    pytest.param(32, 1, id="intra_warp_N32"),
+    pytest.param(128, 1, id="intra_thread_plus_intra_warp_N128"),
+    pytest.param(64, 2, id="inter_warp_N64"),
+    pytest.param(256, 2, id="all_three_phases_N256"),
+]
+
+_OPS = ["add", "mul", "max", "min", "and", "or", "xor"]
+
+
+@pytest.mark.parametrize("n, num_warps", _LAYOUT_CASES_1D)
+@pytest.mark.parametrize("op", _OPS)
+@pytest.mark.parametrize("exclusive", [False, True])
+def test_scan_1d(n: int, num_warps: int, op: str, exclusive: bool):
+    x = _input_for_op(op, (n,))
+    expected = _reference_scan(x, dim=0, op=op, exclusive=exclusive)
+    _ScanKernel1D(n=n, op=op, exclusive=exclusive, num_warps=num_warps)(x)
+    torch.testing.assert_close(x, expected)
+
+
+@pytest.mark.parametrize("n, num_warps", _LAYOUT_CASES_1D)
+@pytest.mark.parametrize("op", ["add", "max"])  # just a sampler — in-place is orthogonal to op logic
+@pytest.mark.parametrize("exclusive", [False, True])
+def test_scan_1d_in_place(n: int, num_warps: int, op: str, exclusive: bool):
+    """Explicitly pass ``out=x`` so input and output alias the same register tile.
+
+    Exercises the scratch-copy path for inclusive scan where the original
+    values need to be preserved across the in-place Blelloch pass.
+    """
+    x = _input_for_op(op, (n,))
+    expected = _reference_scan(x, dim=0, op=op, exclusive=exclusive)
+    _ScanKernel1D(n=n, op=op, exclusive=exclusive, num_warps=num_warps, in_place=True)(x)
+    torch.testing.assert_close(x, expected)
+
+
+# 2D: scan along either axis. Pick a tile that splits nicely across threads.
+_LAYOUT_CASES_2D = [
+    pytest.param(4, 32, 1, id="H4W32_single_warp_scan_W"),
+    pytest.param(4, 32, 1, id="H4W32_single_warp_scan_W_repeat"),  # same — kept for explicit dim param below
+    pytest.param(8, 32, 2, id="H8W32_two_warps"),
+]
+
+
+@pytest.mark.parametrize("h, w, num_warps", [(4, 32, 1), (8, 32, 2)])
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("op", ["add", "max", "xor"])
+@pytest.mark.parametrize("exclusive", [False, True])
+def test_scan_2d(h: int, w: int, num_warps: int, dim: int, op: str, exclusive: bool):
+    x = _input_for_op(op, (h, w))
+    expected = _reference_scan(x, dim=dim, op=op, exclusive=exclusive)
+    _ScanKernel2D(h=h, w=w, dim=dim, op=op, exclusive=exclusive, num_warps=num_warps)(x)
+    torch.testing.assert_close(x, expected)
+
+
+# ---------------------------------------------------------------------------
+# Shortcut methods
+# ---------------------------------------------------------------------------
+
+
+class _CumsumKernel(tilus.Script):
+    def __init__(self, n: int, exclusive: bool = False):
+        super().__init__()
+        self.n = n
+        self.exclusive = exclusive
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1
+        g = self.global_view(out_ptr, dtype=int32, shape=[self.n])
+        x = self.load_global(g, offsets=[0], shape=[self.n])
+        y = self.cumsum(x, dim=0, exclusive=self.exclusive)
+        self.store_global(g, y, offsets=[0])
+
+
+class _CumprodKernel(tilus.Script):
+    def __init__(self, n: int, exclusive: bool = False):
+        super().__init__()
+        self.n = n
+        self.exclusive = exclusive
+
+    def __call__(self, out_ptr: ~int32) -> None:
+        self.attrs.blocks = 1
+        self.attrs.warps = 1
+        g = self.global_view(out_ptr, dtype=int32, shape=[self.n])
+        x = self.load_global(g, offsets=[0], shape=[self.n])
+        y = self.cumprod(x, dim=0, exclusive=self.exclusive)
+        self.store_global(g, y, offsets=[0])
+
+
+def test_cumsum_shortcut():
+    x = torch.arange(1, 33, dtype=torch.int32, device="cuda")
+    expected = _reference_scan(x, dim=0, op="add", exclusive=False)
+    _CumsumKernel(n=32)(x)
+    torch.testing.assert_close(x, expected)
+
+
+def test_cumprod_shortcut():
+    x = torch.randint(-2, 3, (32,), dtype=torch.int32, device="cuda")
+    expected = _reference_scan(x, dim=0, op="mul", exclusive=False)
+    _CumprodKernel(n=32)(x)
+    torch.testing.assert_close(x, expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ir/instructions/test_scan_validation.py
+++ b/tests/ir/instructions/test_scan_validation.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""IR-level validation tests for ``ScanInst``.
+
+Exercises the ``ScanInst.create(...)`` validators directly; no GPU / CUDA
+compilation required.
+"""
+
+import pytest
+from tilus.hidet.ir.dtypes import float32, int32
+from tilus.ir.inst import InstructionError
+from tilus.ir.instructions.generic import SCAN_BITWISE_OPS, SCAN_OPS, ScanInst
+from tilus.ir.tensor import RegisterTensor
+
+
+def _reg(shape=(8,), dtype=int32) -> RegisterTensor:
+    return RegisterTensor.create(dtype=dtype, shape=shape)
+
+
+# ---------------------------------------------------------------------------
+# Accepts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", SCAN_OPS)
+def test_scan_accepts_all_ops_on_int_dtype(op):
+    x = _reg(shape=(8,), dtype=int32)
+    y = _reg(shape=(8,), dtype=int32)
+    inst = ScanInst.create(x=x, output=y, dim=0, op=op, exclusive=False)
+    assert inst.op == op
+    assert inst.dim == 0
+    assert inst.exclusive is False
+    assert inst.inputs == (x,)
+
+
+def test_scan_accepts_float_for_non_bitwise_ops():
+    x = _reg(shape=(8,), dtype=float32)
+    y = _reg(shape=(8,), dtype=float32)
+    for op in ("add", "mul", "max", "min"):
+        ScanInst.create(x=x, output=y, dim=0, op=op, exclusive=False)
+
+
+def test_scan_accepts_exclusive_flag():
+    x = _reg(shape=(8,))
+    y = _reg(shape=(8,))
+    inst = ScanInst.create(x=x, output=y, dim=0, op="add", exclusive=True)
+    assert inst.exclusive is True
+
+
+# ---------------------------------------------------------------------------
+# Rejects
+# ---------------------------------------------------------------------------
+
+
+def test_scan_rejects_unknown_op():
+    x = _reg()
+    y = _reg()
+    with pytest.raises(InstructionError, match="scan op must be one of"):
+        ScanInst.create(x=x, output=y, dim=0, op="bogus", exclusive=False)
+
+
+def test_scan_rejects_out_of_range_dim():
+    x = _reg(shape=(8,))
+    y = _reg(shape=(8,))
+    with pytest.raises(InstructionError, match="scan dim 1 out of range"):
+        ScanInst.create(x=x, output=y, dim=1, op="add", exclusive=False)
+    with pytest.raises(InstructionError, match="scan dim -1 out of range"):
+        ScanInst.create(x=x, output=y, dim=-1, op="add", exclusive=False)
+
+
+def test_scan_rejects_shape_mismatch():
+    x = _reg(shape=(8,))
+    y = _reg(shape=(16,))
+    with pytest.raises(InstructionError, match="shape"):
+        ScanInst.create(x=x, output=y, dim=0, op="add", exclusive=False)
+
+
+def test_scan_rejects_dtype_mismatch():
+    x = _reg(shape=(8,), dtype=int32)
+    y = _reg(shape=(8,), dtype=float32)
+    with pytest.raises(InstructionError, match="dtype"):
+        ScanInst.create(x=x, output=y, dim=0, op="add", exclusive=False)
+
+
+@pytest.mark.parametrize("op", SCAN_BITWISE_OPS)
+def test_scan_rejects_bitwise_on_float(op):
+    x = _reg(shape=(8,), dtype=float32)
+    y = _reg(shape=(8,), dtype=float32)
+    with pytest.raises(InstructionError, match="integer dtype"):
+        ScanInst.create(x=x, output=y, dim=0, op=op, exclusive=False)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds the tile-level prefix scan family called out as PR 5 in the DSV3.2 indexer design report — the last missing primitive for the single-CTA radix top-K's per-pass threshold search (256-bin cumsum × 4 passes).

Surface:
```
  y = self.scan(x, *, dim, op, exclusive=False, out=None)
  y = self.cumsum(x, *, dim, exclusive=False, out=None)  # op='add'
  y = self.cumprod(x, *, dim, exclusive=False, out=None) # op='mul'
```

Supported ops (all in the same PR, per the design-review discussion):
  add, mul, max, min — any numeric dtype
  and, or, xor       — integer dtypes only (validated at create time)

Shape / layout contract:
```
  output.shape == input.shape (no dim collapse, unlike reduce)
  output.layout == input.layout (pinned by the ScanRule inference rule)
  out=x is allowed; the emitter saves a scratch copy only when needed
  (inclusive + aliased).
```

Codegen: layout-agnostic Blelloch (up-sweep + down-sweep). Every round is bit-local — the partner of position i is at i XOR 2^d for a single dim-axis bit d, never a multi-bit borrow. That single-bit flip maps directly to one primitive per level:

  local bit at local_idx position p  →  register-to-register combine
  lane bit at lane-id position p    →  shfl_xor_sync(0xFFFFFFFF, v, 1<<p)
  warp bit at warp-id position p    →  shared-memory exchange

So every valid tilus register layout works uniformly: grouped or interleaved dim-axis, straddling spatial modes (auto-split at the warp boundary), replicated modes, 2D tiles, mixed all-three-phases. Cost: 2 × log2(dim_extent) rounds, each a single op. Kogge-Stone specializations for grouped layouts are a reasonable follow-up once profiles warrant it.

Pieces landing in this PR:

- IR. ScanInst in tilus.ir.instructions.generic alongside ReduceInst, with op / dim / shape / dtype / bitwise-on-float validation at create time. SCAN_OPS / SCAN_BITWISE_OPS module constants for reuse.

- Builder / lang. StmtBuilder.scan() allocates a matching-layout output when out is None; Script.scan / cumsum / cumprod wire through on the root group.

- Layout inference. ScanRule (inference) propagates input.layout ↔ output. layout bidirectionally. ScanRule (validation) asserts layout equality.

- Codegen. backends/emitters/scan.py classifies each dim-axis bit as local / lane / warp, then runs the up-sweep / down-sweep loops dispatching per-bit to the appropriate primitive. Unconditional shfl_xor_sync with captured partner snapshot ensures well-defined warp semantics (full-mask shfl must be called by every lane; the guard only gates the subsequent register update).

- BaseInstEmitter helpers. Two new helpers introduced for this PR and available for reuse: self.lane_id(name) and self.warp_id(name). The warp_id helper broadcasts via __shfl_sync from lane 0 so the compiler sees a warp-uniform value — tends to hoist warp-id-only addressing out of per-lane loops and drops warp-divergent guards.

- Docs. Script.scan / cumsum / cumprod added to the root autosummary in tilus-script.rst; new "Prefix Scan" subsection in programming-guides/ instructions.rst describing ops, inclusive/exclusive, and the Blelloch lowering.

- Tests. 16 IR validation tests (all ops, bitwise-on-float rejection, out-of-range dim, shape/dtype mismatches) plus 98 end-to-end GPU tests covering:
    * 4 layout classes in 1D: pure intra-warp, intra-thread+intra-warp, pure inter-warp, and all-three-phases (spatial(2).local(4).spatial(32) — the interleaved stress case)
    * all 7 ops × inclusive and exclusive
    * out=x in-place path across all layout classes
    * 2D tiles scanning either axis with 1 and 2 warps
    * cumsum / cumprod shortcuts All 117 tests pass together (scan e2e + scan validation + matmul_v2 smoke).

Not in scope: Kogge-Stone specialization for grouped layouts (future optimization), scan across a cluster of CTAs (would need PR 4's map_shared + remote-shared ops first).